### PR TITLE
Specify the Daemon Configuration

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -29,7 +29,18 @@ public class UDPEmitter extends Emitter {
      *
      */
     public UDPEmitter() throws SocketException {
-        config = new DaemonConfiguration();
+        this(new DaemonConfiguration());
+    }
+
+    /**
+     * Constructs a UDPEmitter. This overload allows you to specify the configuration.
+     *
+     * @param config The {@link DaemonConfiguration} for the Emitter.
+     * @throws SocketException
+     *             if an error occurs while instantiating a {@code DatagramSocket}.
+     */
+    public UDPEmitter(DaemonConfiguration config) throws SocketException {
+        this.config = config;
         try {
             daemonSocket = new DatagramSocket();
         } catch (SocketException e) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To provide more direct control over the setting the daemon address, I've added an overloaded constructor `UDPEmitter(DaemonConfiguration config)` to `UDPEmitter`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.