### PR TITLE
Add default protected constructor for HttpClientBuilder

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/HttpClientBuilder.java
+++ b/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/HttpClientBuilder.java
@@ -16,6 +16,10 @@ public class HttpClientBuilder extends org.apache.http.impl.client.HttpClientBui
 
     private AWSXRayRecorder recorder;
 
+    protected HttpClientBuilder() {
+        super();
+    }
+
     public static HttpClientBuilder create() {
         HttpClientBuilder newBuilder = new HttpClientBuilder();
         newBuilder.setRecorder(AWSXRay.getGlobalRecorder());

--- a/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/HttpClientBuilderTest.java
+++ b/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/HttpClientBuilderTest.java
@@ -1,0 +1,38 @@
+package com.amazonaws.xray.proxies.apache.http;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.mockito.Mockito;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
+import com.amazonaws.xray.emitters.Emitter;
+import com.amazonaws.xray.proxies.apache.http.HttpClientBuilder;
+
+import static org.junit.Assert.assertEquals;
+
+@FixMethodOrder(MethodSorters.JVM)
+public class HttpClientBuilderTest {
+
+    @Before
+    public void setupAWSXRay() {
+        // Prevent accidental publish to Daemon
+        Emitter blankEmitter = Mockito.mock(Emitter.class);
+        Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
+        Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.anyObject());
+        AWSXRay.setGlobalRecorder(AWSXRayRecorderBuilder.standard().withEmitter(blankEmitter).build());
+        AWSXRay.clearTraceEntity();
+    }
+
+    @Test
+    public void testConstructorProtected() throws NoSuchMethodException {
+        // Since the constructor is protected and this is in the same package, we have to test this using reflection.
+        Constructor clientBuilderConstructor = HttpClientBuilder.class.getDeclaredConstructor();
+        assertEquals(Modifier.PROTECTED, clientBuilderConstructor.getModifiers()); // PROTECTED = 4;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
#89 

*Description of changes:*
Added protected constructor. The parent Apache HttpClientBuilder implements a protected constructor as well. There was a bug that allowed customers to instantiate our HttpClientBuilder through an implicitly created public constructor. This is a problem because then the recorder instance will be null.

*Testing:*
Wrote a unit test to ensure that the constructor has the protected modifier.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
