### PR TITLE
More safety in UnsignedXrayClient

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import javax.annotation.Nullable;
 
 /**
  * A simple client for sending API requests via the X-Ray daemon. Requests do not have to be
@@ -35,7 +36,8 @@ public class UnsignedXrayClient {
     // Visible for testing
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .setSerializationInclusion(Include.NON_EMPTY)
-            .setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE)
+            // Use deprecated field to support older Jackson versions for now.
+            .setPropertyNamingStrategy(PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE)
             .setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
                 @Override
                 public boolean hasIgnoreMarker(AnnotatedMember m) {
@@ -140,7 +142,12 @@ public class UnsignedXrayClient {
         }
     }
 
-    private static void readTo(InputStream is, ByteArrayOutputStream os) throws IOException {
+    private static void readTo(@Nullable InputStream is, ByteArrayOutputStream os) throws IOException {
+        // It is possible for getErrorStream to return null, though since we don't read it for success cases in practice it
+        // shouldn't happen. Check just in case.
+        if (is == null) {
+            return;
+        }
         int b;
         while ((b = is.read()) != -1) {
             os.write(b);


### PR DESCRIPTION
- Use older Jackson property at least while we depend on AWS SDK which defaults to an old version
- Checking null for a nullable value (not exercised by our code in practice but noticed it elsewhere)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
