### PR TITLE
Subtree Streaming

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
@@ -11,9 +11,7 @@ import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 
 public class DefaultStreamingStrategy implements StreamingStrategy {
-    private static final Log logger =
-        LogFactory.getLog(DefaultStreamingStrategy.class);
-
+    private static final Log logger = LogFactory.getLog(DefaultStreamingStrategy.class);
 
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 100;
 
@@ -25,9 +23,7 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
      * Constructs an instance of DefaultStreamingStrategy using the default {@code maxSegmentSize} of 100.
      *
      */
-    public DefaultStreamingStrategy() {
-        this(DEFAULT_MAX_SEGMENT_SIZE);
-    }
+    public DefaultStreamingStrategy() { this(DEFAULT_MAX_SEGMENT_SIZE); }
 
     /**
      * {@inheritDoc}
@@ -65,26 +61,52 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
     /**
      * {@inheritDoc}
      *
-     * Performs a depth first search to find completed subsegment subtrees. Serializes these subsegments, streams them to the daemon, and removes them from their parents.
+     * Performs Subtree Subsegment Streaming to stream completed subsegment subtrees. Serializes these subtrees of subsegments, streams them to the daemon, and removes them from their parents.
      *
      * @see StreamingStrategy#streamSome(Entity,Emitter)
      */
+
     public void streamSome(Entity entity, Emitter emitter) {
         if (entity.getSubsegmentsLock().tryLock()) {
             try {
-                //copy before traversal to avoid ConcurrentModificationExceptions
-                new ArrayList<Subsegment>(entity.getSubsegments()).forEach( (subsegment) -> {
-                    if (subsegment.isInProgress() || !subsegment.getSubsegments().isEmpty()) {
-                        streamSome(subsegment, emitter);
-                    } else {
-                        emitter.sendSubsegment(subsegment);
-                        subsegment.setEmitted(true);
-                        entity.removeSubsegment(subsegment);
-                    }
-                });
+                stream(entity, emitter);
             } finally {
                 entity.getSubsegmentsLock().unlock();
             }
         }
+    }
+
+    private boolean stream(Entity entity, Emitter emitter) {
+        ArrayList<Subsegment> children = new ArrayList<>(entity.getSubsegments());
+        ArrayList<Subsegment> streamable = new ArrayList<>();
+
+        //Gather children and in the condition they are ready to stream, add them to the streamable list.
+        if (children.size() > 0) {
+            for (Subsegment child : children) {
+                if (child.getSubsegmentsLock().tryLock()) {
+                    try {
+                        if (stream(child, emitter)) {
+                            streamable.add(child);
+                        }
+                    } finally {
+                        child.getSubsegmentsLock().unlock();
+                    }
+                }
+            }
+        }
+
+        //A subsegment is marked streamable if all of its children are streamable and the entity itself is not in progress.
+        if (children.size() == streamable.size() && !entity.isInProgress()) {
+            return true;
+        }
+
+        //Stream the subtrees that are ready.
+        for (Subsegment child : streamable) {
+            emitter.sendSubsegment(child);
+            child.setEmitted(true);
+            entity.removeSubsegment(child);
+        }
+
+        return false;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/DefaultStreamingStrategyTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/DefaultStreamingStrategyTest.java
@@ -1,17 +1,29 @@
 package com.amazonaws.xray.strategy;
 
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
+import com.amazonaws.xray.emitters.Emitter;
+import com.amazonaws.xray.entities.*;
+import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
-
-import com.amazonaws.xray.AWSXRay;
-import com.amazonaws.xray.entities.Segment;
-import com.amazonaws.xray.entities.SegmentImpl;
-import com.amazonaws.xray.entities.SubsegmentImpl;
+import org.mockito.Mockito;
 
 @FixMethodOrder(MethodSorters.JVM)
 public class DefaultStreamingStrategyTest {
+
+    @Before
+    public void setupAWSXRay() {
+        Emitter blankEmitter = Mockito.mock(Emitter.class);
+        LocalizedSamplingStrategy defaultSamplingStrategy = new LocalizedSamplingStrategy();
+        Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
+        Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.anyObject());
+        AWSXRay.setGlobalRecorder(AWSXRayRecorderBuilder.standard().withEmitter(blankEmitter).withSamplingStrategy(defaultSamplingStrategy).build());
+        AWSXRay.clearTraceEntity();
+    }
 
     @Test
     public void testDefaultStreamingStrategyRequiresStreaming() {
@@ -26,8 +38,149 @@ public class DefaultStreamingStrategyTest {
         Assert.assertTrue(defaultStreamingStrategy.requiresStreaming(bigSegment));
     }
 
+    @Test
+    public void testDefaultStreamingStrategyDoesNotRequireStreaming() {
+        DefaultStreamingStrategy defaultStreamingStrategy = new DefaultStreamingStrategy(1);
+        Segment smallSegment = new SegmentImpl(AWSXRay.getGlobalRecorder(), "small");
+        Assert.assertFalse(defaultStreamingStrategy.requiresStreaming(smallSegment));
+    }
+
+    @Test
+    public void testingBasicStreamingFunctionality() {
+        DefaultStreamingStrategy defaultStreamingStrategy = new DefaultStreamingStrategy(1);
+        TraceID traceId = new TraceID();
+
+        Segment segment = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceId);
+        Subsegment subsegment = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test", segment);
+        Subsegment subsegment1 = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test", segment);
+        segment.addSubsegment(subsegment);
+        segment.addSubsegment(subsegment1);
+
+        segment.setStartTime(1.0);
+        subsegment.setStartTime(1.0);
+        subsegment1.setStartTime(1.0);
+
+        subsegment.end();
+
+        defaultStreamingStrategy.streamSome(segment, AWSXRay.getGlobalRecorder().getEmitter());
+        Assert.assertTrue(segment.getTotalSize().intValue() == 1);
+    }
+    @Test
+    public void testStreamSomeChildrenRemovedFromParent() { //test to see if the correct actions are being taken in streamSome (children get removed from parent)
+        TraceID traceId = new TraceID();
+        DefaultStreamingStrategy defaultStreamingStrategy = new DefaultStreamingStrategy(1);
+
+        Segment bigSegment = new SegmentImpl(AWSXRay.getGlobalRecorder(), "big", traceId);
+        bigSegment.setStartTime(1.0);
+
+        for (int i = 0; i < 5; i++) {
+            Subsegment subsegment = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "child"+i, bigSegment);
+            subsegment.setStartTime(1.0);
+            bigSegment.addSubsegment(subsegment);
+            subsegment.end();
+        }
+        Assert.assertTrue(defaultStreamingStrategy.requiresStreaming(bigSegment));
+        defaultStreamingStrategy.streamSome(bigSegment, AWSXRay.getGlobalRecorder().getEmitter());
+        Assert.assertTrue(bigSegment.getTotalSize().intValue() == 0);
+    }
+
+    @Test
+    public void testStreamSomeChildrenNotRemovedFromParent() { //test to see if the correct actions are being taken in streamSome (children do NOT get removed from parent due to subsegments being in progress.)
+        TraceID traceId = new TraceID();
+        DefaultStreamingStrategy defaultStreamingStrategy = new DefaultStreamingStrategy(1);
+
+        Segment bigSegment = new SegmentImpl(AWSXRay.getGlobalRecorder(), "big", traceId);
+        bigSegment.setStartTime(1.0);
+
+        for (int i = 0; i < 5; i++) {
+            Subsegment subsegment = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "child"+i, bigSegment);
+            subsegment.setStartTime(1.0);
+            bigSegment.addSubsegment(subsegment);
+        }
+        Assert.assertTrue(defaultStreamingStrategy.requiresStreaming(bigSegment));
+        defaultStreamingStrategy.streamSome(bigSegment, AWSXRay.getGlobalRecorder().getEmitter());
+        Assert.assertTrue(bigSegment.getTotalSize().intValue() == 5);
+    }
+
+    @Test
+    public void testMultithreadedStreamSome() {
+        TraceID traceId = new TraceID();
+        DefaultStreamingStrategy defaultStreamingStrategy = new DefaultStreamingStrategy(1);
+
+        Segment segment = AWSXRay.beginSegment("big");
+
+
+        Subsegment subsegment = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "subsegment1", segment);
+        subsegment.setStartTime(1.0);
+        segment.addSubsegment(subsegment);
+        subsegment.end();
+
+        Thread thread1 = new Thread(() -> {
+            AWSXRay.setTraceEntity(segment);
+            AWSXRay.beginSubsegment("thread1");
+            AWSXRay.endSubsegment();
+        });
+        Thread thread2 = new Thread(() -> {
+            AWSXRay.setTraceEntity(segment);
+            AWSXRay.beginSubsegment("thread2");
+            AWSXRay.endSubsegment();
+        });
+
+        thread1.start();
+        thread2.start();
+        for (Thread thread : new Thread[]{thread1, thread2}) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                return;
+            }
+        }
+
+        Assert.assertTrue(AWSXRay.getTraceEntity().getName().equals("big"));
+        Assert.assertTrue(AWSXRay.getTraceEntity().getTotalSize().intValue() == 3); //asserts that all subsegments are added correctly.
+
+        defaultStreamingStrategy.streamSome(segment, AWSXRay.getGlobalRecorder().getEmitter());
+
+        Assert.assertTrue(segment.getTotalSize().intValue() == 0);
+    }
+
+    @Test
+    public void testBushyandSpindlySegmentTreeStreaming() {
+        TraceID traceId = new TraceID();
+        DefaultStreamingStrategy defaultStreamingStrategy = new DefaultStreamingStrategy(1);
+
+        Segment bigSegment = new SegmentImpl(AWSXRay.getGlobalRecorder(), "big", traceId);
+        bigSegment.setStartTime(1.0);
+
+        for (int i = 0; i < 5; i++) {
+            Subsegment subsegment = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "child"+i, bigSegment);
+            subsegment.setStartTime(1.0);
+            bigSegment.addSubsegment(subsegment);
+            subsegment.end();
+        }
+
+        SubsegmentImpl holder = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "big_child0", bigSegment);
+        holder.setStartTime(1.0);
+        bigSegment.addSubsegment(holder);
+        holder.end();
+
+        SubsegmentImpl holder1 = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "big_child1", bigSegment);
+        holder1.setStartTime(1.0);
+        bigSegment.addSubsegment(holder1);
+        holder1.end();
+
+        SubsegmentImpl holder2 = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "big_child2", bigSegment);
+        holder2.setStartTime(1.0);
+        bigSegment.addSubsegment(holder2);
+        holder2.end();
+
+        Assert.assertTrue(defaultStreamingStrategy.requiresStreaming(bigSegment));
+        defaultStreamingStrategy.streamSome(bigSegment, AWSXRay.getGlobalRecorder().getEmitter());
+        Assert.assertTrue(bigSegment.getReferenceCount() == 0);
+    }
+
     @SuppressWarnings("unused")
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testDefaultStreamingStrategyMaxSegmentSizeParameterValidation() {
         DefaultStreamingStrategy defaultStreamingStrategy = new DefaultStreamingStrategy(-1);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for Subtree Streaming to the AWS X-Ray Java SDK. This logic is currently implemented in the [AWS X-Ray Python SDK](https://github.com/aws/aws-xray-sdk-python) as well as the [AWS X-Ray Ruby SDK](https://github.com/aws/aws-xray-sdk-ruby).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.