### PR TITLE
Better handling of SQL statements made outside of X-Ray segments.

### DIFF
--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.exceptions.SegmentNotFoundException;
 
 public class TracingStatement {
 
@@ -148,7 +149,13 @@ public class TracingStatement {
                     logger.warn("Unable to parse database URI. Falling back to default '" + DEFAULT_DATABASE_NAME + "' for subsegment name.", e);
                 }
 
-                Subsegment subsegment = AWSXRay.beginSubsegment(subsegmentName);
+                Subsegment subsegment = null;
+                try {
+                    subsegment = AWSXRay.beginSubsegment(subsegmentName);
+                } catch (final SegmentNotFoundException exception) {
+                    logger.debug("Statement was not in a segment.", exception);
+                }
+
                 if (subsegment == null) {
                     return null;
                 }


### PR DESCRIPTION
*Description of changes:*
Some applications only require a subset of SQL statements to be tracked by
X-Ray. This change makes such statements not fail with a
SegmentNotFoundException exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
