### PR TITLE
Minor cleanups of equals and hashcode in core

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
@@ -63,11 +63,11 @@ public class AWSLogReference {
      */
     public int hashCode() {
         if (arn == null && logGroup == null) {
-            return Objects.hash("");
+            return "".hashCode();
         } else if (arn == null) {
-            return Objects.hash(logGroup);
+            return logGroup.hashCode();
         } else {
-            return Objects.hash(arn);
+            return arn.hashCode();
         }
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -2,6 +2,7 @@ package com.amazonaws.xray.entities;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.Objects;
 
 import com.amazonaws.xray.ThreadLocalStorage;
 
@@ -85,18 +86,10 @@ public class TraceID {
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (obj == null)
+        if (!(obj instanceof TraceID)) {
             return false;
-        if (getClass() != obj.getClass())
-            return false;
+        }
         TraceID other = (TraceID) obj;
-        if (number == null) {
-            if (other.number != null)
-                return false;
-        } else if (!number.equals(other.number))
-            return false;
-        if (startTime != other.startTime)
-            return false;
-        return true;
+        return Objects.equals(number, other.number) && startTime == other.startTime;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2Plugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2Plugin.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import com.amazonaws.xray.entities.AWSLogReference;
@@ -155,6 +154,6 @@ public class EC2Plugin implements Plugin {
      * Hash plugin object using origin to uniquely identify them
      */
     public int hashCode() {
-        return Objects.hash(this.getOrigin());
+        return this.getOrigin().hashCode();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
@@ -5,7 +5,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import com.amazonaws.xray.utils.DockerUtils;
 import org.apache.commons.logging.Log;
@@ -90,7 +89,7 @@ public class ECSPlugin implements Plugin {
      * Hash plugin object using origin to uniquely identify them
      */
     public int hashCode() {
-        return Objects.hash(this.getOrigin());
+        return this.getOrigin().hashCode();
     }
 
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EKSPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EKSPlugin.java
@@ -8,12 +8,10 @@ import org.apache.commons.logging.LogFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 
@@ -133,6 +131,6 @@ public class EKSPlugin implements Plugin {
      * Hash plugin object using origin to uniquely identify them
      */
     public int hashCode() {
-        return Objects.hash(this.getOrigin());
+        return this.getOrigin().hashCode();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ElasticBeanstalkPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ElasticBeanstalkPlugin.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -90,6 +89,6 @@ public class ElasticBeanstalkPlugin implements Plugin {
      * Hash plugin object using origin to uniquely identify them
      */
     public int hashCode() {
-        return Objects.hash(this.getOrigin());
+        return this.getOrigin().hashCode();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
@@ -12,6 +12,7 @@ import org.apache.commons.logging.LogFactory;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -240,7 +241,9 @@ public class CentralizedRule implements Rule, Comparable<CentralizedRule> {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof CentralizedRule)) {
+            return false;
+        }
 
         CentralizedRule that = (CentralizedRule) o;
 
@@ -249,7 +252,7 @@ public class CentralizedRule implements Rule, Comparable<CentralizedRule> {
         if (!name.equals(that.name)) return false;
         if (!centralizedReservoir.equals(that.centralizedReservoir)) return false;
         if (!statistics.equals(that.statistics)) return false;
-        return matchers != null ? matchers.equals(that.matchers) : that.matchers == null;
+        return Objects.equals(matchers, that.matchers);
     }
 
     @Override


### PR DESCRIPTION
Just a starter PR with some cleanups as I get to know the repo better :) In particular, I noticed the patterns were mixed within the module so this makes them consistent too.

*Description of changes:*

- Use `hashCode` method instead of `Objects.hash`. The later has poor performance because it allocates a varargs array even for this single argument

- `instanceof` instead of `getClass() ==`. Java 8+, which the module targets, performs better with `instanceof`, and the code is a bit cleaner to boot thanks to automatic null check. `getClass` could still be appropriate where a subclass really has to match a subclass, but this doesn't seem to be intended

- `Object.equals` instead of a tree of `null` checks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
