### PR TITLE
Fix "--allow-script-in-comments" in javadoc pom.xml config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
                 ]]>
          </footer>
          <bottom><![CDATA[Copyright &#169; 2018 Amazon Web Services, Inc. All Rights Reserved.]]></bottom>
-         <additionalparam>&#45;&#45;allow-script-in-comments</additionalparam>-->
+         <additionalOptions>&#45;&#45;allow-script-in-comments</additionalOptions>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Update pom.xml to correctly use "--allow-script-in-comments" param in javadoc plugin.

Since maven-javadoc-plugin version 3.0.0, the configuration parameter `<additionalparam>` in the configuration has been replaced with `<additionalOptions>`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
