### PR TITLE
Fixed implementation of isWrapperFor and unwrap

### DIFF
--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingConnection.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingConnection.java
@@ -307,12 +307,16 @@ public class TracingConnection implements Connection {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(this)) {
+            return (T) this;
+        }
         return delegate.unwrap(iface);
     }
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return delegate.isWrapperFor(iface);
+        return (iface.isInstance(this) || delegate.isWrapperFor(iface));
     }
 }

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingDataSource.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingDataSource.java
@@ -41,19 +41,23 @@ public class TracingDataSource implements DataSource {
         return new TracingConnection(delegate.getConnection(username, password));
     }
 
-    /**
-     * Plain methods
-     */
-
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(this)) {
+            return (T) this;
+        }
         return delegate.unwrap(iface);
     }
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return delegate.isWrapperFor(iface);
+        return (iface.isInstance(this) || delegate.isWrapperFor(iface));
     }
+
+    /**
+     * Plain methods
+     */
 
     @Override
     public PrintWriter getLogWriter() throws SQLException {

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingConnectionTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingConnectionTest.java
@@ -68,6 +68,7 @@ public class TracingConnectionTest {
     @Test
     public void testUnwrap() throws SQLException {
         Assert.assertSame(connection, connection.unwrap(Connection.class));
+        Assert.assertSame(connection, connection.unwrap(TracingConnection.class));
         Assert.assertSame(delegate, connection.unwrap(OtherWrapper.class));
         Assert.assertSame(delegate, connection.unwrap(ExtraInterface.class));
         boolean exceptionThrown = false;
@@ -78,6 +79,7 @@ public class TracingConnectionTest {
         }
         assertTrue(exceptionThrown);
         verify(delegate, never()).unwrap(Connection.class);
+        verify(delegate, never()).unwrap(TracingConnection.class);
         verify(delegate).unwrap(OtherWrapper.class);
         verify(delegate).unwrap(ExtraInterface.class);
         verify(delegate).unwrap(Long.class);

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingDataSourceTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingDataSourceTest.java
@@ -1,10 +1,20 @@
 package com.amazonaws.xray.sql;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,18 +26,55 @@ public class TracingDataSourceTest {
 
     private DataSource dataSource;
 
-    @Mock
-    private DataSource delegate;
+    public interface OtherWrapper extends DataSource, ExtraInterface {
+    }
 
+    public interface ExtraInterface {
+    }
+
+    @Mock
+    private OtherWrapper delegate;
+
+    @SuppressWarnings("unchecked")
     @Before
-    public void setup() {
+    public void setup() throws SQLException {
         dataSource = TracingDataSource.decorate(delegate);
+        doReturn(false).when(delegate).isWrapperFor(any());
+        doReturn(true).when(delegate).isWrapperFor(OtherWrapper.class);
+        doReturn(true).when(delegate).isWrapperFor(ExtraInterface.class);
+        doThrow(SQLException.class).when(delegate).unwrap(any());
+        doReturn(delegate).when(delegate).unwrap(OtherWrapper.class);
+        doReturn(delegate).when(delegate).unwrap(ExtraInterface.class);
     }
 
     @Test
-    public void testDecoration() {
+    public void testDecoration() throws SQLException {
         assertTrue(dataSource instanceof TracingDataSource);
+        assertTrue(dataSource.isWrapperFor(DataSource.class));
+        assertTrue(dataSource.isWrapperFor(TracingDataSource.class));
+        assertTrue(dataSource.isWrapperFor(OtherWrapper.class));
+        assertTrue(dataSource.isWrapperFor(ExtraInterface.class));
+        assertFalse(dataSource.isWrapperFor(Long.class));
+        verify(delegate, never()).isWrapperFor(DataSource.class);
+        verify(delegate, never()).isWrapperFor(TracingDataSource.class);
+        verify(delegate).isWrapperFor(OtherWrapper.class);
+        verify(delegate).isWrapperFor(ExtraInterface.class);
+        verify(delegate).isWrapperFor(Long.class);
     }
+
+    @Test
+    public void testUnwrap() throws SQLException {
+        Assert.assertSame(dataSource, dataSource.unwrap(DataSource.class));
+        Assert.assertSame(delegate, dataSource.unwrap(OtherWrapper.class));
+        Assert.assertSame(delegate, dataSource.unwrap(ExtraInterface.class));
+        boolean exceptionThrown = false;
+        try {
+            dataSource.unwrap(Long.class);
+        } catch (final SQLException e) {
+            exceptionThrown = true;
+        }
+        assertTrue(exceptionThrown);
+    };
 
     @Test
     public void testGetConnection() throws Exception {

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingDataSourceTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingDataSourceTest.java
@@ -65,6 +65,7 @@ public class TracingDataSourceTest {
     @Test
     public void testUnwrap() throws SQLException {
         Assert.assertSame(dataSource, dataSource.unwrap(DataSource.class));
+        Assert.assertSame(dataSource, dataSource.unwrap(TracingDataSource.class));
         Assert.assertSame(delegate, dataSource.unwrap(OtherWrapper.class));
         Assert.assertSame(delegate, dataSource.unwrap(ExtraInterface.class));
         boolean exceptionThrown = false;
@@ -74,6 +75,11 @@ public class TracingDataSourceTest {
             exceptionThrown = true;
         }
         assertTrue(exceptionThrown);
+        verify(delegate, never()).unwrap(DataSource.class);
+        verify(delegate, never()).unwrap(TracingDataSource.class);
+        verify(delegate).unwrap(OtherWrapper.class);
+        verify(delegate).unwrap(ExtraInterface.class);
+        verify(delegate).unwrap(Long.class);
     };
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* #130

*Description of changes:*

Corrected the implementation of `isWrapperFor` and `unwrap` in the `TracingConnection` and `TracingDataSource` classes to properly implement the `java.sql.Wrapper` interface.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
