### PR TITLE
Fully qualified, configurable Trace ID Injection

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -104,7 +104,7 @@ public class AWSXRay {
         return globalRecorder.currentTraceId();
     }
 
-    public static String currentFullyQualifiedId() { return globalRecorder.currentFullyQualifiedId(); }
+    public static String currentFormattedId() { return globalRecorder.currentFormattedId(); }
 
     public static Segment getCurrentSegment() {
         return globalRecorder.getCurrentSegment();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -104,6 +104,8 @@ public class AWSXRay {
         return globalRecorder.currentTraceId();
     }
 
+    public static String currentFullyQualifiedId() { return globalRecorder.currentFullyQualifiedId(); }
+
     public static Segment getCurrentSegment() {
         return globalRecorder.getCurrentSegment();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -878,4 +878,26 @@ public class AWSXRayRecorder {
         }
     }
 
+    /**
+     *
+     * @throws SegmentNotFoundException
+     *             if {@code contextMissingStrategy} throws exceptions and no segment or subsegment is currently in progress
+     * @return the trace ID of the {@code Segment} currently in progress and the ID of the {@code Segment} or {@code Subsegment} in progress, joined with {@code @},
+     *             or {@code null} if {@code contextMissingStrategy} suppresses exceptions and no segment or subsegment is currently in progress
+     */
+    public String currentFullyQualifiedId() {
+        SegmentContext context = getSegmentContext();
+        if (null == context) {
+            return null;
+        }
+        Entity current = context.getTraceEntity();
+        if (null != current) {
+            TraceID traceId = current.getParentSegment().getTraceId();
+            String entityId = current.getId();
+            return traceId.toString() + "@" + entityId;
+        } else {
+            contextMissingStrategy.contextMissing("Failed to get current trace ID: segment cannot be found.", SegmentNotFoundException.class);
+            return null;
+        }
+    }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -885,7 +885,7 @@ public class AWSXRayRecorder {
      * @return the trace ID of the {@code Segment} currently in progress and the ID of the {@code Segment} or {@code Subsegment} in progress, joined with {@code @},
      *             or {@code null} if {@code contextMissingStrategy} suppresses exceptions and no segment or subsegment is currently in progress
      */
-    public String currentFullyQualifiedId() {
+    public String currentFormattedId() {
         SegmentContext context = getSegmentContext();
         if (null == context) {
             return null;
@@ -896,7 +896,7 @@ public class AWSXRayRecorder {
             String entityId = current.getId();
             return traceId.toString() + "@" + entityId;
         } else {
-            contextMissingStrategy.contextMissing("Failed to get current trace ID: segment cannot be found.", SegmentNotFoundException.class);
+            contextMissingStrategy.contextMissing("Failed to get current formatted ID: segment cannot be found.", SegmentNotFoundException.class);
             return null;
         }
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -1,5 +1,6 @@
 package com.amazonaws.xray.contexts;
 
+import com.amazonaws.xray.listeners.SegmentListener;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -13,6 +14,9 @@ import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.entities.TraceHeader.SampleDecision;
 import com.amazonaws.xray.entities.TraceID;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
+
+import java.util.List;
+import java.util.Objects;
 
 public class LambdaSegmentContext implements SegmentContext {
     private static final Log logger = LogFactory.getLog(LambdaSegmentContext.class);
@@ -61,6 +65,12 @@ public class LambdaSegmentContext implements SegmentContext {
             subsegment.setParent(parentSubsegment);
             parentSubsegment.addSubsegment(subsegment);
             setTraceEntity(subsegment);
+
+            List<SegmentListener> segmentListeners = recorder.getSegmentListeners();
+            segmentListeners.stream()
+                    .filter(Objects::nonNull)
+                    .forEach(listener -> listener.onBeginSubsegment(subsegment));
+
             return subsegment;
         }
     }
@@ -73,11 +83,23 @@ public class LambdaSegmentContext implements SegmentContext {
                 logger.debug("Ending subsegment named: " + current.getName());
             }
             Subsegment currentSubsegment = (Subsegment) current;
+
+            List<SegmentListener> segmentListeners = recorder.getSegmentListeners();
+            segmentListeners
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .forEach(listener -> listener.beforeEndSubsegment(currentSubsegment));
+
             currentSubsegment.end();
 
             if (recorder.getStreamingStrategy().requiresStreaming(currentSubsegment.getParentSegment())) {
                 recorder.getStreamingStrategy().streamSome(currentSubsegment.getParentSegment(), recorder.getEmitter());
             }
+
+            segmentListeners
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .forEach(listener -> listener.afterEndSubsegment(currentSubsegment));
 
             Entity parentEntity = current.getParent();
             if (parentEntity instanceof FacadeSegment) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
@@ -78,7 +78,7 @@ public interface SegmentListener {
     }
 
     /**
-     * onSetEntity is invoked when the SegmentContext is being updated with a new entity.
+     * onSetEntity is invoked immediately before the SegmentContext is updated with a new entity.
      * Both the new entity and the previous entity (or null if unset) are passed.
      *
      * @param previousEntity

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
@@ -2,6 +2,7 @@ package com.amazonaws.xray.listeners;
 
 import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
 
 /**
  * An interface to intercept lifecycle events, namely the beginning and ending, of segments produced by the AWSXRayRecorder.
@@ -22,6 +23,17 @@ public interface SegmentListener {
     }
 
     /**
+     * onBeginSubsegment is invoked immediately after a subsegment is created by the recorder.
+     * The subsegment can be manipulated, e.g. with putAnnotation.
+     *
+     * @param subsegment
+     * The subsegment that has just begun
+     */
+    default void onBeginSubsegment(Subsegment subsegment) {
+
+    }
+
+    /**
      * beforeEndSegment is invoked just before a segment is ended by the recorder.
      * The segment can be manipulated, e.g. with putAnnotation.
      *
@@ -33,13 +45,35 @@ public interface SegmentListener {
     }
 
     /**
-     * afterEndSegment is invoked after a segment is ended by the recorder and immediately before it is emitted to the daemon.
+     * afterEndSegment is invoked after a segment is ended by the recorder and emitted to the daemon.
      * The segment must not be manipulated. Attempts to do so will raise an exception.
      *
      * @param segment
      * The segment that has just ended
      */
-    default void afterEndSegment(Segment segment) {
+    default void afterEndSegment(final Segment segment) {
+
+    }
+
+    /**
+     * beforeEndSubsegment is invoked just before a subsegment is ended by the recorder.
+     * The subsegment can be manipulated, e.g. with putAnnotation.
+     *
+     * @param subsegment
+     * The subsegment that has just ended
+     */
+    default void beforeEndSubsegment(Subsegment subsegment) {
+
+    }
+
+    /**
+     * afterEndSubsegment is invoked after a subsegment is ended by the recorder and emitted to the daemon.
+     * The subsegment must not be manipulated. Attempts to do so will raise an exception.
+     *
+     * @param subsegment
+     * The subsegment that has just ended
+     */
+    default void afterEndSubsegment(final Subsegment subsegment) {
 
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
@@ -46,12 +46,13 @@ public interface SegmentListener {
 
     /**
      * afterEndSegment is invoked after a segment is ended by the recorder and emitted to the daemon.
-     * The segment must not be manipulated. Attempts to do so will raise an exception.
+     * The segment must not be modified since it has already been sent to X-Ray's backend.
+     * Attempts to do so will raise an {@code AlreadyEmittedException}.
      *
      * @param segment
      * The segment that has just ended
      */
-    default void afterEndSegment(final Segment segment) {
+    default void afterEndSegment(Segment segment) {
 
     }
 
@@ -68,12 +69,13 @@ public interface SegmentListener {
 
     /**
      * afterEndSubsegment is invoked after a subsegment is ended by the recorder and emitted to the daemon.
-     * The subsegment must not be manipulated. Attempts to do so will raise an exception.
+     * The subsegment must not be modified since it has already been sent to X-Ray's backend.
+     * Attempts to do so will raise an {@code AlreadyEmittedException}.
      *
      * @param subsegment
      * The subsegment that has just ended
      */
-    default void afterEndSubsegment(final Subsegment subsegment) {
+    default void afterEndSubsegment(Subsegment subsegment) {
 
     }
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -576,4 +576,15 @@ public class AWSXRayRecorderTest {
 
         Assert.assertEquals(4, plugins.size());
     }
+
+    @Test
+    public void testGetFullyQualifiedId() {
+        TraceID traceId = TraceID.fromString("1-5759e988-bd862e3fe1be46a994272793");
+        String entityId = "123456789";
+
+        Segment seg = AWSXRay.beginSegment("test", traceId, "FakeParentId");
+        seg.setId(entityId);
+
+        Assert.assertEquals(traceId.toString() + "@" + entityId, AWSXRay.currentFullyQualifiedId());
+    }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -578,13 +578,13 @@ public class AWSXRayRecorderTest {
     }
 
     @Test
-    public void testGetFullyQualifiedId() {
+    public void testCurrentFormattedId() {
         TraceID traceId = TraceID.fromString("1-5759e988-bd862e3fe1be46a994272793");
         String entityId = "123456789";
 
         Segment seg = AWSXRay.beginSegment("test", traceId, "FakeParentId");
         seg.setId(entityId);
 
-        Assert.assertEquals(traceId.toString() + "@" + entityId, AWSXRay.currentFullyQualifiedId());
+        Assert.assertEquals(traceId.toString() + "@" + entityId, AWSXRay.currentFormattedId());
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/listeners/SegmentListenerTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/listeners/SegmentListenerTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.emitters.Emitter;
 import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,7 +19,13 @@ public class SegmentListenerTest {
         }
 
         @Override
+        public void onBeginSubsegment(Subsegment subsegment) { subsegment.putAnnotation("subAnnotation1", "began"); }
+
+        @Override
         public void beforeEndSegment(Segment segment) { segment.putAnnotation("endTest", "isPresent"); }
+
+        @Override
+        public void beforeEndSubsegment(Subsegment subsegment) { subsegment.putAnnotation("subAnnotation2", "ended"); }
     }
 
     class SecondSegmentListener implements SegmentListener {
@@ -67,6 +74,18 @@ public class SegmentListenerTest {
         String endAnnotation = test.getAnnotations().get("endTest").toString();
 
         Assert.assertEquals("isPresent", endAnnotation);
+    }
+
+    @Test
+    public void testSubsegmentListeners() {
+        AWSXRay.beginSegment("test");
+        Subsegment sub = AWSXRay.beginSubsegment("testSub");
+        String beginAnnotation = sub.getAnnotations().get("subAnnotation1").toString();
+        AWSXRay.endSubsegment();
+        String endAnnotation = sub.getAnnotations().get("subAnnotation2").toString();
+
+        Assert.assertEquals("began", beginAnnotation);
+        Assert.assertEquals("ended", endAnnotation);
     }
 
     @Test

--- a/aws-xray-recorder-sdk-log4j/pom.xml
+++ b/aws-xray-recorder-sdk-log4j/pom.xml
@@ -46,6 +46,19 @@
             <version>${awsxrayrecordersdk.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!--test-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/aws-xray-recorder-sdk-log4j/src/main/java/com/amazonaws/xray/log4j/Log4JSegmentListener.java
+++ b/aws-xray-recorder-sdk-log4j/src/main/java/com/amazonaws/xray/log4j/Log4JSegmentListener.java
@@ -46,13 +46,12 @@ public class Log4JSegmentListener implements SegmentListener {
     }
 
     /**
-     * Maps the AWS-XRAY-TRACE-ID key to the formatted ID of the segment that's just been created in the Log4J ThreadContext.
+     * Maps the AWS-XRAY-TRACE-ID key to the formatted ID of the entity that's just been created in the Log4J ThreadContext.
      * Does not perform injection if entity is not available or not sampled, since then the given entity would not be displayed
      * in X-Ray console.
      *
      * @param oldEntity the previous entity or null
-     * @param newEntity the new entity
-     * The segment that has just begun
+     * @param newEntity the new entity, either a subsegment or segment
      */
     @Override
     public void onSetEntity(Entity oldEntity, Entity newEntity) {

--- a/aws-xray-recorder-sdk-log4j/src/main/java/com/amazonaws/xray/log4j/Log4JSegmentListener.java
+++ b/aws-xray-recorder-sdk-log4j/src/main/java/com/amazonaws/xray/log4j/Log4JSegmentListener.java
@@ -1,6 +1,8 @@
 package com.amazonaws.xray.log4j;
 
 import com.amazonaws.xray.entities.Entity;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.StringValidator;
 import com.amazonaws.xray.listeners.SegmentListener;
 import org.apache.logging.log4j.ThreadContext;
 
@@ -13,9 +15,40 @@ import org.apache.logging.log4j.ThreadContext;
  */
 public class Log4JSegmentListener implements SegmentListener {
     private static final String TRACE_ID_KEY = "AWS-XRAY-TRACE-ID";
+    private String prefix;
 
     /**
-     * Maps the AWS-XRAY-TRACE-ID key to the trace ID of the segment that's just been created in the Log4J ThreadContext.
+     * Returns a default {@code Log4JSegmentListener} using {@code AWS-XRAY-TRACE-ID} as the prefix for trace ID injections
+     */
+    public Log4JSegmentListener() {
+        this(TRACE_ID_KEY);
+    }
+
+    /**
+     * Returns a {@code Log4JSegmentListener} using the provided prefix for trace ID injections
+     * @param prefix
+     */
+    public Log4JSegmentListener(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * Sets the trace ID injection prefix to provided value. A colon and space separate the prefix and trace ID, unless
+     * the {@code prefix} is null or blank.
+     * @param prefix
+     */
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /**
+     * Maps the AWS-XRAY-TRACE-ID key to the formatted ID of the segment that's just been created in the Log4J ThreadContext.
+     * Does not perform injection if entity is not available or not sampled, since then the given entity would not be displayed
+     * in X-Ray console.
      *
      * @param oldEntity the previous entity or null
      * @param newEntity the new entity
@@ -23,8 +56,18 @@ public class Log4JSegmentListener implements SegmentListener {
      */
     @Override
     public void onSetEntity(Entity oldEntity, Entity newEntity) {
-        if (newEntity != null && newEntity.getTraceId() != null) {
-            ThreadContext.put(TRACE_ID_KEY, TRACE_ID_KEY + ": " + newEntity.getTraceId().toString());
+        if (newEntity == null) {
+            ThreadContext.remove(TRACE_ID_KEY);
+            return;
+        }
+
+        Segment segment =  newEntity instanceof Segment ? ((Segment) newEntity) : newEntity.getParentSegment();
+
+        if (segment != null && segment.getTraceId() != null && segment.isSampled() && newEntity.getId() != null) {
+            String fullPrefix = StringValidator.isNullOrBlank(this.prefix) ? "" : this.prefix + ": ";
+            ThreadContext.put(TRACE_ID_KEY, fullPrefix + segment.getTraceId() + "@" + newEntity.getId());
+        } else {
+            ThreadContext.remove(TRACE_ID_KEY);  // Ensure traces don't spill over to unlinked messages
         }
     }
 

--- a/aws-xray-recorder-sdk-log4j/src/test/java/com.amazonaws.xray.log4j/Log4JSegmentListenerTest.java
+++ b/aws-xray-recorder-sdk-log4j/src/test/java/com.amazonaws.xray.log4j/Log4JSegmentListenerTest.java
@@ -1,0 +1,100 @@
+package com.amazonaws.xray.log4j;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
+import com.amazonaws.xray.emitters.Emitter;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.SegmentImpl;
+import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.entities.SubsegmentImpl;
+import com.amazonaws.xray.entities.TraceID;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class Log4JSegmentListenerTest {
+    private final TraceID traceID =  TraceID.fromString("1-1-d0a73661177562839f503b9f");
+    private static final String TRACE_ID_KEY = "AWS-XRAY-TRACE-ID";
+
+    @Before
+    public void setupAWSXRay() {
+        Emitter blankEmitter = Mockito.mock(Emitter.class);
+        Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.any());
+        Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.any());
+        Log4JSegmentListener segmentListener = new Log4JSegmentListener();
+
+        AWSXRay.setGlobalRecorder(AWSXRayRecorderBuilder.standard().withEmitter(blankEmitter).withSegmentListener(segmentListener).build());
+        AWSXRay.clearTraceEntity();
+        ThreadContext.clearAll();
+    }
+
+    @Test
+    public void testDefaultPrefix() {
+        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
+
+        listener.onSetEntity(null, seg);
+
+        Assert.assertEquals(ThreadContext.get(TRACE_ID_KEY), TRACE_ID_KEY + ": " + traceID.toString() + "@" + seg.getId());
+    }
+
+    @Test
+    public void testSetPrefix() {
+        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        listener.setPrefix("");
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
+
+        listener.onSetEntity(null, seg);
+
+        Assert.assertEquals(ThreadContext.get(TRACE_ID_KEY), traceID.toString() + "@" + seg.getId());
+    }
+
+    @Test
+    public void testSegmentInjection() {
+        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        listener.setPrefix("");
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
+        listener.onSetEntity(null, seg);
+
+        Assert.assertEquals(ThreadContext.get(TRACE_ID_KEY), traceID.toString() + "@" + seg.getId());
+    }
+
+    @Test
+    public void testUnsampledSegmentInjection() {
+        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        listener.setPrefix("");
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
+        seg.setSampled(false);
+        listener.onSetEntity(null, seg);
+
+        Assert.assertNull(ThreadContext.get(TRACE_ID_KEY));
+    }
+
+    @Test
+    public void testSubsegmentInjection() {
+        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        listener.setPrefix("");
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
+        listener.onSetEntity(null, seg);
+        Subsegment sub = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test", seg);
+        listener.onSetEntity(seg, sub);
+
+        Assert.assertEquals(ThreadContext.get(TRACE_ID_KEY), traceID.toString() + "@" + sub.getId());
+    }
+
+    @Test
+    public void testNestedSubsegmentInjection() {
+        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        listener.setPrefix("");
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
+        listener.onSetEntity(null, seg);
+        Subsegment sub1 = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test1", seg);
+        listener.onSetEntity(seg, sub1);
+        Subsegment sub2 = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test2", seg);
+        listener.onSetEntity(sub1, sub2);
+
+        Assert.assertEquals(ThreadContext.get(TRACE_ID_KEY), traceID.toString() + "@" + sub2.getId());
+    }
+}

--- a/aws-xray-recorder-sdk-slf4j/pom.xml
+++ b/aws-xray-recorder-sdk-slf4j/pom.xml
@@ -40,12 +40,30 @@
             <version>[1.4.1,)</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-core</artifactId>
             <version>${awsxrayrecordersdk.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <!--test-->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.3.0-alpha5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/aws-xray-recorder-sdk-slf4j/src/main/java/com/amazonaws/xray/slf4j/SLF4JSegmentListener.java
+++ b/aws-xray-recorder-sdk-slf4j/src/main/java/com/amazonaws/xray/slf4j/SLF4JSegmentListener.java
@@ -1,6 +1,8 @@
 package com.amazonaws.xray.slf4j;
 
 import com.amazonaws.xray.entities.Entity;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.StringValidator;
 import com.amazonaws.xray.listeners.SegmentListener;
 import org.slf4j.MDC;
 
@@ -14,18 +16,58 @@ import org.slf4j.MDC;
  */
 public class SLF4JSegmentListener implements SegmentListener {
     private static final String TRACE_ID_KEY = "AWS-XRAY-TRACE-ID";
+    private String prefix;
 
     /**
-     * Maps the AWS-XRAY-TRACE-ID key to the trace ID of the segment that's just been created in the MDC.
+     * Returns a default {@code SLF4JSegmentListener} using {@code AWS-XRAY-TRACE-ID} as the prefix for trace ID injections
+     */
+    public SLF4JSegmentListener() {
+        this(TRACE_ID_KEY);
+    }
+
+    /**
+     * Returns a {@code SLF4JSegmentListener} using the provided prefix for trace ID injections
+     * @param prefix
+     */
+    public SLF4JSegmentListener(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * Sets the trace ID injection prefix to provided value. A colon and space separate the prefix and trace ID, unless
+     * the {@code prefix} is null or blank.
+     * @param prefix
+     */
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    /**
+     * Maps the AWS-XRAY-TRACE-ID key to the trace ID of the entity that's just been created in the MDC.
+     * Does not perform injection if entity is not available or not sampled, since then the given entity would not be displayed
+     * in X-Ray console.
      *
      * @param oldEntity the previous entity or null
-     * @param newEntity the new entity
-     * The segment that has just begun
+     * @param newEntity the new entity, either a subsegment or segment
      */
     @Override
     public void onSetEntity(Entity oldEntity, Entity newEntity) {
-        if (newEntity != null && newEntity.getTraceId() != null) {
-            MDC.put(TRACE_ID_KEY, TRACE_ID_KEY + ": " + newEntity.getTraceId().toString());
+        if (newEntity == null) {
+            MDC.remove(TRACE_ID_KEY);
+            return;
+        }
+
+        Segment segment =  newEntity instanceof Segment ? ((Segment) newEntity) : newEntity.getParentSegment();
+
+        if (segment != null && segment.getTraceId() != null && segment.isSampled() && newEntity.getId() != null) {
+            String fullPrefix = StringValidator.isNullOrBlank(this.prefix) ? "" : this.prefix + ": ";
+            MDC.put(TRACE_ID_KEY, fullPrefix + segment.getTraceId() + "@" + newEntity.getId());
+        } else {
+            MDC.remove(TRACE_ID_KEY);  // Ensure traces don't spill over to unlinked messages
         }
     }
 

--- a/aws-xray-recorder-sdk-slf4j/test/java/com/amazonaws/xray/slf4j/SLF4JSegmentListenerTest.java
+++ b/aws-xray-recorder-sdk-slf4j/test/java/com/amazonaws/xray/slf4j/SLF4JSegmentListenerTest.java
@@ -1,4 +1,4 @@
-package com.amazonaws.xray.log4j;
+package com.amazonaws.xray.slf4j;
 
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
@@ -8,13 +8,14 @@ import com.amazonaws.xray.entities.SegmentImpl;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.SubsegmentImpl;
 import com.amazonaws.xray.entities.TraceID;
-import org.apache.logging.log4j.ThreadContext;
+
+import org.slf4j.MDC;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class Log4JSegmentListenerTest {
+public class SLF4JSegmentListenerTest {
     private final TraceID traceID =  TraceID.fromString("1-1-d0a73661177562839f503b9f");
     private static final String TRACE_ID_KEY = "AWS-XRAY-TRACE-ID";
 
@@ -23,70 +24,70 @@ public class Log4JSegmentListenerTest {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.any());
         Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.any());
-        Log4JSegmentListener segmentListener = new Log4JSegmentListener();
+        SLF4JSegmentListener segmentListener = new SLF4JSegmentListener();
 
         AWSXRay.setGlobalRecorder(AWSXRayRecorderBuilder.standard().withEmitter(blankEmitter).withSegmentListener(segmentListener).build());
         AWSXRay.clearTraceEntity();
-        ThreadContext.clearAll();
+        MDC.clear();
     }
 
     @Test
     public void testDefaultPrefix() {
-        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        SLF4JSegmentListener listener = (SLF4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
 
         listener.onSetEntity(null, seg);
 
-        Assert.assertEquals(TRACE_ID_KEY + ": " + traceID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assert.assertEquals(TRACE_ID_KEY + ": " + traceID.toString() + "@" + seg.getId(), MDC.get(TRACE_ID_KEY));
     }
 
     @Test
     public void testSetPrefix() {
-        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        SLF4JSegmentListener listener = (SLF4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
 
         listener.onSetEntity(null, seg);
 
-        Assert.assertEquals(traceID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assert.assertEquals(traceID.toString() + "@" + seg.getId(), MDC.get(TRACE_ID_KEY));
     }
 
     @Test
     public void testSegmentInjection() {
-        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        SLF4JSegmentListener listener = (SLF4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
         listener.onSetEntity(null, seg);
 
-        Assert.assertEquals(traceID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assert.assertEquals(traceID.toString() + "@" + seg.getId(), MDC.get(TRACE_ID_KEY));
     }
 
     @Test
     public void testUnsampledSegmentInjection() {
-        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        SLF4JSegmentListener listener = (SLF4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
         seg.setSampled(false);
         listener.onSetEntity(null, seg);
 
-        Assert.assertNull(ThreadContext.get(TRACE_ID_KEY));
+        Assert.assertNull(MDC.get(TRACE_ID_KEY));
     }
 
     @Test
     public void testSubsegmentInjection() {
-        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        SLF4JSegmentListener listener = (SLF4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
         listener.onSetEntity(null, seg);
         Subsegment sub = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test", seg);
         listener.onSetEntity(seg, sub);
 
-        Assert.assertEquals(traceID.toString() + "@" + sub.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assert.assertEquals(traceID.toString() + "@" + sub.getId(), MDC.get(TRACE_ID_KEY));
     }
 
     @Test
     public void testNestedSubsegmentInjection() {
-        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        SLF4JSegmentListener listener = (SLF4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", traceID);
         listener.onSetEntity(null, seg);
@@ -95,6 +96,6 @@ public class Log4JSegmentListenerTest {
         Subsegment sub2 = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test2", seg);
         listener.onSetEntity(sub1, sub2);
 
-        Assert.assertEquals(traceID.toString() + "@" + sub2.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assert.assertEquals(traceID.toString() + "@" + sub2.getId(), MDC.get(TRACE_ID_KEY));
     }
 }


### PR DESCRIPTION
## Description of changes
* Added listeners for subsegments
* Inject the fully qualified ID instead of just the Trace ID by default. The fully qualified ID is represented as `TraceID@EntityID`, for example: 
```
1-5df42873-011e96598b447dfca814c156@541b3365be3dafc3
```
* Exposed new `AWSXRay.currentFormattedId()` API
* Added the ability to configure, or disable, prefixes in trace ID Injection
* Cleaned up JavaDocs and added unit tests

Note that this change will affect customers who are currently using trace ID injection. The trace IDs injected into logs will automatically be converted to fully qualified IDs such as the ones described above, which may impact log parsing. Customers should inspect how their logs are consumed to make sure there won't be any difficulties upgrading.

Tested on sample app with Log4J and SLF4J loggers. Verified cross-thread propagation and nested subsegments work as expected.


## Example
```java
Log4JSegmentListener listener = new Log4JSegmentListener();
AWSXRayRecorderBuilder builder = new AWSXRayRecorderBuilder()
  .withSegmentListener(listener);
AWSXRay.setGlobalRecorder(builder.build());
AWSXRay.beginSegment("Example1");  // segment ID = 541b3365be3dafc3
logger.info("First logging message");
AWSXRay.beginSubsegment("Example2");  // subsegment ID = 1ce7df03252d99e1
listener.setPrefix("");  // Setting the prefix to an empty string removes it entirely
logger.info("Second logging message");
AWSXRay.endSubsegment();
AWSXRay.endSegment();
```

Would result in logs similar to this:
```
14:19:48.618 INFO  AWS-XRAY-TRACE-ID: 1-5df42873-011e96598b447dfca814c156@541b3365be3dafc3 First logging message
14:19:48.745 INFO  1-5df42873-011e96598b447dfca814c156@1ce7df03252d99e1 Second logging message
```

***
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
