### PR TITLE
Added interceptor without spring data dependency

### DIFF
--- a/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/AbstractXRayInterceptor.java
+++ b/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/AbstractXRayInterceptor.java
@@ -11,15 +11,15 @@ public abstract class AbstractXRayInterceptor extends BaseAbstractXRayIntercepto
 
     private static final Log logger = LogFactory.getLog(AbstractXRayInterceptor.class);
 
-    @Override
     @Pointcut("execution(public !void org.springframework.data.repository.Repository+.*(..))")
     protected void springRepositories() {
     }
 
     /**
-     * {@inheritDoc}
+     * @param pjp the proceeding join point
+     * @return the result of the method being wrapped
+     * @throws Throwable
      */
-    @Override
     @Around("springRepositories()")
     public Object traceAroundRepositoryMethods(ProceedingJoinPoint pjp) throws Throwable {
         logger.trace("Advising repository");

--- a/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/AbstractXRayInterceptor.java
+++ b/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/AbstractXRayInterceptor.java
@@ -1,80 +1,25 @@
 package com.amazonaws.xray.spring.aop;
 
-import com.amazonaws.xray.AWSXRay;
-import com.amazonaws.xray.entities.Segment;
-import com.amazonaws.xray.entities.Subsegment;
-import com.amazonaws.xray.exceptions.SegmentNotFoundException;
-import com.amazonaws.xray.strategy.ContextMissingStrategy;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Pointcut;
 
-import java.util.Map;
-import java.util.Optional;
 
-import static com.amazonaws.xray.AWSXRay.getCurrentSegmentOptional;
-
-public abstract class AbstractXRayInterceptor {
+public abstract class AbstractXRayInterceptor extends BaseAbstractXRayInterceptor {
 
     private static final Log logger = LogFactory.getLog(AbstractXRayInterceptor.class);
 
-    private static ContextMissingStrategy getContextMissingStrategy() {
-        return AWSXRay.getGlobalRecorder().getContextMissingStrategy();
-    }
-
-    private static Segment getCurrentSegment() {
-        Optional<Segment> segment = getCurrentSegmentOptional();
-        if (segment.isPresent()) {
-            return segment.get();
-        }
-        ContextMissingStrategy contextMissingStrategy = getContextMissingStrategy();
-        contextMissingStrategy.contextMissing("No segment in progress.", SegmentNotFoundException.class);
-        return null;
-    }
-
-    /**
-     * @param pjp the proceeding join point
-     * @return the result of the method being wrapped
-     * @throws Throwable
-     */
-    @Around("xrayTracedClasses() || xrayEnabledClasses()")
-    public Object traceAroundMethods(ProceedingJoinPoint pjp) throws Throwable {
-        return this.processXRayTrace(pjp);
-    }
-
-    protected Object processXRayTrace(ProceedingJoinPoint pjp) throws Throwable {
-        try {
-            Subsegment subsegment = AWSXRay.beginSubsegment(pjp.getSignature().getName());
-            if(subsegment != null) {
-                subsegment.setMetadata(generateMetadata(pjp, subsegment));
-            }
-            return XRayInterceptorUtils.conditionalProceed(pjp);
-        } catch (Exception e) {
-            AWSXRay.getCurrentSegment().addException(e);
-            throw e;
-        } finally {
-            logger.trace("Ending Subsegment");
-            AWSXRay.endSubsegment();
-        }
-    }
-
-    protected abstract void xrayEnabledClasses();
-
-    @Pointcut("execution(* XRayTraced+.*(..))")
-    protected void xrayTracedClasses() {
-    }
-
+    @Override
     @Pointcut("execution(public !void org.springframework.data.repository.Repository+.*(..))")
     protected void springRepositories() {
     }
 
     /**
-     * @param pjp the proceeding join point
-     * @return the result of the method being wrapped
-     * @throws Throwable
+     * {@inheritDoc}
      */
+    @Override
     @Around("springRepositories()")
     public Object traceAroundRepositoryMethods(ProceedingJoinPoint pjp) throws Throwable {
         logger.trace("Advising repository");
@@ -93,9 +38,4 @@ public abstract class AbstractXRayInterceptor {
             return XRayInterceptorUtils.conditionalProceed(pjp);
         }
     }
-
-    protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint pjp, Subsegment subsegment) {
-        return XRayInterceptorUtils.generateMetadata(pjp, subsegment);
-    }
-
 }

--- a/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/BaseAbstractXRayInterceptor.java
+++ b/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/BaseAbstractXRayInterceptor.java
@@ -71,18 +71,6 @@ public abstract class BaseAbstractXRayInterceptor {
     protected void xrayTracedClasses() {
     }
 
-    protected void springRepositories() {
-    }
-
-    /**
-     * @param pjp the proceeding join point
-     * @return the result of the method being wrapped
-     * @throws Throwable
-     */
-    public Object traceAroundRepositoryMethods(ProceedingJoinPoint pjp) throws Throwable {
-        return XRayInterceptorUtils.conditionalProceed(pjp);
-    }
-
     protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint pjp, Subsegment subsegment) {
         return XRayInterceptorUtils.generateMetadata(pjp, subsegment);
     }

--- a/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/BaseAbstractXRayInterceptor.java
+++ b/aws-xray-recorder-sdk-spring/src/main/java/com/amazonaws/xray/spring/aop/BaseAbstractXRayInterceptor.java
@@ -1,0 +1,89 @@
+package com.amazonaws.xray.spring.aop;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.exceptions.SegmentNotFoundException;
+import com.amazonaws.xray.strategy.ContextMissingStrategy;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Pointcut;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.amazonaws.xray.AWSXRay.getCurrentSegmentOptional;
+
+
+/**
+ * Allows for use of this library without Spring Data JPA being in the classpath.
+ * For projects using Spring Data JPA, consider using {@link AbstractXRayInterceptor} instead.
+ */
+public abstract class BaseAbstractXRayInterceptor {
+
+    private static final Log logger = LogFactory.getLog(BaseAbstractXRayInterceptor.class);
+
+    private static ContextMissingStrategy getContextMissingStrategy() {
+        return AWSXRay.getGlobalRecorder().getContextMissingStrategy();
+    }
+
+    private static Segment getCurrentSegment() {
+        Optional<Segment> segment = getCurrentSegmentOptional();
+        if (segment.isPresent()) {
+            return segment.get();
+        }
+        ContextMissingStrategy contextMissingStrategy = getContextMissingStrategy();
+        contextMissingStrategy.contextMissing("No segment in progress.", SegmentNotFoundException.class);
+        return null;
+    }
+
+    /**
+     * @param pjp the proceeding join point
+     * @return the result of the method being wrapped
+     * @throws Throwable
+     */
+    @Around("xrayTracedClasses() || xrayEnabledClasses()")
+    public Object traceAroundMethods(ProceedingJoinPoint pjp) throws Throwable {
+        return this.processXRayTrace(pjp);
+    }
+
+    protected Object processXRayTrace(ProceedingJoinPoint pjp) throws Throwable {
+        try {
+            Subsegment subsegment = AWSXRay.beginSubsegment(pjp.getSignature().getName());
+            if(subsegment != null) {
+                subsegment.setMetadata(generateMetadata(pjp, subsegment));
+            }
+            return XRayInterceptorUtils.conditionalProceed(pjp);
+        } catch (Exception e) {
+            AWSXRay.getCurrentSegment().addException(e);
+            throw e;
+        } finally {
+            logger.trace("Ending Subsegment");
+            AWSXRay.endSubsegment();
+        }
+    }
+
+    protected abstract void xrayEnabledClasses();
+
+    @Pointcut("execution(* XRayTraced+.*(..))")
+    protected void xrayTracedClasses() {
+    }
+
+    protected void springRepositories() {
+    }
+
+    /**
+     * @param pjp the proceeding join point
+     * @return the result of the method being wrapped
+     * @throws Throwable
+     */
+    public Object traceAroundRepositoryMethods(ProceedingJoinPoint pjp) throws Throwable {
+        return XRayInterceptorUtils.conditionalProceed(pjp);
+    }
+
+    protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint pjp, Subsegment subsegment) {
+        return XRayInterceptorUtils.generateMetadata(pjp, subsegment);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-java/issues/45

*Description of changes:*
Added another abstract interceptor, extended by the existing one. This shouldn't break backwards-compatibility, but gives the option to users who don't have spring-data-jpa on their classpath.

Note that I haven't been able to test this yet, will be doing that soon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Edit: I won't be able to test this, as the original library itself doesn't work for my use case. I'll leave this open in case it's still useful for this quite old issue.