### PR TITLE
The method 'sendSubegment' of AWSXRay should have been 'sendSubsegment'

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -160,7 +160,15 @@ public class AWSXRay {
         return globalRecorder.sendSegment(segment);
     }
 
+    /**
+     * @deprecated use {@link #sendSubsegment()} instead
+     */
+    @Deprecated
     public static boolean sendSubegment(Subsegment subsegment) {
+        return AWSXRay.sendSubsegment(subsegment);
+    }
+    
+    public static boolean sendSubsegment(Subsegment subsegment) {
         return globalRecorder.sendSubsegment(subsegment);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
No issue created.  

*Description of changes:*
This is fixing a typo in a method name.  sendSubegment vs sendSubsegment (missing the 's').

I marked 'sendSubegment' as deprecated and added a new 'sendSubsegment' method.
I made the old 'sendSubegment' call the new 'sendSubsegment' for backwards compatibility.
Since this is an interface change that is breaking (if the typo was just fixed) I figured the best way to handle this would be to mark the old method as deprecated, but keep it around.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
