### PR TITLE
Avoid String.split when parsing header to reduce some garbage generat…

### DIFF
--- a/aws-xray-recorder-sdk-benchmark/tst/main/java/com/amazonaws/xray/entities/TraceHeaderBenchmark.java
+++ b/aws-xray-recorder-sdk-benchmark/tst/main/java/com/amazonaws/xray/entities/TraceHeaderBenchmark.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.entities;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class TraceHeaderBenchmark {
+
+    private static final String HEADER = "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1";
+
+    @Benchmark
+    public TraceHeader parse() {
+        return TraceHeader.fromString(HEADER);
+    }
+
+    // Convenience main entry-point
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .addProfiler("gc")
+            .include(".*" + TraceHeaderBenchmark.class.getSimpleName())
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -24,7 +24,6 @@ public class TraceID {
 
     private static final char VERSION = '1';
     private static final char DELIMITER = '-';
-    private static final String HEX_PREFIX = "0x";
 
     private BigInteger number;
     private long startTime;
@@ -39,13 +38,38 @@ public class TraceID {
     }
 
     public static TraceID fromString(String string) {
+        string = string.trim();
         TraceID traceId = new TraceID();
-        String[] parts = string.trim().split(DELIMITER + "");
 
-        if (parts.length >= 3) {
-            traceId.setStartTime(Long.decode(HEX_PREFIX + parts[1]));
-            traceId.setNumber(new BigInteger(parts[2], 16));
+        long startTime = 0;
+        BigInteger number = null;
+
+        int delimiterIndex;
+
+        // Skip version number
+        delimiterIndex = string.indexOf(DELIMITER);
+        if (delimiterIndex < 0) {
+            return traceId;
         }
+
+        int valueStartIndex = delimiterIndex + 1;
+        delimiterIndex = string.indexOf(DELIMITER, valueStartIndex);
+        if (delimiterIndex < 0) {
+            return traceId;
+        } else {
+            startTime = Long.valueOf(string.substring(valueStartIndex, delimiterIndex), 16);
+        }
+
+        valueStartIndex = delimiterIndex + 1;
+        delimiterIndex = string.indexOf(DELIMITER, valueStartIndex);
+        if (delimiterIndex < 0) {
+            // End of string
+            delimiterIndex = string.length();
+        }
+        number = new BigInteger(string.substring(valueStartIndex, delimiterIndex), 16);
+
+        traceId.setStartTime(startTime);
+        traceId.setNumber(number);
 
         return traceId;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -41,8 +41,7 @@ public class TraceID {
         string = string.trim();
         TraceID traceId = new TraceID();
 
-        long startTime = 0;
-        BigInteger number = null;
+        long startTime;
 
         int delimiterIndex;
 
@@ -66,10 +65,9 @@ public class TraceID {
             // End of string
             delimiterIndex = string.length();
         }
-        number = new BigInteger(string.substring(valueStartIndex, delimiterIndex), 16);
 
+        traceId.setNumber(new BigInteger(string.substring(valueStartIndex, delimiterIndex), 16));
         traceId.setStartTime(startTime);
-        traceId.setNumber(number);
 
         return traceId;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
@@ -114,7 +114,7 @@ public class UnsignedXrayClient {
 
         try (OutputStream outputStream = connection.getOutputStream()) {
             OBJECT_MAPPER.writeValue(outputStream, request);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new XrayClientException("Could not serialize and send request.", e);
         }
 


### PR DESCRIPTION
…ion.

*Description of changes:*

Instead of String.split, can use indexOf to reduce allocations of arrays. About 20% faster / less allocations, not huge but these things add up and as instrumentation we need to keep an eye on minimizing cycles to reduce the cost burden of the customer. I would say the readability is not significantly impaired. @shengxil feel free to copy this away.

After
```
Benchmark                                                      Mode     Cnt     Score    Error   Units
TraceHeaderBenchmark.parse                                   sample  437664     2.024 ±  0.209   us/op
TraceHeaderBenchmark.parse:parse·p0.00                       sample             0.498            us/op
TraceHeaderBenchmark.parse:parse·p0.50                       sample             0.800            us/op
TraceHeaderBenchmark.parse:parse·p0.90                       sample             0.934            us/op
TraceHeaderBenchmark.parse:parse·p0.95                       sample             1.170            us/op
TraceHeaderBenchmark.parse:parse·p0.99                       sample             4.496            us/op
TraceHeaderBenchmark.parse:parse·p0.999                      sample            40.021            us/op
TraceHeaderBenchmark.parse:parse·p0.9999                     sample          1761.280            us/op
TraceHeaderBenchmark.parse:parse·p1.00                       sample          3551.232            us/op
TraceHeaderBenchmark.parse:·gc.alloc.rate                    sample      15   627.784 ± 53.949  MB/sec
TraceHeaderBenchmark.parse:·gc.alloc.rate.norm               sample      15  1072.556 ±  0.061    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space           sample      15   631.644 ± 86.257  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space.norm      sample      15  1076.679 ± 92.875    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space       sample      15     0.100 ±  0.017  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space.norm  sample      15     0.172 ±  0.030    B/op
TraceHeaderBenchmark.parse:·gc.count                         sample      15    94.000           counts
TraceHeaderBenchmark.parse:·gc.time                          sample      15    95.000               ms
```

Before
```
Benchmark                                                      Mode     Cnt     Score     Error   Units
TraceHeaderBenchmark.parse                                   sample  372019     2.519 ±   0.257   us/op
TraceHeaderBenchmark.parse:parse·p0.00                       sample             0.609             us/op
TraceHeaderBenchmark.parse:parse·p0.50                       sample             0.939             us/op
TraceHeaderBenchmark.parse:parse·p0.90                       sample             1.102             us/op
TraceHeaderBenchmark.parse:parse·p0.95                       sample             1.552             us/op
TraceHeaderBenchmark.parse:parse·p0.99                       sample            15.680             us/op
TraceHeaderBenchmark.parse:parse·p0.999                      sample            60.283             us/op
TraceHeaderBenchmark.parse:parse·p0.9999                     sample          2006.213             us/op
TraceHeaderBenchmark.parse:parse·p1.00                       sample          3317.760             us/op
TraceHeaderBenchmark.parse:·gc.alloc.rate                    sample      15   719.021 ±  36.796  MB/sec
TraceHeaderBenchmark.parse:·gc.alloc.rate.norm               sample      15  1448.702 ±   0.038    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space           sample      15   726.083 ±  72.496  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space.norm      sample      15  1461.632 ± 107.197    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space       sample      15     0.082 ±   0.084  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space.norm  sample      15     0.165 ±   0.168    B/op
TraceHeaderBenchmark.parse:·gc.count                         sample      15   108.000            counts
TraceHeaderBenchmark.parse:·gc.time                          sample      15   109.000                ms
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
