### PR TITLE
Handle sampling requests with null fields & bugfix

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
@@ -100,12 +100,12 @@ public class LocalizedSamplingStrategy implements SamplingStrategy {
     @Override
     public SamplingResponse shouldTrace(SamplingRequest samplingRequest) {
         if (logger.isDebugEnabled()) {
-            logger.debug("Determining shouldTrace decision for:\n\thost: " + samplingRequest.getHost().get() + "\n\tpath: " + samplingRequest.getUrl().get() + "\n\tmethod: " + samplingRequest.getMethod().get());
+            logger.debug("Determining shouldTrace decision for:\n\thost: " + samplingRequest.getHost().orElse("") + "\n\tpath: " + samplingRequest.getUrl().orElse("") + "\n\tmethod: " + samplingRequest.getMethod().orElse(""));
         }
         SamplingResponse sampleResponse = new SamplingResponse();
         SamplingRule firstApplicableRule = null;
         if (null != rules) {
-            firstApplicableRule = rules.stream().filter( rule -> rule.appliesTo(samplingRequest.getHost().get(), samplingRequest.getUrl().get(), samplingRequest.getMethod().get())).findFirst().orElse(null);
+            firstApplicableRule = rules.stream().filter( rule -> rule.appliesTo(samplingRequest.getHost().orElse(""), samplingRequest.getUrl().orElse(""), samplingRequest.getMethod().orElse(""))).findFirst().orElse(null);
         }
         sampleResponse.setSampled(null == firstApplicableRule ? shouldTrace(defaultRule) : shouldTrace(firstApplicableRule));
         return sampleResponse;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/SamplingRule.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/SamplingRule.java
@@ -160,7 +160,7 @@ public class SamplingRule {
      * @return whether or not this rule applies to the incoming request
      */
     public boolean appliesTo(String requestHost, String requestPath, String requestMethod) {
-        return (null == host || SearchPattern.wildcardMatch(host, requestHost)) &&
+        return (null == requestHost || SearchPattern.wildcardMatch(host, requestHost)) &&
             (null == requestPath || SearchPattern.wildcardMatch(urlPath, requestPath)) &&
             (null == requestMethod || SearchPattern.wildcardMatch(httpMethod, requestMethod));
     }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategyTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategyTest.java
@@ -112,4 +112,11 @@ public class LocalizedSamplingStrategyTest {
         Assert.assertFalse(s3.isSampled());
     }
 
+    @Test
+    public void testSamplingRequestHasNullField() {
+        URL samplingRules = LocalizedSamplingStrategyTest.class.getResource("/com/amazonaws/xray/strategy/sampling/TwoSamplingRules.json");
+        LocalizedSamplingStrategy localizedSamplingStrategy = new LocalizedSamplingStrategy(samplingRules);
+        localizedSamplingStrategy.shouldTrace(new SamplingRequest(null,null, null, null, ""));
+    }
+
 }


### PR DESCRIPTION
*Issue #, if available:*
#120 

*Description of changes:*
The current sampling rules calls `Optional.get()` which triggers a NSE when the sampling request contains a null field. Handle this a properly. Also fixing an obvious bug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
