### PR TITLE
Extended try block in UDPEmitter (#151)

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -52,16 +52,6 @@ public class UDPEmitter extends Emitter {
         }
     }
 
-    /**
-     * Constructs a UDPEmitter. This overload allows you to specify the daemonSocket and configuration.
-     * @param daemonSocket The {@link DatagramSocket} for the Emitter.
-     * @param config The {@link DaemonConfiguration} for the Emitter.
-     */
-    UDPEmitter(final DatagramSocket daemonSocket, final DaemonConfiguration config) {
-        this.daemonSocket = daemonSocket;
-        this.config = config;
-    }
-
     public String getUDPAddress() {
         return config.getUDPAddress();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -1,18 +1,16 @@
 package com.amazonaws.xray.emitters;
 
-import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.SocketException;
-import java.util.Optional;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import com.amazonaws.xray.config.DaemonConfiguration;
 import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketException;
+import java.util.Optional;
 
 /**
  * @deprecated Use {@link Emitter#create()}.
@@ -54,6 +52,16 @@ public class UDPEmitter extends Emitter {
         }
     }
 
+    /**
+     * Constructs a UDPEmitter. This overload allows you to specify the daemonSocket and configuration.
+     * @param daemonSocket The {@link DatagramSocket} for the Emitter.
+     * @param config The {@link DaemonConfiguration} for the Emitter.
+     */
+    UDPEmitter(final DatagramSocket daemonSocket, final DaemonConfiguration config) {
+        this.daemonSocket = daemonSocket;
+        this.config = config;
+    }
+
     public String getUDPAddress() {
         return config.getUDPAddress();
     }
@@ -83,12 +91,12 @@ public class UDPEmitter extends Emitter {
     }
 
     private boolean sendData(byte[] data, Entity entity) {
-        DatagramPacket packet = new DatagramPacket(sendBuffer, DAEMON_BUF_RECEIVE_SIZE, config.getAddressForEmitter());
-        packet.setData(data);
         try {
+            DatagramPacket packet = new DatagramPacket(sendBuffer, DAEMON_BUF_RECEIVE_SIZE, config.getAddressForEmitter());
+            packet.setData(data);
             logger.debug("Sending UDP packet.");
             daemonSocket.send(packet);
-        } catch (IOException e) {
+        } catch (Exception e) {
             String segmentName = Optional.ofNullable(entity.getParent()).map(this::nameAndId).orElse("[no parent segment]");
             logger.error("Exception while sending segment over UDP for entity " +  nameAndId(entity) + " on segment " + segmentName, e);
             return false;

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
@@ -1,15 +1,12 @@
 package com.amazonaws.xray.emitters;
 
+import static com.amazonaws.xray.AWSXRay.getGlobalRecorder;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.amazonaws.xray.config.DaemonConfiguration;
 import com.amazonaws.xray.entities.DummySegment;
-import org.junit.Test;
-
-import java.net.DatagramSocket;
 import java.net.SocketException;
-
-import static com.amazonaws.xray.AWSXRay.getGlobalRecorder;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
+import org.junit.Test;
 
 public class UDPEmitterTest {
 
@@ -20,18 +17,17 @@ public class UDPEmitterTest {
 
         UDPEmitter emitter = new UDPEmitter(config);
 
-        assertEquals(address, emitter.getUDPAddress());
+        assertThat(emitter.getUDPAddress()).isEqualTo(address);
     }
 
 
     @Test
     public void sendingSegmentShouldNotThrowExceptions() throws SocketException {
-        DaemonConfiguration config = getDaemonConfiguration("host:1234");
-        UDPEmitter emitter = new UDPEmitter(mock(DatagramSocket.class), config);
+        DaemonConfiguration config = getDaemonConfiguration("__udpemittertest_unresolvable__:1234");
+        UDPEmitter emitter = new UDPEmitter(config);
 
-        final boolean success = emitter.sendSegment(new DummySegment(getGlobalRecorder()));
-
-        assertEquals(false, success);
+        boolean success = emitter.sendSegment(new DummySegment(getGlobalRecorder()));
+        assertThat(success).isFalse();
     }
 
     protected DaemonConfiguration getDaemonConfiguration(final String address) {

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
@@ -1,21 +1,42 @@
 package com.amazonaws.xray.emitters;
 
 import com.amazonaws.xray.config.DaemonConfiguration;
-import org.junit.Assert;
+import com.amazonaws.xray.entities.DummySegment;
 import org.junit.Test;
 
+import java.net.DatagramSocket;
 import java.net.SocketException;
+
+import static com.amazonaws.xray.AWSXRay.getGlobalRecorder;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class UDPEmitterTest {
 
     @Test
     public void testCustomAddress() throws SocketException {
         String address = "123.4.5.6:1234";
-        DaemonConfiguration config = new DaemonConfiguration();
-        config.setDaemonAddress(address);
+        DaemonConfiguration config = getDaemonConfiguration(address);
 
         UDPEmitter emitter = new UDPEmitter(config);
 
-        Assert.assertEquals(address, emitter.getUDPAddress());
+        assertEquals(address, emitter.getUDPAddress());
+    }
+
+
+    @Test
+    public void sendingSegmentShouldNotThrowExceptions() throws SocketException {
+        DaemonConfiguration config = getDaemonConfiguration("host:1234");
+        UDPEmitter emitter = new UDPEmitter(mock(DatagramSocket.class), config);
+
+        final boolean success = emitter.sendSegment(new DummySegment(getGlobalRecorder()));
+
+        assertEquals(false, success);
+    }
+
+    protected DaemonConfiguration getDaemonConfiguration(final String address) {
+        DaemonConfiguration config = new DaemonConfiguration();
+        config.setDaemonAddress(address);
+        return config;
     }
 }


### PR DESCRIPTION

 (#151)

- fixed bubbling up exceptions thrown during sending segment to xray daemon

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
