### PR TITLE
Fixed implementation of TracingStatement when no segment is present.

### DIFF
--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
@@ -90,58 +90,39 @@ public class TracingStatement {
         }
 
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            if (!isExecution(method)) {
-                // don't trace non execution methods
-                return method.invoke(delegate, args);
+            Subsegment subsegment = null;
+
+            if (isExecution(method)) {
+                // only trace on execution methods
+                subsegment = createSubsegment();
             }
 
-            Subsegment subsegment = createSubsegment();
-            if (subsegment == null) {
-                try {
-                    // don't trace if failed to create subsegment
-                    return method.invoke(delegate, args);
-                } catch (Throwable t) {
-                    if (t instanceof InvocationTargetException) {
-                        // the reflection may wrap the actual error with an InvocationTargetException.
-                        // we want to use the root cause to make the instrumentation seamless
-                        InvocationTargetException ite = (InvocationTargetException) t;
-                        if (ite.getTargetException() != null) {
-                            throw ite.getTargetException();
-                        }
-                        if (ite.getCause() != null) {
-                            throw ite.getCause();
-                        }
-                    }
-
-                    throw t;
-                }
-            }
-
-            logger.debug("Invoking statement execution with X-Ray tracing.");
+            logger.debug(String.format("Invoking statement execution with X-Ray tracing. Tracing active: %s", subsegment != null));
             try {
                 // execute the query "wrapped" in a XRay Subsegment
                 return method.invoke(delegate, args);
             } catch (Throwable t) {
+                Throwable rootThrowable = t;
                 if (t instanceof InvocationTargetException) {
                     // the reflection may wrap the actual error with an InvocationTargetException.
                     // we want to use the root cause to make the instrumentation seamless
                     InvocationTargetException ite = (InvocationTargetException) t;
                     if (ite.getTargetException() != null) {
-                        subsegment.addException(ite.getTargetException());
-                        throw ite.getTargetException();
+                        rootThrowable = ite.getTargetException();
                     }
-                    if (ite.getCause() != null) {
-                        subsegment.addException(ite.getCause());
-                        throw ite.getCause();
+                    else if (ite.getCause() != null) {
+                        rootThrowable = ite.getCause();
                     }
-                    subsegment.addException(ite);
-                    throw ite;
                 }
 
-                subsegment.addException(t);
-                throw t;
+                if (subsegment != null) {
+                    subsegment.addException(rootThrowable);
+                }
+                throw rootThrowable;
             } finally {
-                AWSXRay.endSubsegment();
+                if (isExecution(method)) {
+                    AWSXRay.endSubsegment();
+                }
             }
         }
 

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java
@@ -120,7 +120,7 @@ public class TracingStatement {
                 }
                 throw rootThrowable;
             } finally {
-                if (isExecution(method)) {
+                if (subsegment != null && isExecution(method)) {
                     AWSXRay.endSubsegment();
                 }
             }


### PR DESCRIPTION
Solves issues brought up in #136

Adds transparent exception handling from TracingStatement when no segment is present.

Adds new tests to test for both checked and unchecked exceptions also tests the exceptions in a environment with no segment created and `IgnoreErrorContextMissingStrategy` set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
