### PR TITLE
fix(core): prevents CentralizedSamplingStrategy from instatiating extraneous recorders when no origin set

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
@@ -60,10 +60,6 @@ public class CentralizedSamplingStrategy implements SamplingStrategy {
             logger.debug("Determining shouldTrace decision for:\n\tserviceName: " + samplingRequest.getService().orElse("") + "\n\thost: " + samplingRequest.getHost().orElse("") + "\n\tpath: " + samplingRequest.getUrl().orElse("") + "\n\tmethod: " + samplingRequest.getMethod().orElse("") + "\n\tserviceType: " + samplingRequest.getServiceType().orElse(""));
         }
 
-        if (!samplingRequest.getServiceType().isPresent()) {
-            samplingRequest.setServiceType(AWSXRayRecorderBuilder.defaultRecorder().getOrigin());
-        }
-
         if (manifest.isExpired(Instant.now())) {
             logger.debug("Centralized sampling data expired. Using fallback sampling strategy.");
             return fallback.shouldTrace(samplingRequest);


### PR DESCRIPTION
*Issue #, if available:*
#46 

*Description of changes:*
## Problem
Currently, when the `CentralizedSamplingStrategy` is used, the [shouldTrace](https://github.com/aws/aws-xray-sdk-java/blob/db6c2fd98f7b3eb236ce71a4d1e565fc919af029/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java#L54) method checks if the provided `samplingRequest` has a service type provided. If it does not, a default `AWSXRayRecorder` will be instantiated, and its origin retrieved. This leads to a new recorder being instantiated for every invocation as a worst case.

## Background
The `origin` that gets passed as the `serviceType` to the `SamplingRequest` can either be explicitly set on an AWSXRayRecorder, or set by a plugin that is provided to the recorder.

In the current implementation, the user does not have access to the newly created recorder, and so can not explicitly set the `origin` or add any plugins. The default recorder also does not contain any plugins. This means that we can be sure the origin is never present on the instantiated recorder.

## Solution
This change removes the `getServiceType()` check, and stops attempting to set the service type on the `samplingRequest`. This has no change on behavior apart from reducing the number of recorders instantiated.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
