### PR TITLE
Adding IgnoreContextMissingStrategy

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
@@ -22,6 +22,7 @@ import com.amazonaws.xray.contexts.SegmentContextResolverChain;
 import com.amazonaws.xray.emitters.Emitter;
 import com.amazonaws.xray.plugins.Plugin;
 import com.amazonaws.xray.strategy.ContextMissingStrategy;
+import com.amazonaws.xray.strategy.IgnoreErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.LogErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.PrioritizationStrategy;
 import com.amazonaws.xray.strategy.RuntimeErrorContextMissingStrategy;
@@ -77,6 +78,8 @@ public class AWSXRayRecorderBuilder {
                 return Optional.of(new LogErrorContextMissingStrategy());
             } else if (contextMissingStrategyOverrideValue.equalsIgnoreCase(RuntimeErrorContextMissingStrategy.OVERRIDE_VALUE)) {
                 return Optional.of(new RuntimeErrorContextMissingStrategy());
+            } else if (contextMissingStrategyOverrideValue.equalsIgnoreCase(IgnoreErrorContextMissingStrategy.OVERRIDE_VALUE)) {
+                return Optional.of(new IgnoreErrorContextMissingStrategy());
             }
         }
         return Optional.empty();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/ContextMissingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/ContextMissingStrategy.java
@@ -3,13 +3,13 @@ package com.amazonaws.xray.strategy;
 public interface ContextMissingStrategy {
 
     /**
-     * Environment variable key used to override the default {@code ContextMissingStrategy} used in new instances of {@code AWSXRayRecorder}. Valid values for this environment variable are (case-insensitive) {@code RUNTIME_ERROR} and {@code LOG_ERROR}. Invalid values will be ignored.
+     * Environment variable key used to override the default {@code ContextMissingStrategy} used in new instances of {@code AWSXRayRecorder}. Valid values for this environment variable are (case-insensitive) {@code RUNTIME_ERROR}, {@code LOG_ERROR} and {@code IGNORE_ERROR}. Invalid values will be ignored.
      * Takes precedence over any system property or builder value used for the {@code DefaultContextMissingStrategy}.
      */
     public static final String CONTEXT_MISSING_STRATEGY_ENVIRONMENT_VARIABLE_OVERRIDE_KEY = "AWS_XRAY_CONTEXT_MISSING";
 
     /**
-     * System property key used to override the default {@code ContextMissingStrategy} used in new instances of {@code AWSXRayRecorder}. Valid values for this system property are (case-insensitive) {@code RUNTIME_ERROR} and {@code LOG_ERROR}. Invalid values will be ignored.
+     * System property key used to override the default {@code ContextMissingStrategy} used in new instances of {@code AWSXRayRecorder}. Valid values for this system property are (case-insensitive) {@code RUNTIME_ERROR}, {@code LOG_ERROR} and {@code IGNORE_ERROR}. Invalid values will be ignored.
      * Takes precedence over any builder value used for the {@code DefaultContextMissingStrategy}.
      */
     public static final String CONTEXT_MISSING_STRATEGY_SYSTEM_PROPERTY_OVERRIDE_KEY = "com.amazonaws.xray.strategy.contextMissingStrategy";

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/IgnoreErrorContextMissingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/IgnoreErrorContextMissingStrategy.java
@@ -1,0 +1,16 @@
+package com.amazonaws.xray.strategy;
+
+public class IgnoreErrorContextMissingStrategy implements ContextMissingStrategy {
+    public static final String OVERRIDE_VALUE = "IGNORE_ERROR";
+
+    /**
+     * Ignore the error
+     * @param message not used
+     * @param exceptionClass not used
+     */
+    @Override
+    public void contextMissing(String message, Class<? extends RuntimeException> exceptionClass) {
+        // do nothing
+    }
+
+}

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -16,6 +16,7 @@ import com.amazonaws.xray.plugins.EKSPlugin;
 import com.amazonaws.xray.plugins.ElasticBeanstalkPlugin;
 import com.amazonaws.xray.plugins.Plugin;
 import com.amazonaws.xray.strategy.ContextMissingStrategy;
+import com.amazonaws.xray.strategy.IgnoreErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.LogErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.RuntimeErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
@@ -122,6 +123,12 @@ public class AWSXRayRecorderTest {
     @Test
     public void testBeginSubsegmentOnEmptyThreadDoesNotThrowExceptionWithLogErrorContextMissingStrategy() {
         AWSXRay.getGlobalRecorder().setContextMissingStrategy(new LogErrorContextMissingStrategy());
+        AWSXRay.beginSubsegment("test");
+    }
+
+    @Test
+    public void testBeginSubsegmentOnEmptyThreadDoesNotThrowExceptionWithIgnoreErrorContextMissingStrategy() {
+        AWSXRay.getGlobalRecorder().setContextMissingStrategy(new IgnoreErrorContextMissingStrategy());
         AWSXRay.beginSubsegment("test");
     }
 


### PR DESCRIPTION
*Description of changes:*
With tracing auto-instrumentation, sometimes context missing is inevitable and hard to mitigate.  Using `LogErrorContextMissingStrategy` is not enough as some users set alarm on the ERROR logs. The `IgnoreContextMissingStrategy` will ignore the context missing. It can be set via environment variable/system property.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
