### PR TITLE
Only allocate a new (random) trace ID when trace ID parse fails rathe…

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -59,7 +59,7 @@ public class LambdaSegmentContext implements SegmentContext {
             if (LambdaSegmentContext.isInitializing(LambdaSegmentContext.getTraceHeaderFromEnvironment())) {
                 logger.warn(LAMBDA_TRACE_HEADER_KEY + " is missing a trace ID, parent ID, or sampling decision. Subsegment "
                             + name + " discarded.");
-                parentSegment = new FacadeSegment(recorder, new TraceID(), "", SampleDecision.NOT_SAMPLED);
+                parentSegment = new FacadeSegment(recorder, TraceID.create(), "", SampleDecision.NOT_SAMPLED);
             } else {
                 parentSegment = LambdaSegmentContext.newFacadeSegment(recorder);
             }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
@@ -53,7 +53,7 @@ public class DummySegment implements Segment {
     }
 
     public DummySegment(AWSXRayRecorder creator) {
-        this(creator, new TraceID());
+        this(creator, TraceID.create());
     }
 
     public DummySegment(AWSXRayRecorder creator, TraceID traceId) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
@@ -39,7 +39,7 @@ public class DummySubsegment implements Subsegment {
     private Segment parentSegment;
 
     public DummySubsegment(AWSXRayRecorder creator) {
-        this(creator, new TraceID());
+        this(creator, TraceID.create());
     }
 
     public DummySubsegment(AWSXRayRecorder creator, TraceID traceId) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
@@ -39,7 +39,7 @@ public class SegmentImpl extends EntityImpl implements Segment {
     } // default constructor for jackson
 
     public SegmentImpl(AWSXRayRecorder creator, String name) {
-        this(creator, name, new TraceID());
+        this(creator, name, TraceID.create());
     }
 
     public SegmentImpl(AWSXRayRecorder creator, String name, TraceID traceId) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 public class TraceID {
 
-    private static final char TRACE_ID_LENGTH = 35;
+    private static final int TRACE_ID_LENGTH = 35;
     private static final int TRACE_ID_DELIMITER_INDEX_1 = 1;
     private static final int TRACE_ID_DELIMITER_INDEX_2 = 10;
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -22,54 +22,77 @@ import java.util.Objects;
 
 public class TraceID {
 
+    private static final char TRACE_ID_LENGTH = 35;
+    private static final int TRACE_ID_DELIMITER_INDEX_1 = 1;
+    private static final int TRACE_ID_DELIMITER_INDEX_2 = 10;
+
     private static final char VERSION = '1';
     private static final char DELIMITER = '-';
 
     private BigInteger number;
     private long startTime;
 
+    /**
+     * @deprecated Use {@link #create()}.
+     */
+    @Deprecated
     public TraceID() {
         this(Instant.now().getEpochSecond());
     }
 
+    /**
+     * @deprecated Use {@link #create()}.
+     */
+    @Deprecated
     public TraceID(long startTime) {
         number = new BigInteger(96, ThreadLocalStorage.getRandom());
         this.startTime = startTime;
     }
 
-    public static TraceID fromString(String string) {
-        string = string.trim();
-        TraceID traceId = new TraceID();
+    private TraceID(long startTime, BigInteger number) {
+        this.startTime = startTime;
+        this.number = number;
+    }
 
-        long startTime;
+    /**
+     * Returns a new {@link TraceID} which represents the start of a new trace.
+     */
+    public static TraceID create() {
+        return new TraceID();
+    }
 
-        int delimiterIndex;
+    /**
+     * Returns the {@link TraceID} parsed out of the {@link String}. If the parse fails, a new {@link TraceID} will be returned,
+     * effectively restarting the trace.
+     */
+    public static TraceID fromString(String xrayTraceId) {
+        xrayTraceId = xrayTraceId.trim();
 
-        // Skip version number
-        delimiterIndex = string.indexOf(DELIMITER);
-        if (delimiterIndex < 0) {
-            return traceId;
+        if (xrayTraceId.length() != TRACE_ID_LENGTH) {
+            return TraceID.create();
         }
 
-        int valueStartIndex = delimiterIndex + 1;
-        delimiterIndex = string.indexOf(DELIMITER, valueStartIndex);
-        if (delimiterIndex < 0) {
-            return traceId;
-        } else {
-            startTime = Long.valueOf(string.substring(valueStartIndex, delimiterIndex), 16);
+        // Check version trace id version
+        if (xrayTraceId.charAt(0) != VERSION) {
+            return TraceID.create();
         }
 
-        valueStartIndex = delimiterIndex + 1;
-        delimiterIndex = string.indexOf(DELIMITER, valueStartIndex);
-        if (delimiterIndex < 0) {
-            // End of string
-            delimiterIndex = string.length();
+        // Check delimiters
+        if (xrayTraceId.charAt(TRACE_ID_DELIMITER_INDEX_1) != DELIMITER
+            || xrayTraceId.charAt(TRACE_ID_DELIMITER_INDEX_2) != DELIMITER) {
+            return TraceID.create();
         }
 
-        traceId.setNumber(new BigInteger(string.substring(valueStartIndex, delimiterIndex), 16));
-        traceId.setStartTime(startTime);
+        String startTimePart = xrayTraceId.substring(TRACE_ID_DELIMITER_INDEX_1 + 1, TRACE_ID_DELIMITER_INDEX_2);
+        String randomPart = xrayTraceId.substring(TRACE_ID_DELIMITER_INDEX_2 + 1, TRACE_ID_LENGTH);
 
-        return traceId;
+        final TraceID result;
+        try {
+            result = new TraceID(Long.valueOf(startTimePart, 16), new BigInteger(randomPart, 16));
+        } catch (NumberFormatException e) {
+            return TraceID.create();
+        }
+        return result;
     }
 
     @Override
@@ -90,7 +113,10 @@ public class TraceID {
 
     /**
      * @param number the number to set
+     *
+     * @deprecated TraceID is effectively immutable and this will be removed
      */
+    @Deprecated
     public void setNumber(BigInteger number) {
         this.number = number;
     }
@@ -104,7 +130,10 @@ public class TraceID {
 
     /**
      * @param startTime the startTime to set
+     *
+     * @deprecated TraceID is effectively immutable and this will be removed
      */
+    @Deprecated
     public void setStartTime(long startTime) {
         this.startTime = startTime;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletFilter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletFilter.java
@@ -301,7 +301,7 @@ public class AWSXRayServletFilter implements javax.servlet.Filter {
         HttpServletRequest httpServletRequest = castServletRequest(request);
         if (null == httpServletRequest) {
             logger.warn("Null value for incoming HttpServletRequest. Beginning DummySegment.");
-            return recorder.beginDummySegment(new TraceID());
+            return recorder.beginDummySegment(TraceID.create());
         }
 
         Optional<TraceHeader> incomingHeader = getTraceHeader(httpServletRequest);
@@ -321,7 +321,7 @@ public class AWSXRayServletFilter implements javax.servlet.Filter {
 
         TraceID traceId = incomingHeader.isPresent() ? incomingHeader.get().getRootTraceId() : null;
         if (null == traceId) {
-            traceId = new TraceID();
+            traceId = TraceID.create();
         }
 
         String parentId = incomingHeader.isPresent() ? incomingHeader.get().getParentId() : null;


### PR DESCRIPTION
…r than all the time and prepare for immutable.

Noticed that we always allocate a fresh `TraceID` even when parsing one successfully. We should only do so in the case of a failure, since generating a random is very expensive. Most parses are successful. Around 4x speedup.

Also cleaned up delimiter parsing using @shengxil's pattern and prepared to make this an immutable class by deprecating setters / constructors and creating factories.

After
```
Benchmark                                                      Mode     Cnt     Score     Error   Units
TraceHeaderBenchmark.parse                                   sample  556594     0.555 ±   0.025   us/op
TraceHeaderBenchmark.parse:parse·p0.00                       sample             0.339             us/op
TraceHeaderBenchmark.parse:parse·p0.50                       sample             0.405             us/op
TraceHeaderBenchmark.parse:parse·p0.90                       sample             0.542             us/op
TraceHeaderBenchmark.parse:parse·p0.95                       sample             0.746             us/op
TraceHeaderBenchmark.parse:parse·p0.99                       sample             1.914             us/op
TraceHeaderBenchmark.parse:parse·p0.999                      sample            19.232             us/op
TraceHeaderBenchmark.parse:parse·p0.9999                     sample            52.097             us/op
TraceHeaderBenchmark.parse:parse·p1.00                       sample          1740.800             us/op
TraceHeaderBenchmark.parse:·gc.alloc.rate                    sample      15  1322.606 ±  78.021  MB/sec
TraceHeaderBenchmark.parse:·gc.alloc.rate.norm               sample      15   888.236 ±   0.024    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space           sample      15  1331.803 ± 119.214  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space.norm      sample      15   894.092 ±  54.121    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space       sample      15     0.093 ±   0.014  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space.norm  sample      15     0.062 ±   0.011    B/op
TraceHeaderBenchmark.parse:·gc.count                         sample      15   145.000            counts
TraceHeaderBenchmark.parse:·gc.time                          sample      15   128.000                ms
```

Before
```
Benchmark                                                      Mode     Cnt     Score    Error   Units
TraceHeaderBenchmark.parse                                   sample  437664     2.024 ±  0.209   us/op
TraceHeaderBenchmark.parse:parse·p0.00                       sample             0.498            us/op
TraceHeaderBenchmark.parse:parse·p0.50                       sample             0.800            us/op
TraceHeaderBenchmark.parse:parse·p0.90                       sample             0.934            us/op
TraceHeaderBenchmark.parse:parse·p0.95                       sample             1.170            us/op
TraceHeaderBenchmark.parse:parse·p0.99                       sample             4.496            us/op
TraceHeaderBenchmark.parse:parse·p0.999                      sample            40.021            us/op
TraceHeaderBenchmark.parse:parse·p0.9999                     sample          1761.280            us/op
TraceHeaderBenchmark.parse:parse·p1.00                       sample          3551.232            us/op
TraceHeaderBenchmark.parse:·gc.alloc.rate                    sample      15   627.784 ± 53.949  MB/sec
TraceHeaderBenchmark.parse:·gc.alloc.rate.norm               sample      15  1072.556 ±  0.061    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space           sample      15   631.644 ± 86.257  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Eden_Space.norm      sample      15  1076.679 ± 92.875    B/op
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space       sample      15     0.100 ±  0.017  MB/sec
TraceHeaderBenchmark.parse:·gc.churn.G1_Survivor_Space.norm  sample      15     0.172 ±  0.030    B/op
TraceHeaderBenchmark.parse:·gc.count                         sample      15    94.000           counts
TraceHeaderBenchmark.parse:·gc.time                          sample      15    95.000               ms
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
