### PR TITLE
Handling absolute URLs in TracedHttpClient.getURL() .

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
+++ b/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
@@ -2,6 +2,7 @@ package com.amazonaws.xray.proxies.apache.http;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -78,7 +79,18 @@ public class TracedHttpClient extends CloseableHttpClient {
     }
 
     public static String getUrl(HttpHost target, HttpRequest request) {
-        return target.getHostName() + request.getRequestLine().getUri();
+        String uri = request.getRequestLine().getUri();
+
+        try {
+            URI requestURI = new URI(uri);
+            if (requestURI.isAbsolute()) {
+                return requestURI.toString();
+            }
+        } catch (URISyntaxException ex){
+            // Not a valid URI
+        }
+
+        return target.toURI() + uri;
     }
 
     public static void addRequestInformation(Subsegment subsegment, HttpRequest request, String url) {

--- a/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
+++ b/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
@@ -1,0 +1,28 @@
+package com.amazonaws.xray.proxies.apache.http;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.message.BasicHttpRequest;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TracedHttpClientTest {
+    @Test
+    public void testGetUrlHttpUriRequest() {
+        assertThat(TracedHttpClient.getUrl(new HttpGet("http://amazon.com")), is("http://amazon.com"));
+        assertThat(TracedHttpClient.getUrl(new HttpGet("https://docs.aws.amazon.com/xray/latest/devguide/xray-api.html")), is("https://docs.aws.amazon.com/xray/latest/devguide/xray-api.html"));
+        assertThat(TracedHttpClient.getUrl(new HttpGet("https://localhost:8443/api/v1")), is("https://localhost:8443/api/v1"));
+    }
+
+    @Test
+    public void testGetUrlHttpHostHttpRequest() {
+        assertThat(TracedHttpClient.getUrl(new HttpHost("amazon.com"), new BasicHttpRequest("GET", "/")), is("http://amazon.com/"));
+        assertThat(TracedHttpClient.getUrl(new HttpHost("amazon.com", -1, "https"), new BasicHttpRequest("GET", "/")), is("https://amazon.com/"));
+        assertThat(TracedHttpClient.getUrl(new HttpHost("localhost", 8080), new BasicHttpRequest("GET", "/api/v1")), is("http://localhost:8080/api/v1"));
+        assertThat(TracedHttpClient.getUrl(new HttpHost("localhost", 8443, "https"), new BasicHttpRequest("GET", "/api/v1")), is("https://localhost:8443/api/v1"));
+
+        assertThat(TracedHttpClient.getUrl(new HttpHost("amazon.com", -1, "https"), new BasicHttpRequest("GET", "https://docs.aws.amazon.com/xray/latest/devguide/xray-api.html")), is("https://docs.aws.amazon.com/xray/latest/devguide/xray-api.html"));
+    }
+}


### PR DESCRIPTION
Based on https://github.com/aws/aws-xray-sdk-java/pull/18 submitted by https://github.com/bsalzberg

Fixes https://github.com/aws/aws-xray-sdk-java/issues/17

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
