### PR TITLE
Fixed options tags to build on linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,9 @@
           </footer>
           <bottom><![CDATA[Copyright &#169; 2018 Amazon Web Services, Inc. All Rights Reserved.]]></bottom>
           <additionalJOption>-Xdoclint:none</additionalJOption>
-          <additionalOptions>--allow-script-in-comments</additionalOptions>
+          <additionalOptions>
+            <addititionalOption>--allow-script-in-comments</addititionalOption>
+          </additionalOptions>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Minor change to `pom.xml` that was causing build to fail on linux. 

Tested with `mvn install`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
