### PR TITLE
Cleanup duplicate code for handling the context missing strategy. 

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
@@ -24,7 +24,7 @@ public class AWSXRayRecorderBuilder {
     private static final Log logger =
         LogFactory.getLog(AWSXRayRecorderBuilder.class);
 
-    private Collection<Plugin> plugins;
+    private final Collection<Plugin> plugins;
 
     private SamplingStrategy samplingStrategy;
     private StreamingStrategy streamingStrategy;
@@ -42,18 +42,15 @@ public class AWSXRayRecorderBuilder {
 
     public static Optional<ContextMissingStrategy> contextMissingStrategyFromEnvironmentVariable() {
         String contextMissingStrategyOverrideValue = System.getenv(ContextMissingStrategy.CONTEXT_MISSING_STRATEGY_ENVIRONMENT_VARIABLE_OVERRIDE_KEY);
-        if (null != contextMissingStrategyOverrideValue) {
-            if (contextMissingStrategyOverrideValue.equalsIgnoreCase(LogErrorContextMissingStrategy.OVERRIDE_VALUE)) {
-                return Optional.of(new LogErrorContextMissingStrategy());
-            } else if (contextMissingStrategyOverrideValue.equalsIgnoreCase(RuntimeErrorContextMissingStrategy.OVERRIDE_VALUE)) {
-                return Optional.of(new RuntimeErrorContextMissingStrategy());
-            }
-        }
-        return Optional.empty();
+        return getContextMissingStrategy(contextMissingStrategyOverrideValue);
     }
 
     public static Optional<ContextMissingStrategy> contextMissingStrategyFromSystemProperty() {
         String contextMissingStrategyOverrideValue = System.getProperty(ContextMissingStrategy.CONTEXT_MISSING_STRATEGY_SYSTEM_PROPERTY_OVERRIDE_KEY);
+        return getContextMissingStrategy(contextMissingStrategyOverrideValue);
+    }
+
+    private static Optional<ContextMissingStrategy> getContextMissingStrategy(String contextMissingStrategyOverrideValue) {
         if (null != contextMissingStrategyOverrideValue) {
             if (contextMissingStrategyOverrideValue.equalsIgnoreCase(LogErrorContextMissingStrategy.OVERRIDE_VALUE)) {
                 return Optional.of(new LogErrorContextMissingStrategy());
@@ -167,7 +164,7 @@ public class AWSXRayRecorderBuilder {
             client.setEmitter(emitter);
         }
 
-        plugins.stream().filter(Objects::nonNull).forEach((plugin) -> {
+        plugins.stream().filter(Objects::nonNull).forEach(plugin -> {
             Map<String, Object> runtimeContext = plugin.getRuntimeContext();
             if (!runtimeContext.isEmpty()) {
                 client.putRuntimeContext(plugin.getServiceName(), runtimeContext);


### PR DESCRIPTION
make a couple additional minor code cleanups.

*Issue #, if available:*
None

*Description of changes:*
Code used in `contextMissingStrategyFromEnvironmentVariable()` and `contextMissingStrategyFromSystemProperty()` was duplicated.  This change removes the duplication to a separate function.  The change also includes a couple additional cleanups indicated by IntelliJ and SonarLint.  Tests were run and are all passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
