### PR TITLE
Exposed sampling manifest URL for testing

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -49,6 +49,10 @@ public class UDPEmitter extends Emitter {
         }
     }
 
+    public DaemonConfiguration getConfig() {
+        return config;
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -49,8 +49,8 @@ public class UDPEmitter extends Emitter {
         }
     }
 
-    public DaemonConfiguration getConfig() {
-        return config;
+    public String getUDPAddress() {
+        return config.getUDPAddress();
     }
 
     /**

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
@@ -17,6 +17,10 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
 
     private final int maxSegmentSize;
 
+    public int getMaxSegmentSize() {
+        return maxSegmentSize;
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
@@ -50,7 +50,6 @@ public class CentralizedSamplingStrategy implements SamplingStrategy {
         this.targetPoller = new TargetPoller(manifest, client, Clock.systemUTC());
     }
 
-    @Override
     public URL getSamplingManifestURL() {
         return this.fallback.getSamplingManifestURL();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
@@ -51,6 +51,11 @@ public class CentralizedSamplingStrategy implements SamplingStrategy {
     }
 
     @Override
+    public URL getSamplingManifestURL() {
+        return this.fallback.getSamplingManifestURL();
+    }
+
+    @Override
     public SamplingResponse shouldTrace(SamplingRequest samplingRequest) {
         if (!isStarted) {
             startPoller();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
@@ -40,7 +40,6 @@ public class LocalizedSamplingStrategy implements SamplingStrategy {
         processRuleManifest(getRuleManifest(ruleLocation));
     }
 
-    @Override
     public URL getSamplingManifestURL() {
         return samplingRulesLocation;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
@@ -23,6 +23,7 @@ public class LocalizedSamplingStrategy implements SamplingStrategy {
 
     private static final URL DEFAULT_RULES = LocalizedSamplingStrategy.class.getResource("/com/amazonaws/xray/strategy/sampling/DefaultSamplingRules.json");
 
+    private URL samplingRulesLocation;
     private List<SamplingRule> rules;
     private SamplingRule defaultRule;
 
@@ -35,7 +36,13 @@ public class LocalizedSamplingStrategy implements SamplingStrategy {
     }
 
     public LocalizedSamplingStrategy(URL ruleLocation) {
+        this.samplingRulesLocation = ruleLocation;
         processRuleManifest(getRuleManifest(ruleLocation));
+    }
+
+    @Override
+    public URL getSamplingManifestURL() {
+        return samplingRulesLocation;
     }
 
     private SamplingRuleManifest getRuleManifest(URL ruleLocation) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingStrategy.java
@@ -1,7 +1,17 @@
 package com.amazonaws.xray.strategy.sampling;
 
+import java.net.URL;
+
 public interface SamplingStrategy {
     SamplingResponse shouldTrace(SamplingRequest sampleRequest);
+
+    /**
+     * @return the URL of the sampling manifest provided by the customer, the default sampling rule URL, or
+     * null if custom rules are not applicable to the strategy
+     */
+    default URL getSamplingManifestURL() {
+        return null;
+    }
 
     /**
      * Returns whether or not this sampling strategy supports 'forced sampling'.

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingStrategy.java
@@ -1,7 +1,5 @@
 package com.amazonaws.xray.strategy.sampling;
 
-import java.net.URL;
-
 public interface SamplingStrategy {
     SamplingResponse shouldTrace(SamplingRequest sampleRequest);
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingStrategy.java
@@ -6,14 +6,6 @@ public interface SamplingStrategy {
     SamplingResponse shouldTrace(SamplingRequest sampleRequest);
 
     /**
-     * @return the URL of the sampling manifest provided by the customer, the default sampling rule URL, or
-     * null if custom rules are not applicable to the strategy
-     */
-    default URL getSamplingManifestURL() {
-        return null;
-    }
-
-    /**
      * Returns whether or not this sampling strategy supports 'forced sampling'.
      *
      * Forced sampling allows a segment's initial non-sampled decision to be later overriden to sampled. Supporting this feature requires that all segments, sampled or otherwise, be kept in memory for

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
@@ -1,0 +1,21 @@
+package com.amazonaws.xray.emitters;
+
+import com.amazonaws.xray.config.DaemonConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.SocketException;
+
+public class UDPEmitterTest {
+
+    @Test
+    public void testCustomAddress() throws SocketException {
+        String address = "123.4.5.6:1234";
+        DaemonConfiguration config = new DaemonConfiguration();
+        config.setDaemonAddress(address);
+
+        UDPEmitter emitter = new UDPEmitter(config);
+
+        Assert.assertEquals(address, emitter.getUDPAddress());
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Add a method to retrieve the URL of the sampling manifest file being used by the recorder's sampling strategy. This can be used for testing, e.g. to verify the expected sampling file is being used. Currently there is no way of knowing this information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
