### PR TITLE
Replace calls to X-Ray daemon for rules / targets with a simple JDK-b…

### DIFF
--- a/aws-xray-recorder-sdk-core/pom.xml
+++ b/aws-xray-recorder-sdk-core/pom.xml
@@ -54,6 +54,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/aws-xray-recorder-sdk-core/pom.xml
+++ b/aws-xray-recorder-sdk-core/pom.xml
@@ -40,6 +40,11 @@
       <version>1.11.398</version>
     </dependency>
     <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>

--- a/aws-xray-recorder-sdk-core/pom.xml
+++ b/aws-xray-recorder-sdk-core/pom.xml
@@ -40,17 +40,21 @@
       <version>1.11.398</version>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <!-- Test -->
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
@@ -1,0 +1,129 @@
+package com.amazonaws.xray.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.AmazonWebServiceResult;
+import com.amazonaws.services.xray.model.GetSamplingRulesRequest;
+import com.amazonaws.services.xray.model.GetSamplingRulesResult;
+import com.amazonaws.services.xray.model.GetSamplingTargetsRequest;
+import com.amazonaws.services.xray.model.GetSamplingTargetsResult;
+import com.amazonaws.xray.config.DaemonConfiguration;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+/**
+ * A simple client for sending API requests via the X-Ray daemon. Requests do not have to be
+ * signed, so we can avoid having a strict dependency on the full AWS SDK in instrumentation. This
+ * is an internal utility and not meant to represent the entire X-Ray API nor be particularly
+ * efficient as we only use it in long poll loops.
+ */
+public class UnsignedXrayClient {
+
+    // Visible for testing
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .setSerializationInclusion(Include.NON_EMPTY)
+            .setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
+            .setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
+                @Override
+                public boolean hasIgnoreMarker(AnnotatedMember m) {
+                    // This is a somewhat hacky way of having ObjectMapper only serialize the fields in our
+                    // model classes instead of the base class that comes from the SDK. In the future, we will
+                    // remove the SDK dependency itself and the base classes and this hack will go away.
+                    if (m.getDeclaringClass() == AmazonWebServiceRequest.class ||
+                        m.getDeclaringClass() == AmazonWebServiceResult.class) {
+                        return true;
+                    }
+                    return super.hasIgnoreMarker(m);
+                }
+            });
+    private static final int TIME_OUT_MILLIS = 2000;
+
+    private final URL getSamplingRulesEndpoint;
+    private final URL getSamplingTargetsEndpoint;
+
+    public UnsignedXrayClient() {
+        this(new DaemonConfiguration().getEndpointForTCPConnection());
+    }
+
+    // Visible for testing
+    UnsignedXrayClient(String endpoint) {
+        try {
+            getSamplingRulesEndpoint = new URL(endpoint + "/GetSamplingRules");
+            getSamplingTargetsEndpoint = new URL(endpoint + "/GetSamplingTargets");
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid URL: " + endpoint, e);
+        }
+    }
+
+    public GetSamplingRulesResult getSamplingRules(GetSamplingRulesRequest request) {
+        return sendRequest(getSamplingRulesEndpoint, request, GetSamplingRulesResult.class);
+    }
+
+    public GetSamplingTargetsResult getSamplingTargets(GetSamplingTargetsRequest request) {
+        return sendRequest(getSamplingTargetsEndpoint, request, GetSamplingTargetsResult.class);
+    }
+
+    private <T> T sendRequest(URL endpoint, Object request, Class<T> responseClass) {
+        final HttpURLConnection connection;
+        try {
+            connection = (HttpURLConnection) endpoint.openConnection();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not connect to endpoint " + endpoint, e);
+        }
+
+        connection.setConnectTimeout(TIME_OUT_MILLIS);
+        connection.setReadTimeout(TIME_OUT_MILLIS);
+
+        try {
+            connection.setRequestMethod("POST");
+        } catch (ProtocolException e) {
+            throw new IllegalStateException("Invalid protocol, can't happen.");
+        }
+
+        connection.addRequestProperty("Content-Type", "application/json");
+        connection.setDoOutput(true);
+
+        try (OutputStream outputStream = connection.getOutputStream()) {
+            OBJECT_MAPPER.writeValue(outputStream, request);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not serialize and send request.", e);
+        }
+
+        try {
+            if (connection.getResponseCode() != 200) {
+                throw new IllegalStateException("Error response from X-Ray: " +
+                                                readString(connection.getInputStream()));
+            }
+
+            return OBJECT_MAPPER.readValue(connection.getInputStream(), responseClass);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error reading response.", e);
+        }
+    }
+
+    private static String readString(InputStream stream) {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (InputStream is = stream) {
+            int b;
+            while ((b = is.read()) != -1) {
+                os.write(b);
+            }
+            return os.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not decode error response.", e);
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -82,7 +81,7 @@ public class UnsignedXrayClient {
         try {
             connection = (HttpURLConnection) endpoint.openConnection();
         } catch (IOException e) {
-            throw new UncheckedIOException("Could not connect to endpoint " + endpoint, e);
+            throw new XrayClientException("Could not connect to endpoint " + endpoint, e);
         }
 
         connection.setConnectTimeout(TIME_OUT_MILLIS);
@@ -100,25 +99,25 @@ public class UnsignedXrayClient {
         try (OutputStream outputStream = connection.getOutputStream()) {
             OBJECT_MAPPER.writeValue(outputStream, request);
         } catch (IOException e) {
-            throw new UncheckedIOException("Could not serialize and send request.", e);
+            throw new XrayClientException("Could not serialize and send request.", e);
         }
 
         final int responseCode;
         try {
             responseCode = connection.getResponseCode();
         } catch (IOException e) {
-            throw new UncheckedIOException("Could not read response code.", e);
+            throw new XrayClientException("Could not read response code.", e);
         }
 
         if (responseCode != 200) {
-            throw new IllegalStateException("Error response from X-Ray: " +
-                                            readResponseString(connection));
+            throw new XrayClientException("Error response from X-Ray: " +
+                                          readResponseString(connection));
         }
 
         try {
             return OBJECT_MAPPER.readValue(connection.getInputStream(), responseClass);
         } catch (IOException e) {
-            throw new UncheckedIOException("Error reading response.", e);
+            throw new XrayClientException("Error reading response.", e);
         }
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/XrayClientException.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/XrayClientException.java
@@ -1,0 +1,17 @@
+package com.amazonaws.xray.internal;
+
+/**
+ * A {@link RuntimeException} thrown when we fail to send HTTP requests to the X-Ray daemon.
+ */
+class XrayClientException extends RuntimeException {
+
+    private static final long serialVersionUID = -32616082201202518L;
+
+    XrayClientException(String message) {
+        super(message);
+    }
+
+    XrayClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/XRayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/XRayClient.java
@@ -9,6 +9,11 @@ import com.amazonaws.services.xray.AWSXRayClientBuilder;
 import com.amazonaws.services.xray.AWSXRay;
 import com.amazonaws.xray.config.DaemonConfiguration;
 
+/**
+ * @deprecated aws-xray-recorder only supports communicating with the X-Ray daemon, which does not
+ * require the usual AWS API signatures so we have stopped using the SDK X-Ray client.
+ */
+@Deprecated
 public final class XRayClient {
 
     private static final AWSCredentialsProvider ANONYMOUS_CREDENTIALS = new AWSStaticCredentialsProvider(
@@ -17,6 +22,12 @@ public final class XRayClient {
     private static final int TIME_OUT = 2000; // Milliseconds
     private XRayClient() {}
 
+    /**
+     *
+     * @deprecated aws-xray-recorder only supports communicating with the X-Ray daemon, which does
+     * not require the usual AWS API signatures so we have stopped using the SDK X-Ray client.
+     */
+    @Deprecated
     public static AWSXRay newClient() {
         DaemonConfiguration config = new DaemonConfiguration();
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
@@ -54,8 +54,9 @@ public class RulePoller {
                 pollRule();
             } catch (Throwable t) {
                 logger.error("Encountered error polling GetSamplingRules: ", t);
-                // An Error should not be handled by the application.
-                // The executor will die and not abrupt main thread.
+                // Propagate if Error so executor stops executing.
+                // TODO(anuraaga): Many Errors aren't fatal, this should probably be more restricted, e.g.
+                // https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/Throwables.java
                 if(t instanceof Error) { throw t; }
             }
         }, 0, getIntervalWithJitter(), TimeUnit.SECONDS);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
@@ -1,41 +1,49 @@
 package com.amazonaws.xray.strategy.sampling.pollers;
 
-import com.amazonaws.services.xray.model.GetSamplingRulesRequest;
-import com.amazonaws.services.xray.model.GetSamplingRulesResult;
-import com.amazonaws.services.xray.model.SamplingRule;
-import com.amazonaws.services.xray.AWSXRay;
-import com.amazonaws.services.xray.model.SamplingRuleRecord;
-import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
-import com.amazonaws.xray.strategy.sampling.rand.Rand;
-import com.amazonaws.xray.strategy.sampling.rand.RandImpl;
-import com.amazonaws.xray.strategy.sampling.rule.CentralizedRule;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.time.Clock;
 import java.time.Instant;
-import java.util.*;
-import java.util.concurrent.Executor;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.services.xray.AWSXRay;
+import com.amazonaws.services.xray.model.GetSamplingRulesRequest;
+import com.amazonaws.services.xray.model.GetSamplingRulesResult;
+import com.amazonaws.services.xray.model.SamplingRule;
+import com.amazonaws.services.xray.model.SamplingRuleRecord;
+import com.amazonaws.xray.internal.UnsignedXrayClient;
+import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
+import com.amazonaws.xray.strategy.sampling.rand.Rand;
+import com.amazonaws.xray.strategy.sampling.rand.RandImpl;
+import com.amazonaws.xray.strategy.sampling.rule.CentralizedRule;
+
 public class RulePoller {
-    private static Log logger = LogFactory.getLog(RulePoller.class);
+    private static final Log logger = LogFactory.getLog(RulePoller.class);
 
     private static final long PERIOD = 300; // Seconds
     private static final long MAX_JITTER = 5; // Seconds
 
+    private final UnsignedXrayClient client;
+    private final CentralizedManifest manifest;
+    private final Clock clock;
+    private final ScheduledExecutorService executor;
 
-    private AWSXRay client;
-    private Clock clock;
-    private CentralizedManifest manifest;
-    private ScheduledExecutorService executor;
+    /**
+     * @deprecated Use {@link #RulePoller(UnsignedXrayClient, CentralizedManifest, Clock)}.
+     */
+    @Deprecated
+    public RulePoller(CentralizedManifest manifest, AWSXRay unused, Clock clock) {
+        this(new UnsignedXrayClient(), manifest, clock);
+    }
 
-    public RulePoller(CentralizedManifest manifest, AWSXRay client, Clock clock) {
-        this.manifest = manifest;
+    public RulePoller(UnsignedXrayClient client, CentralizedManifest manifest, Clock clock) {
         this.client = client;
+        this.manifest = manifest;
         this.clock = clock;
         executor = Executors.newSingleThreadScheduledExecutor();
     }
@@ -50,11 +58,16 @@ public class RulePoller {
                 // The executor will die and not abrupt main thread.
                 if(t instanceof Error) { throw t; }
             }
-        }, 0, getJitterInterval(), TimeUnit.SECONDS);
+        }, 0, getIntervalWithJitter(), TimeUnit.SECONDS);
     }
 
     public void shutdown() {
         executor.shutdownNow();
+    }
+
+    // Visible for testing
+    ScheduledExecutorService getExecutor() {
+        return executor;
     }
 
     private void pollRule() {
@@ -72,9 +85,8 @@ public class RulePoller {
         manifest.putRules(rules, now);
     }
 
-    private long getJitterInterval() {
+    private long getIntervalWithJitter() {
         Rand random = new RandImpl();
-        long interval = Math.round(random.next() * MAX_JITTER) + PERIOD;
-        return interval;
+        return Math.round(random.next() * MAX_JITTER) + PERIOD;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
@@ -49,8 +49,9 @@ public class TargetPoller {
                 pollManifest();
             } catch (Throwable t) {
                 logger.error("Encountered error polling GetSamplingTargets: ", t);
-                // An Error should not be handled by the application.
-                // The executor will die and not abrupt main thread.
+                // Propagate if Error so executor stops executing.
+                // TODO(anuraaga): Many Errors aren't fatal, this should probably be more restricted, e.g.
+                // https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/Throwables.java
                 if(t instanceof Error) { throw t; }
             }
         }, PERIOD_MILLIS, getIntervalWithJitter(), TimeUnit.MILLISECONDS);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
@@ -20,8 +20,8 @@ import com.amazonaws.xray.strategy.sampling.rand.RandImpl;
 
 public class TargetPoller {
     private static final Log logger = LogFactory.getLog(TargetPoller.class);
-    private static final long PERIOD = 10; // Seconds
-    private static final long MAX_JITTER = 100; // Milliseconds
+    private static final long PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(10);
+    private static final long MAX_JITTER_MILLIS = 100;
 
     private final UnsignedXrayClient client;
     private final CentralizedManifest manifest;
@@ -53,7 +53,7 @@ public class TargetPoller {
                 // The executor will die and not abrupt main thread.
                 if(t instanceof Error) { throw t; }
             }
-        }, PERIOD * 1000, getIntervalWithJitter(), TimeUnit.MILLISECONDS);
+        }, PERIOD_MILLIS, getIntervalWithJitter(), TimeUnit.MILLISECONDS);
     }
 
     public void shutdown() {
@@ -82,6 +82,6 @@ public class TargetPoller {
 
     private long getIntervalWithJitter() {
         Rand random = new RandImpl();
-        return Math.round(random.next() * MAX_JITTER) + PERIOD * 1000;
+        return Math.round(random.next() * MAX_JITTER_MILLIS) + PERIOD_MILLIS;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
@@ -1,35 +1,44 @@
 package com.amazonaws.xray.strategy.sampling.pollers;
 
-import com.amazonaws.services.xray.AWSXRay;
-import com.amazonaws.services.xray.model.GetSamplingTargetsRequest;
-import com.amazonaws.services.xray.model.GetSamplingTargetsResult;
-import com.amazonaws.services.xray.model.SamplingStatisticsDocument;
-import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
-
-import com.amazonaws.xray.strategy.sampling.rand.Rand;
-import com.amazonaws.xray.strategy.sampling.rand.RandImpl;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.time.Clock;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.services.xray.AWSXRay;
+import com.amazonaws.services.xray.model.GetSamplingTargetsRequest;
+import com.amazonaws.services.xray.model.GetSamplingTargetsResult;
+import com.amazonaws.services.xray.model.SamplingStatisticsDocument;
+import com.amazonaws.xray.internal.UnsignedXrayClient;
+import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
+import com.amazonaws.xray.strategy.sampling.rand.Rand;
+import com.amazonaws.xray.strategy.sampling.rand.RandImpl;
+
 public class TargetPoller {
-    private static Log logger = LogFactory.getLog(TargetPoller.class);
+    private static final Log logger = LogFactory.getLog(TargetPoller.class);
     private static final long PERIOD = 10; // Seconds
     private static final long MAX_JITTER = 100; // Milliseconds
 
-    private AWSXRay client;
-    private Clock clock;
-    private CentralizedManifest manifest;
-    private ScheduledExecutorService executor;
+    private final UnsignedXrayClient client;
+    private final CentralizedManifest manifest;
+    private final Clock clock;
+    private final ScheduledExecutorService executor;
 
-    public TargetPoller(CentralizedManifest m, AWSXRay client, Clock clock) {
-        this.manifest = m;
+    /**
+     * @deprecated Use {@link #TargetPoller(UnsignedXrayClient, CentralizedManifest, Clock)}.
+     */
+    @Deprecated
+    public TargetPoller(CentralizedManifest manifest, AWSXRay unused, Clock clock) {
+        this(new UnsignedXrayClient(), manifest, clock);
+    }
+
+    public TargetPoller(UnsignedXrayClient client, CentralizedManifest manifest, Clock clock) {
         this.client = client;
+        this.manifest = manifest;
         this.clock = clock;
         executor = Executors.newSingleThreadScheduledExecutor();
     }
@@ -44,11 +53,16 @@ public class TargetPoller {
                 // The executor will die and not abrupt main thread.
                 if(t instanceof Error) { throw t; }
             }
-        }, PERIOD * 1000, getJitterInterval(), TimeUnit.MILLISECONDS);
+        }, PERIOD * 1000, getIntervalWithJitter(), TimeUnit.MILLISECONDS);
     }
 
     public void shutdown() {
         executor.shutdownNow();
+    }
+
+    // Visible for testing
+    ScheduledExecutorService getExecutor() {
+        return executor;
     }
 
     private void pollManifest() {
@@ -66,9 +80,8 @@ public class TargetPoller {
         manifest.putTargets(result.getSamplingTargetDocuments(), clock.instant());
     }
 
-    private long getJitterInterval() {
+    private long getIntervalWithJitter() {
         Rand random = new RandImpl();
-        long interval = Math.round(random.next() * MAX_JITTER) + PERIOD * 1000;
-        return interval;
+        return Math.round(random.next() * MAX_JITTER) + PERIOD * 1000;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
@@ -93,7 +93,7 @@ public class UnsignedXrayClientTest {
                                                  .withBody(expectedMessage)));
 
         assertThatThrownBy(() -> client.getSamplingRules(new GetSamplingRulesRequest()))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(XrayClientException.class)
                 .hasMessageContaining(expectedMessage);
     }
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
@@ -1,0 +1,84 @@
+package com.amazonaws.xray.internal;
+
+import static com.amazonaws.xray.internal.UnsignedXrayClient.OBJECT_MAPPER;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.amazonaws.services.xray.model.GetSamplingRulesRequest;
+import com.amazonaws.services.xray.model.GetSamplingRulesResult;
+import com.amazonaws.services.xray.model.GetSamplingTargetsRequest;
+import com.amazonaws.services.xray.model.GetSamplingTargetsResult;
+import com.amazonaws.services.xray.model.SamplingStatisticsDocument;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+
+public class UnsignedXrayClientTest {
+
+    @ClassRule
+    public static WireMockClassRule server = new WireMockClassRule(wireMockConfig().dynamicPort());
+
+    private UnsignedXrayClient client;
+
+    @Before
+    public void setUp() {
+        client = new UnsignedXrayClient(server.baseUrl());
+    }
+
+    @Test
+    public void getSamplingRules() throws Exception {
+        GetSamplingRulesResult expected = new GetSamplingRulesResult();
+        expected.setNextToken("nexttoken");
+
+        stubFor(any(anyUrl()).willReturn(aResponse()
+                                                 .withStatus(200)
+                                                 .withBody(OBJECT_MAPPER.writeValueAsBytes(expected))));
+
+        GetSamplingRulesResult result = client.getSamplingRules(new GetSamplingRulesRequest());
+
+        assertEquals(expected, result);
+
+        verify(postRequestedFor(urlEqualTo("/GetSamplingRules"))
+                       .withHeader("Content-Type", equalTo("application/json"))
+                       .withRequestBody(equalToJson("{}")));
+    }
+    @Test
+    public void getSamplingTargets() throws Exception {
+        GetSamplingTargetsResult expected = new GetSamplingTargetsResult();
+        expected.setLastRuleModification(new Date(1000));
+
+        stubFor(any(anyUrl()).willReturn(aResponse()
+                                                 .withStatus(200)
+                                                 .withBody(OBJECT_MAPPER.writeValueAsBytes(expected))));
+
+        GetSamplingTargetsRequest request = new GetSamplingTargetsRequest().
+                withSamplingStatisticsDocuments(new SamplingStatisticsDocument().withClientID("client-id"));
+
+        GetSamplingTargetsResult result = client.getSamplingTargets(request);
+
+        assertEquals(expected, result);
+
+        verify(postRequestedFor(urlEqualTo("/GetSamplingTargets"))
+                       .withHeader("Content-Type", equalTo("application/json"))
+                       .withRequestBody(equalToJson("{"
+                                                    + " \"SamplingStatisticsDocuments\": ["
+                                                    + "    {"
+                                                    + "      \"ClientID\": \"client-id\""
+                                                    + "    }"
+                                                    + " ] "
+                                                    + "}")));
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
@@ -55,6 +55,7 @@ public class UnsignedXrayClientTest {
                        .withHeader("Content-Type", equalTo("application/json"))
                        .withRequestBody(equalToJson("{}")));
     }
+
     @Test
     public void getSamplingTargets() throws Exception {
         GetSamplingTargetsResult expected = new GetSamplingTargetsResult();

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
@@ -14,7 +14,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.UncheckedIOException;
 import java.util.Date;
 
 import org.junit.Before;
@@ -104,7 +103,7 @@ public class UnsignedXrayClientTest {
         client = new UnsignedXrayClient("http://localhost:" + (server.port() + 1234));
 
         assertThatThrownBy(() -> client.getSamplingRules(new GetSamplingRulesRequest()))
-                .isInstanceOf(UncheckedIOException.class)
+                .isInstanceOf(XrayClientException.class)
                 .hasMessageContaining("Could not serialize and send request");
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/RulePollerTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/RulePollerTest.java
@@ -1,43 +1,44 @@
 package com.amazonaws.xray.strategy.sampling.pollers;
 
-import com.amazonaws.services.xray.AWSXRayClient;
+import com.amazonaws.xray.internal.UnsignedXrayClient;
 import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.powermock.reflect.Whitebox;
-
 import java.time.Clock;
 import java.util.concurrent.ScheduledExecutorService;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 public class RulePollerTest {
 
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private UnsignedXrayClient client;
+
     @Test
     public void testPollerShutdown() {
-        RulePoller poller = new RulePoller(new CentralizedManifest(), getMockedClient(), Clock.systemUTC());
+        RulePoller poller = new RulePoller(client, new CentralizedManifest(), Clock.systemUTC());
         poller.start();
         poller.shutdown();
 
-        ScheduledExecutorService executor = getExecutor(poller);
-        Assert.assertTrue(executor.isShutdown());
+        ScheduledExecutorService executor = poller.getExecutor();
+        assertTrue(executor.isShutdown());
     }
 
     @Test
     public void testPollerErrorNotAbruptMainThread() throws InterruptedException {
-        AWSXRayClient mockedClient = getMockedClient();
-        Mockito.doThrow(new NoSuchMethodError()).when(mockedClient).getSamplingRules(Mockito.any());
-        RulePoller poller = new RulePoller(new CentralizedManifest(), mockedClient, Clock.systemUTC());
+        when(client.getSamplingRules(any())).thenThrow(new OutOfMemoryError());
+        RulePoller poller = new RulePoller(client, new CentralizedManifest(), Clock.systemUTC());
         poller.start();
         //Give the mocked client time (1s) to throw the pre-defined Error
         Thread.sleep(1000L);
-        Assert.assertTrue(Thread.currentThread().isAlive());
-    }
-
-    private ScheduledExecutorService getExecutor(RulePoller poller) {
-        return (ScheduledExecutorService) Whitebox.getInternalState(poller, "executor");
-    }
-
-    private AWSXRayClient getMockedClient() {
-        return Mockito.mock(AWSXRayClient.class);
+        assertTrue(Thread.currentThread().isAlive());
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/RulePollerTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/RulePollerTest.java
@@ -1,18 +1,18 @@
 package com.amazonaws.xray.strategy.sampling.pollers;
 
-import com.amazonaws.xray.internal.UnsignedXrayClient;
-import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Clock;
 import java.util.concurrent.ScheduledExecutorService;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import com.amazonaws.xray.internal.UnsignedXrayClient;
+import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
 
 public class RulePollerTest {
 
@@ -29,16 +29,6 @@ public class RulePollerTest {
         poller.shutdown();
 
         ScheduledExecutorService executor = poller.getExecutor();
-        assertTrue(executor.isShutdown());
-    }
-
-    @Test
-    public void testPollerErrorNotAbruptMainThread() throws InterruptedException {
-        when(client.getSamplingRules(any())).thenThrow(new OutOfMemoryError());
-        RulePoller poller = new RulePoller(client, new CentralizedManifest(), Clock.systemUTC());
-        poller.start();
-        //Give the mocked client time (1s) to throw the pre-defined Error
-        Thread.sleep(1000L);
-        assertTrue(Thread.currentThread().isAlive());
+        assertThat(executor.isShutdown()).isTrue();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPollerTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPollerTest.java
@@ -1,11 +1,8 @@
 package com.amazonaws.xray.strategy.sampling.pollers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import java.time.Clock;
-import java.util.Collections;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import com.amazonaws.services.xray.model.SamplingStatisticsDocument;
 import com.amazonaws.xray.internal.UnsignedXrayClient;
 import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPollerTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPollerTest.java
@@ -1,32 +1,32 @@
 package com.amazonaws.xray.strategy.sampling.pollers;
 
-import com.amazonaws.services.xray.AWSXRayClient;
+import com.amazonaws.xray.internal.UnsignedXrayClient;
 import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
-import org.junit.Test;
-import org.junit.Assert;
-import org.mockito.Mockito;
-import org.powermock.reflect.Whitebox;
-
 import java.time.Clock;
-import java.util.concurrent.ScheduledExecutorService;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.junit.Assert.assertTrue;
 
 public class TargetPollerTest {
 
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private UnsignedXrayClient client;
+
     @Test
     public void testPollerShutdown() {
-        TargetPoller poller = new TargetPoller(new CentralizedManifest(), getMockedClient(), Clock.systemUTC());
+        TargetPoller poller = new TargetPoller(
+            client, new CentralizedManifest(), Clock.systemUTC());
         poller.start();
         poller.shutdown();
 
 
-        Assert.assertTrue(getExecutor(poller).isShutdown());
-    }
-
-    private ScheduledExecutorService getExecutor(TargetPoller poller) {
-        return (ScheduledExecutorService) Whitebox.getInternalState(poller, "executor");
-    }
-
-    private AWSXRayClient getMockedClient() {
-        return Mockito.mock(AWSXRayClient.class);
+        assertTrue(poller.getExecutor().isShutdown());
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPollerTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPollerTest.java
@@ -1,15 +1,21 @@
 package com.amazonaws.xray.strategy.sampling.pollers;
 
-import com.amazonaws.xray.internal.UnsignedXrayClient;
-import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import java.time.Clock;
+import java.util.Collections;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static org.junit.Assert.assertTrue;
+import com.amazonaws.services.xray.model.SamplingStatisticsDocument;
+import com.amazonaws.xray.internal.UnsignedXrayClient;
+import com.amazonaws.xray.strategy.sampling.manifest.CentralizedManifest;
 
 public class TargetPollerTest {
 
@@ -17,16 +23,17 @@ public class TargetPollerTest {
     public MockitoRule mocks = MockitoJUnit.rule();
 
     @Mock
+    private CentralizedManifest manifest;
+
+    @Mock
     private UnsignedXrayClient client;
 
     @Test
     public void testPollerShutdown() {
-        TargetPoller poller = new TargetPoller(
-            client, new CentralizedManifest(), Clock.systemUTC());
+        TargetPoller poller = new TargetPoller(client, manifest, Clock.systemUTC());
         poller.start();
         poller.shutdown();
 
-
-        assertTrue(poller.getExecutor().isShutdown());
+        assertThat(poller.getExecutor().isShutdown()).isTrue();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,22 @@
     <module>aws-xray-recorder-sdk-log4j</module>
     <module>aws-xray-recorder-sdk-metrics</module>
   </modules>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.11.0</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-jre8</artifactId>
+        <version>2.26.3</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <distributionManagement>
     <repository>
       <id>sonatype-nexus-staging</id>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
         <artifactId>wiremock-jre8</artifactId>
         <version>2.26.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.16.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <distributionManagement>


### PR DESCRIPTION
…ased client to allow removing SDK dependency in the future.

*Issue #, if available:*
For #92

*Description of changes:*

Instead of using the SDK to send X-Ray API requests for rules / targets, we just use the JDK's `HttpUrlConnection`. This is fine because these requests are proxied by the daemon and don't need to be authenticated.

I haven't removed the dependency because we expose the SDK classes in many public APIs. It seems that we have too many public methods that are only for internal use, let's aim to reduce this surface for a 3.0 release, where we should also remove the SDK dependency. When doing so, we can just vendor-in simple models corresponding to the four classes we use.

 I have tried to clean stuff up in the classes I touched, especially missing `final` on many variables and an overuse of powermock (well, technically any use is overuse ;) ). I also picked wiremock as my testing framework since I saw the SDK use it too. Also took the liberty of adding assertj which SDK also uses since exception assertions are much nicer with it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
