### PR TITLE
Provide a public API for creating Emitter without exposing implementa…

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -4,21 +4,30 @@ import com.amazonaws.xray.contexts.LambdaSegmentContextResolver;
 import com.amazonaws.xray.contexts.SegmentContext;
 import com.amazonaws.xray.contexts.SegmentContextResolverChain;
 import com.amazonaws.xray.contexts.ThreadLocalSegmentContextResolver;
-import com.amazonaws.xray.emitters.DefaultEmitter;
 import com.amazonaws.xray.emitters.Emitter;
-import com.amazonaws.xray.listeners.SegmentListener;
-import com.amazonaws.xray.entities.*;
+import com.amazonaws.xray.entities.AWSLogReference;
+import com.amazonaws.xray.entities.DummySegment;
+import com.amazonaws.xray.entities.Entity;
+import com.amazonaws.xray.entities.FacadeSegment;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.SegmentImpl;
+import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.entities.TraceID;
 import com.amazonaws.xray.exceptions.SegmentNotFoundException;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
-import com.amazonaws.xray.strategy.*;
+import com.amazonaws.xray.listeners.SegmentListener;
+import com.amazonaws.xray.strategy.ContextMissingStrategy;
+import com.amazonaws.xray.strategy.DefaultContextMissingStrategy;
+import com.amazonaws.xray.strategy.DefaultPrioritizationStrategy;
+import com.amazonaws.xray.strategy.DefaultStreamingStrategy;
+import com.amazonaws.xray.strategy.DefaultThrowableSerializationStrategy;
+import com.amazonaws.xray.strategy.PrioritizationStrategy;
+import com.amazonaws.xray.strategy.StreamingStrategy;
+import com.amazonaws.xray.strategy.ThrowableSerializationStrategy;
 import com.amazonaws.xray.strategy.sampling.DefaultSamplingStrategy;
 import com.amazonaws.xray.strategy.sampling.SamplingStrategy;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -32,6 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public class AWSXRayRecorder {
 
@@ -129,8 +140,8 @@ public class AWSXRayRecorder {
         serviceRuntimeContext.putAll(RUNTIME_INFORMATION);
 
         try {
-            emitter = new DefaultEmitter();
-        } catch (SocketException e) {
+            emitter = Emitter.create();
+        } catch (IOException e) {
             throw new RuntimeException("Unable to instantiate AWSXRayRecorder: ", e);
         }
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/DefaultEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/DefaultEmitter.java
@@ -2,6 +2,10 @@ package com.amazonaws.xray.emitters;
 
 import java.net.SocketException;
 
+/**
+ * @deprecated Use {@link Emitter#create()}.
+ */
+@Deprecated
 public class DefaultEmitter extends UDPEmitter {
     public DefaultEmitter() throws SocketException {
         super();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/DelegatingEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/DelegatingEmitter.java
@@ -1,0 +1,49 @@
+package com.amazonaws.xray.emitters;
+
+import static java.util.Objects.requireNonNull;
+
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
+
+/**
+ * An {@link Emitter} which delegates all calls to another {@link Emitter}.
+ * Extend from this class to customize when segments and subsegments are sent.
+ *
+ * <p>For example, {@code
+ * class CircuitBreakingEmitter extends DelegatingEmitter {
+ *
+ *     private final CircuitBreaker circuitBreaker;
+ *
+ *     CircuitBreakingEmitter() {
+ *         super(Emitter.create());
+ *         circuitBreaker = CircuitBreaker.create();
+ *     }
+ *
+ *     @Override
+ *     public boolean sendSegment(Segment segment) {
+ *         if (circuitBreaker.isOpen()) {
+ *             return super.sendSegment(segment);
+ *         }
+ *         return false;
+ *     }
+ * }
+ * }
+ */
+public class DelegatingEmitter extends Emitter {
+
+    private final Emitter delegate;
+
+    protected DelegatingEmitter(Emitter delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public boolean sendSegment(Segment segment) {
+        return delegate.sendSegment(segment);
+    }
+
+    @Override
+    public boolean sendSubsegment(Subsegment subsegment) {
+        return delegate.sendSubsegment(subsegment);
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/DelegatingEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/DelegatingEmitter.java
@@ -33,6 +33,9 @@ public class DelegatingEmitter extends Emitter {
 
     private final Emitter delegate;
 
+    /**
+     * Constructs a new {@link DelegatingEmitter} that delegates all calls to the provided {@link Emitter}.
+     */
     protected DelegatingEmitter(Emitter delegate) {
         this.delegate = requireNonNull(delegate, "delegate");
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/Emitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/Emitter.java
@@ -1,9 +1,34 @@
 package com.amazonaws.xray.emitters;
 
+import java.io.IOException;
+
+import com.amazonaws.xray.config.DaemonConfiguration;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 
+/**
+ * An emitter of segments and subsegments to X-Ray.
+ */
 public abstract class Emitter {
+
+    /**
+     * Returns an {@link Emitter} that uses a default {@link DaemonConfiguration}.
+     *
+     * @throws IOException if an error occurs while instantiating the {@link Emitter} (e.g., socket failure).
+     */
+    public static Emitter create() throws IOException {
+        return new UDPEmitter();
+    }
+
+    /**
+     * Returns an {@link Emitter} that uses the provided {@link DaemonConfiguration}.
+     *
+     * @throws IOException if an error occurs while instantiating the {@link Emitter} (e.g., socket failure).
+     */
+    public static Emitter create(DaemonConfiguration configuration) throws IOException {
+        return new UDPEmitter(configuration);
+    }
+
     protected static final String PROTOCOL_HEADER = "{\"format\": \"json\", \"version\": 1}";
     protected static final String PRIORITY_PROTOCOL_HEADER = "{\"format\": \"json\", \"version\": 1}";
     protected static final char PROTOCOL_DELIMITER = '\n';

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -1,18 +1,23 @@
 package com.amazonaws.xray.emitters;
 
-import com.amazonaws.xray.config.DaemonConfiguration;
-import com.amazonaws.xray.entities.Entity;
-import com.amazonaws.xray.entities.Segment;
-import com.amazonaws.xray.entities.Subsegment;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
 import java.util.Optional;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.amazonaws.xray.config.DaemonConfiguration;
+import com.amazonaws.xray.entities.Entity;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
+
+/**
+ * @deprecated Use {@link Emitter#create()}.
+ */
+@Deprecated
 public class UDPEmitter extends Emitter {
     private static final Log logger = LogFactory.getLog(UDPEmitter.class);
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -3,7 +3,6 @@ package com.amazonaws.xray;
 import com.amazonaws.xray.contexts.LambdaSegmentContext;
 import com.amazonaws.xray.contexts.LambdaSegmentContextResolver;
 import com.amazonaws.xray.emitters.Emitter;
-import com.amazonaws.xray.emitters.UDPEmitter;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
@@ -22,22 +21,6 @@ import com.amazonaws.xray.strategy.RuntimeErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.json.JSONException;
-import org.junit.*;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
-import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,6 +30,24 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.json.JSONException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 @FixMethodOrder(MethodSorters.JVM)
 @PrepareForTest({LambdaSegmentContext.class, LambdaSegmentContextResolver.class})
@@ -245,7 +246,7 @@ public class AWSXRayRecorderTest {
 
     @Test
     public void testNotSendingUnsampledSegment() {
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
 
         Segment segment = recorder.beginSegment("test");
@@ -257,7 +258,7 @@ public class AWSXRayRecorderTest {
 
     @Test
     public void testSegmentEmitted() {
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
 
         recorder.beginSegment("test");
@@ -270,7 +271,7 @@ public class AWSXRayRecorderTest {
 
     @Test
     public void testExplicitSubsegmentEmitted() {
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
 
         recorder.beginSegment("test");
@@ -283,7 +284,7 @@ public class AWSXRayRecorderTest {
 
     @Test
     public void testDummySegmentNotEmitted() {
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
 
         recorder.beginDummySegment();
@@ -302,7 +303,7 @@ public class AWSXRayRecorderTest {
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
 
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
         recorder.createSubsegment("test", () -> {});
 
@@ -331,7 +332,7 @@ public class AWSXRayRecorderTest {
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(TraceHeader.fromString(null));
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
 
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
         recorder.createSubsegment("test", () -> {});
 
@@ -345,7 +346,7 @@ public class AWSXRayRecorderTest {
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
 
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
 
         recorder.createSubsegment("testTogether", () -> {
@@ -368,7 +369,7 @@ public class AWSXRayRecorderTest {
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
         PowerMockito.stub(PowerMockito.method(LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
 
-        Emitter mockEmitter = Mockito.mock(UDPEmitter.class);
+        Emitter mockEmitter = Mockito.mock(Emitter.class);
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard().withEmitter(mockEmitter).build();
 
         recorder.createSubsegment("testTogether", () -> {

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/DelegatingEmitterTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/DelegatingEmitterTest.java
@@ -1,0 +1,33 @@
+package com.amazonaws.xray.emitters;
+
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.SegmentImpl;
+import com.amazonaws.xray.entities.Subsegment;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class DelegatingEmitterTest {
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
+
+    @Mock
+    private Emitter emitter;
+
+    @Mock
+    private Segment segment;
+
+    @Mock
+    private Subsegment subsegment;
+
+    @Test
+    public void delegates() {
+        Emitter delegator = new DelegatingEmitter(emitter);
+
+        assertThat(delegator.sendSegment(segment));
+
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/DelegatingEmitterTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/DelegatingEmitterTest.java
@@ -1,8 +1,13 @@
 package com.amazonaws.xray.emitters;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.amazonaws.xray.entities.Segment;
-import com.amazonaws.xray.entities.SegmentImpl;
 import com.amazonaws.xray.entities.Subsegment;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -23,11 +28,21 @@ public class DelegatingEmitterTest {
     @Mock
     private Subsegment subsegment;
 
+    @Before
+    public void setUp() {
+        when(emitter.sendSegment(any())).thenReturn(true);
+        when(emitter.sendSubsegment(any())).thenReturn(true);
+    }
+
     @Test
     public void delegates() {
         Emitter delegator = new DelegatingEmitter(emitter);
 
-        assertThat(delegator.sendSegment(segment));
+        assertThat(delegator.sendSegment(segment)).isTrue();
+        verify(emitter).sendSegment(segment);
+
+        assertThat(delegator.sendSubsegment(subsegment)).isTrue();
+        verify(emitter).sendSubsegment(subsegment);
 
     }
 }


### PR DESCRIPTION
I noticed that the SDK exposes almost all of its classes to users. For an SDK, where it's important to preserve backwards compatibility, this can make it difficult to improve on the code. An example is #145 where we want to optimize our SDK by changing the implementation of how we request rules, but we can't do so on a minor version release since we expose all of the rule APIs to users. There's a low chance they're using them in their code, but as soon as a method is public, it has to stay that way until the next major version, which cramps evolution of the SDK.

In an aim to improving by 3.0, I'd like to deprecate much of the public API surface to reduce it to only what users / instrumentation writers need. This PR is a small first step to serve as an example of what that may look like.

Let me know your thoughts on this. If it sounds like a good idea (I strongly suggest it), I'll file a tracking issue and we can maybe do a fixit at some point to knock it out.