### PR TITLE
Initializes Reservoir reset setting  eagerly.

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/reservoir/Reservoir.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/reservoir/Reservoir.java
@@ -11,7 +11,7 @@ public class Reservoir {
     private final int tracesPerSecond;
     private final MaxFunction maxFunction;
     private final AtomicInteger usage = new AtomicInteger(0);
-    private final AtomicLong nextReset = new AtomicLong(0);
+    private final AtomicLong nextReset;
 
     public Reservoir() {
         this(0);
@@ -21,6 +21,9 @@ public class Reservoir {
         this.tracesPerSecond = tracesPerSecond;
         this.maxFunction =
             tracesPerSecond < 10 ? new LessThan10(tracesPerSecond) : new AtLeast10(tracesPerSecond);
+
+        long now = System.nanoTime();
+        this.nextReset = new AtomicLong(now + NANOS_PER_SECOND);
     }
 
     public boolean take() {

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/reservoir/ReservoirTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/reservoir/ReservoirTest.java
@@ -36,6 +36,19 @@ public class ReservoirTest {
         assertFalse(reservoir.take());
     }
 
+    @Test public void samplesFairNegativeNanoTime() {
+        mockStatic(System.class);
+        when(System.nanoTime()).thenReturn(-2 * NANOS_PER_SECOND);
+        Reservoir reservoir = new Reservoir(10);
+
+        when(System.nanoTime()).thenReturn(-2 * NANOS_PER_SECOND + 1);
+        assertTrue(reservoir.take());
+        when(System.nanoTime()).thenReturn(-2 * NANOS_PER_SECOND + 2);
+        assertTrue(reservoir.take());
+        when(System.nanoTime()).thenReturn(-2 * NANOS_PER_SECOND + 2);
+        assertFalse(reservoir.take());
+    }
+
     @Test public void resetsAfterASecond() {
         mockStatic(System.class);
 


### PR DESCRIPTION
As in the [javadoc](https://javadoc.scijava.org/Java9/java/lang/System.html#nanoTime--)  states, `System.nanoTime()` may return a negative value, the current implementation  of Reservoir may initially set the reset time to 0, when this value is compared to `System.nanoTime()` to determine max traces per decisecond,  an IndexOutOfBoundsException may occur in case of a negative nano time value.

This bug is introduced by the [this commit](https://github.com/aws/aws-xray-sdk-java/pull/47/commits/1c327137a47e31a28c3155a5852fe8d6052a5d48).