### PR TITLE
Capture throwable instead of just errors in AWSXRayServletFilter

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletFilter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletFilter.java
@@ -151,7 +151,7 @@ public class AWSXRayServletFilter implements javax.servlet.Filter {
 
         try {
             chain.doFilter(request, response);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             if (null != segment) {
                 segment.addException(e);
             }


### PR DESCRIPTION
Added unit tests to ensure we capture both exceptions and errors.

*Issue #, if available:*
#98 

*Description of changes:*
One liner change from catching exceptions to base class Throwable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
