### PR TITLE
Adding a X-Ray recorder to trace SQL queries without external dependencies

### DIFF
--- a/aws-xray-recorder-sdk-sql/pom.xml
+++ b/aws-xray-recorder-sdk-sql/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>aws-xray-recorder-sdk-pom</artifactId>
+      <version>2.3.0</version>
+  </parent>
+  <groupId>com.amazonaws</groupId>
+  <artifactId>aws-xray-recorder-sdk-sql</artifactId>
+    <version>2.3.0</version>
+  <name>AWS X-Ray Recorder SDK for Java - generic SQL</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.4</version>
+        <configuration>
+          <javadocDirectory>${basedir}/docs</javadocDirectory>
+          <docfilessubdirs>true</docfilessubdirs>
+          <overview>${basedir}/docs/overview.html</overview>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-xray-recorder-sdk-core</artifactId>
+      <version>${awsxrayrecordersdk.version}</version>
+    </dependency>
+    <!-- Test -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingConnection.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingConnection.java
@@ -1,0 +1,37 @@
+package com.amazonaws.xray.sql;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.Statement;
+
+class TracingConnection {
+    static Connection decorate(Connection c) {
+        return (Connection) Proxy.newProxyInstance(TracingConnection.class.getClassLoader(),
+                new Class[] { Connection.class },
+                new TracingConnectionHandler(c));
+    }
+
+    private static class TracingConnectionHandler implements InvocationHandler {
+
+        private final Connection original;
+
+        TracingConnectionHandler(Connection original) {
+            this.original = original;
+        }
+
+        public Object invoke(Object proxy, Method method, Object[] args)
+                throws IllegalAccessException, IllegalArgumentException,
+                InvocationTargetException {
+            //intercepted methods taken from https://github.com/aws/aws-xray-sdk-java/blob/master/aws-xray-recorder-sdk-sql-mysql/src/main/java/com/amazonaws/xray/sql/mysql/TracingInterceptor.java
+            if (method.getName().equals("prepareCall") || method.getName().equals("prepareStatement") || method.getName().equals("createStatement")) {
+                Statement s = (Statement) method.invoke(original, args);
+                return TracingStatement.decorate(s, method.getName(), args);
+            }
+            //else, simply delegates
+            return method.invoke(original, args);
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingConnection.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingConnection.java
@@ -26,12 +26,22 @@ class TracingConnection {
                 throws IllegalAccessException, IllegalArgumentException,
                 InvocationTargetException {
             //intercepted methods taken from https://github.com/aws/aws-xray-sdk-java/blob/master/aws-xray-recorder-sdk-sql-mysql/src/main/java/com/amazonaws/xray/sql/mysql/TracingInterceptor.java
-            if (method.getName().equals("prepareCall") || method.getName().equals("prepareStatement") || method.getName().equals("createStatement")) {
+            if (isNewStatement(method)) {
                 Statement s = (Statement) method.invoke(original, args);
                 return TracingStatement.decorate(s, method.getName(), args);
             }
             //else, simply delegates
             return method.invoke(original, args);
+        }
+
+        private static final String PREPARE_CALL = "prepareCall";
+        private static final String PREPARE_STATEMENT = "prepareStatement";
+        private static final String CREATE_STATEMENT = "createStatement";
+
+        private boolean isNewStatement(Method method) {
+            return method.getName().equals(PREPARE_CALL)
+                    || method.getName().equals(PREPARE_STATEMENT)
+                    || method.getName().equals(CREATE_STATEMENT);
         }
     }
 }

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingDataSource.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingDataSource.java
@@ -35,12 +35,18 @@ public class TracingDataSource {
         public Object invoke(Object proxy, Method method, Object[] args)
                 throws IllegalAccessException, IllegalArgumentException,
                 InvocationTargetException {
-            if (method.getName().equals("getConnection")) {
+            if (isGetConnection(method)) {
                 Connection con = (Connection) method.invoke(original, args);
                 return TracingConnection.decorate(con);
             }
             //else, simply delegates
             return method.invoke(original, args);
+        }
+
+        private static final String GET_CONNECTION = "getConnection";
+
+        private boolean isGetConnection(Method method) {
+            return method.getName().equals(GET_CONNECTION);
         }
     }
 }

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingDataSource.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingDataSource.java
@@ -1,0 +1,46 @@
+package com.amazonaws.xray.sql;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+
+public class TracingDataSource {
+
+    /**
+     * Call this method on your {@link DataSource} before any calls to #getConnection in order to have all your SQL
+     * queries added in a X-Ray Subsegment.
+     * If X-Ray is incorrectly configured, all queries will be traced to stdout.
+     * If there is a problem to retrieve DB metadata, the X-Ray trace will contain "strange SQLException occurred ...".
+     *
+     * @param ds the datasource to decorate
+     * @return a DataSource that traces all SQL queries in X-Ray
+     */
+    public static DataSource decorate(DataSource ds) {
+        return (DataSource) Proxy.newProxyInstance(TracingDataSource.class.getClassLoader(),
+                new Class[] { DataSource.class },
+                new TracingDatasourceHandler(ds));
+    }
+
+    private static class TracingDatasourceHandler implements InvocationHandler {
+
+        private final DataSource original;
+
+        TracingDatasourceHandler(DataSource original) {
+            this.original = original;
+        }
+
+        public Object invoke(Object proxy, Method method, Object[] args)
+                throws IllegalAccessException, IllegalArgumentException,
+                InvocationTargetException {
+            if (method.getName().equals("getConnection")) {
+                Connection con = (Connection) method.invoke(original, args);
+                return TracingConnection.decorate(con);
+            }
+            //else, simply delegates
+            return method.invoke(original, args);
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
@@ -1,0 +1,134 @@
+package com.amazonaws.xray.sql;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Namespace;
+import com.amazonaws.xray.entities.Subsegment;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
+
+class TracingStatement {
+    static Statement decorate(Statement s, String invokedMethodName, Object[] invokedMethodArgs) {
+        return (Statement) Proxy.newProxyInstance(TracingConnection.class.getClassLoader(),
+                new Class[] { resolveProxiedInterface(invokedMethodName) },
+                new TracingStatementHandler(s, resolveSqlQuery(invokedMethodName, invokedMethodArgs)));
+    }
+
+    private static Class resolveProxiedInterface(String invokedMethodName) {
+        switch (invokedMethodName) {
+            case "prepareCall": return CallableStatement.class;
+            case "prepareStatement": return PreparedStatement.class;
+            case "createStatement": return Statement.class;
+            default: throw new IllegalStateException("TracingSegment can not decorate " + invokedMethodName);
+        }
+    }
+
+    private static String resolveSqlQuery(String invokedMethodName, Object[] invokedMethodArgs) {
+        switch (invokedMethodName) {
+            case "prepareCall":
+            case "prepareStatement":
+                return (String) invokedMethodArgs[0];
+            case "createStatement":
+                return null; //the correct sql will be retrieved later in resolveExecutedSql
+            default: throw new IllegalStateException("TracingSegment can not resolve sql for " + invokedMethodName);
+        }
+    }
+
+    private static class TracingStatementHandler implements InvocationHandler {
+
+        private final Statement original;
+        private final String sql;
+
+        TracingStatementHandler(Statement original, String sql) {
+            this.original = original;
+            this.sql = sql;
+        }
+
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            //mostly based on https://github.com/aws/aws-xray-sdk-java/blob/master/aws-xray-recorder-sdk-sql-mysql/src/main/java/com/amazonaws/xray/sql/mysql/TracingInterceptor.java
+            // but in a more straightforward logic (IMHO :) )
+            if (method.getName().equals("execute") || method.getName().equals("executeQuery") || method.getName().equals("executeUpdate") || method.getName().equals("executeBatch")) {
+                //invoke the original method "wrapped" in a XRay Subsegment
+                //implementation note : can not use shorter AWSXRay.createSubsegment because we need to deal with InvocationTargetException
+                boolean openDummySegment = false;
+                if (! AWSXRay.getCurrentSegmentOptional().isPresent()) {
+                    //we are (probably) being executed outside AWS env (unit tests, background process, ...)
+                    // -> we do not want to crash or to log a SegmentNotFoundException, so we print to stdout
+                    // note that if you are in AWS context, stdout will be log to cloudwatch logs anyway
+                    openDummySegment = true;
+                    System.out.println(sanitizeSql(resolveExecutedSql(method.getName(), args)));
+                    AWSXRay.beginDummySegment();
+                }
+                Subsegment subsegment = AWSXRay.beginSubsegment("SQL");
+                subsegment.putAllSql(extractSqlParams(method, args));
+                subsegment.setNamespace(Namespace.REMOTE.toString());
+                try {
+                    return method.invoke(original, args); //execute the query
+                } catch (Throwable t) {
+                    subsegment.addException(t);
+                    if (t instanceof InvocationTargetException && t.getCause() != null) {
+                        throw t.getCause();
+                    } else {
+                        throw t;
+                    }
+                } finally {
+                    AWSXRay.endSubsegment();
+                    if (openDummySegment) {
+                        AWSXRay.endSegment();
+                    }
+                }
+
+            } else {
+                //else, simply delegates
+                return method.invoke(original, args);
+            }
+        }
+
+        private Map<String, Object> extractSqlParams(Method method, Object[] args) {
+            Map<String, Object> additionalParams = new HashMap<>();
+            try {
+                DatabaseMetaData metadata = original.getConnection().getMetaData();
+                additionalParams.put("url", metadata.getURL());
+                additionalParams.put("driver_version", metadata.getDriverVersion());
+                additionalParams.put("database_type", metadata.getDatabaseProductName());
+                additionalParams.put("database_version", metadata.getDatabaseProductVersion());
+                additionalParams.put("sanitized_query", sanitizeSql(resolveExecutedSql(method.getName(), args)));
+            } catch (SQLException e) {
+                //a SqlException at this stage is kind of strange ... just ignore
+                // (i.e the XRay trace will not contain the info but this is not very severe)
+                //at least, we provide a way to identify the problem in the XRay trace
+                additionalParams.put("url", "strange SQLException occurred ...");
+            }
+            return additionalParams;
+        }
+
+        private String resolveExecutedSql(String invokedMethodName, Object[] invokedMethodArgs) {
+            switch (invokedMethodName) {
+                case "execute":
+                case "executeQuery":
+                case "executeUpdate":
+                    return invokedMethodArgs != null && invokedMethodArgs.length > 0 && (invokedMethodArgs[0] instanceof String) ? (String) invokedMethodArgs[0] : sql;
+                case "executeBatch":
+                    //retrieving the executed queries is possible ... but that would produce a very big output !
+                    return "BATCH";
+                default:
+                    throw new IllegalStateException("can not resolve executed SQL for " + invokedMethodName);
+            }
+        }
+
+        private String sanitizeSql(String sql) {
+            //TODO: ask programmer consent and log intelligently
+            //First problem : we should not expose sensitive data here, at least without the programmer consent
+            //  note that in the .net SDK, they simply have a look at a config var (https://github.com/aws/aws-xray-sdk-dotnet/blob/master/sdk/src/Handlers/SqlServer/DbCommandInterceptor.cs > ShouldCollectSqlText)
+            //  also note that in the python SDK, they simply trust SqlAlchemy or Django ...
+            //Second problem : we should not log something too big (because that would incur storage costs all over AWS infrastructure)
+            //  however, just truncating is a bit harsh ...
+            return sql != null && sql.length() > 300 ? (sql.substring(0, 297)+"...") : sql;
+        }
+    }
+}


### PR DESCRIPTION
TracingDataSource.decorate is the only thing needed in order to have X-Ray traces of all SQL queries issued from the datasource

*Issue #, if available:* #103 

*Description of changes:* Currently, one can easily add SQL traces from mysql or postgres if using tomcat-jdbc / spring.
In this PR, I've made a solution without external dependencies, purely based on Java reflection proxy


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
