### PR TITLE
Use singleton SecureRandom

### DIFF
--- a/aws-xray-recorder-sdk-benchmark/tst/main/java/com/amazonaws/xray/entities/IdsBenchmark.java
+++ b/aws-xray-recorder-sdk-benchmark/tst/main/java/com/amazonaws/xray/entities/IdsBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.entities;
+
+import com.amazonaws.xray.ThreadLocalStorage;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(16)
+public class IdsBenchmark {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    @Benchmark
+    public BigInteger traceId_secureRandom() {
+        return new BigInteger(96, SECURE_RANDOM);
+    }
+
+    @Benchmark
+    public BigInteger traceId_threadLocalSecureRandom() {
+        return new BigInteger(96, ThreadLocalStorage.getRandom());
+    }
+
+    @Benchmark
+    public BigInteger traceId_threadLocalRandom() {
+        return new BigInteger(96, ThreadLocalRandom.current());
+    }
+
+    @Benchmark
+    public String segmentId_secureRandom() {
+        return Long.toString(SECURE_RANDOM.nextLong() >>> 1, 16);
+    }
+
+    @Benchmark
+    public String segmentId_threadLocalSecureRandom() {
+        return Long.toString(ThreadLocalStorage.getRandom().nextLong() >>> 1, 16);
+    }
+
+    @Benchmark
+    public String segmentId_threadLocalRandom() {
+        return Long.toString(ThreadLocalRandom.current().nextLong() >>> 1, 16);
+    }
+
+    // Convenience main entry-point
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .addProfiler("gc")
+            .include(".*" + IdsBenchmark.class.getSimpleName())
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
@@ -25,6 +25,8 @@ import java.security.SecureRandom;
 @Deprecated
 public class ThreadLocalStorage {
 
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     static class LocalEntity extends ThreadLocal<Entity> {
         @Override
         protected Entity initialValue() {
@@ -32,15 +34,7 @@ public class ThreadLocalStorage {
         }
     }
 
-    static class LocalSecureRandom extends ThreadLocal<SecureRandom> {
-        @Override
-        protected SecureRandom initialValue() {
-            return new SecureRandom();
-        }
-    }
-
     private static final LocalEntity CURRENT_ENTITY = new LocalEntity();
-    private static final LocalSecureRandom CURRENT_RANDOM = new LocalSecureRandom();
 
     public static Entity get() {
         return CURRENT_ENTITY.get();
@@ -63,6 +57,6 @@ public class ThreadLocalStorage {
     }
 
     public static SecureRandom getRandom() {
-        return CURRENT_RANDOM.get();
+        return SECURE_RANDOM;
     }
 }


### PR DESCRIPTION
`SecureRandom` implementations synchronize internally because they read state from the OS. That means having a separate instance per thread doesn't actually provide any benefit - it's why JDK doesn't provide any `ThreadLocalSecureRandom` :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

```
Benchmark                                                                                   Mode      Cnt      Score     Error   Units
IdsBenchmark.segmentId_secureRandom                                                       sample  4058353     23.127 ±   0.262   us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p0.00                          sample               0.012             us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p0.50                          sample               1.660             us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p0.90                          sample              15.104             us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p0.95                          sample             115.840             us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p0.99                          sample             302.592             us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p0.999                         sample            1894.400             us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p0.9999                        sample            3392.836             us/op
IdsBenchmark.segmentId_secureRandom:segmentId_secureRandom·p1.00                          sample           21331.968             us/op
IdsBenchmark.segmentId_secureRandom:·gc.alloc.rate                                        sample       15    179.162 ±   2.918  MB/sec
IdsBenchmark.segmentId_secureRandom:·gc.alloc.rate.norm                                   sample       15    264.496 ±   0.434    B/op
IdsBenchmark.segmentId_secureRandom:·gc.churn.G1_Eden_Space                               sample       15    187.673 ±  68.505  MB/sec
IdsBenchmark.segmentId_secureRandom:·gc.churn.G1_Eden_Space.norm                          sample       15    277.872 ± 104.019    B/op
IdsBenchmark.segmentId_secureRandom:·gc.churn.G1_Old_Gen                                  sample       15      0.264 ±   0.746  MB/sec
IdsBenchmark.segmentId_secureRandom:·gc.churn.G1_Old_Gen.norm                             sample       15      0.387 ±   1.091    B/op
IdsBenchmark.segmentId_secureRandom:·gc.churn.G1_Survivor_Space                           sample       15      1.251 ±   1.581  MB/sec
IdsBenchmark.segmentId_secureRandom:·gc.churn.G1_Survivor_Space.norm                      sample       15      1.859 ±   2.342    B/op
IdsBenchmark.segmentId_secureRandom:·gc.count                                             sample       15     22.000            counts
IdsBenchmark.segmentId_secureRandom:·gc.time                                              sample       15    220.000                ms
IdsBenchmark.segmentId_threadLocalRandom                                                  sample  6763828      1.502 ±   0.170   us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p0.00                sample               0.001             us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p0.50                sample               0.192             us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p0.90                sample               0.220             us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p0.95                sample               0.245             us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p0.99                sample               0.927             us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p0.999               sample              13.808             us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p0.9999              sample            3073.919             us/op
IdsBenchmark.segmentId_threadLocalRandom:segmentId_threadLocalRandom·p1.00                sample           46137.344             us/op
IdsBenchmark.segmentId_threadLocalRandom:·gc.alloc.rate                                   sample       15   5332.847 ± 432.643  MB/sec
IdsBenchmark.segmentId_threadLocalRandom:·gc.alloc.rate.norm                              sample       15    144.105 ±   0.013    B/op
IdsBenchmark.segmentId_threadLocalRandom:·gc.churn.G1_Eden_Space                          sample       15   5339.965 ± 437.265  MB/sec
IdsBenchmark.segmentId_threadLocalRandom:·gc.churn.G1_Eden_Space.norm                     sample       15    144.373 ±   5.354    B/op
IdsBenchmark.segmentId_threadLocalRandom:·gc.churn.G1_Survivor_Space                      sample       15      0.635 ±   0.480  MB/sec
IdsBenchmark.segmentId_threadLocalRandom:·gc.churn.G1_Survivor_Space.norm                 sample       15      0.018 ±   0.014    B/op
IdsBenchmark.segmentId_threadLocalRandom:·gc.count                                        sample       15    213.000            counts
IdsBenchmark.segmentId_threadLocalRandom:·gc.time                                         sample       15    500.000                ms
IdsBenchmark.segmentId_threadLocalSecureRandom                                            sample  4148265     21.804 ±   0.234   us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p0.00    sample               0.109             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p0.50    sample               1.618             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p0.90    sample              14.960             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p0.95    sample             111.872             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p0.99    sample             282.112             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p0.999   sample            1847.296             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p0.9999  sample            2740.224             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:segmentId_threadLocalSecureRandom·p1.00    sample           17104.896             us/op
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.alloc.rate                             sample       15    183.228 ±   3.063  MB/sec
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.alloc.rate.norm                        sample       15    264.212 ±   0.309    B/op
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.churn.G1_Eden_Space                    sample       15    182.656 ±  58.666  MB/sec
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.churn.G1_Eden_Space.norm               sample       15    263.488 ±  85.052    B/op
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.churn.G1_Old_Gen                       sample       15      0.265 ±   0.746  MB/sec
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.churn.G1_Old_Gen.norm                  sample       15      0.377 ±   1.063    B/op
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.churn.G1_Survivor_Space                sample       15      1.666 ±   1.731  MB/sec
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.churn.G1_Survivor_Space.norm           sample       15      2.406 ±   2.500    B/op
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.count                                  sample       15     23.000            counts
IdsBenchmark.segmentId_threadLocalSecureRandom:·gc.time                                   sample       15    220.000                ms
IdsBenchmark.traceId_secureRandom                                                         sample  4508342     21.721 ±   0.240   us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p0.00                              sample               0.091             us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p0.50                              sample               1.008             us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p0.90                              sample               6.936             us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p0.95                              sample              93.952             us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p0.99                              sample             306.176             us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p0.999                             sample            1865.728             us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p0.9999                            sample            2936.832             us/op
IdsBenchmark.traceId_secureRandom:traceId_secureRandom·p1.00                              sample           17825.792             us/op
IdsBenchmark.traceId_secureRandom:·gc.alloc.rate                                          sample       15    125.804 ±   5.520  MB/sec
IdsBenchmark.traceId_secureRandom:·gc.alloc.rate.norm                                     sample       15    167.345 ±   0.453    B/op
IdsBenchmark.traceId_secureRandom:·gc.churn.G1_Eden_Space                                 sample       15    127.781 ±  42.629  MB/sec
IdsBenchmark.traceId_secureRandom:·gc.churn.G1_Eden_Space.norm                            sample       15    170.454 ±  58.471    B/op
IdsBenchmark.traceId_secureRandom:·gc.churn.G1_Survivor_Space                             sample       15      0.539 ±   1.105  MB/sec
IdsBenchmark.traceId_secureRandom:·gc.churn.G1_Survivor_Space.norm                        sample       15      0.722 ±   1.485    B/op
IdsBenchmark.traceId_secureRandom:·gc.count                                               sample       15     17.000            counts
IdsBenchmark.traceId_secureRandom:·gc.time                                                sample       15    190.000                ms
IdsBenchmark.traceId_threadLocalRandom                                                    sample  5759490      1.693 ±   0.194   us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p0.00                    sample               0.001             us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p0.50                    sample               0.202             us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p0.90                    sample               0.222             us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p0.95                    sample               0.240             us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p0.99                    sample               0.784             us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p0.999                   sample              14.016             us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p0.9999                  sample            6950.299             us/op
IdsBenchmark.traceId_threadLocalRandom:traceId_threadLocalRandom·p1.00                    sample           38928.384             us/op
IdsBenchmark.traceId_threadLocalRandom:·gc.alloc.rate                                     sample       15   3281.592 ± 201.977  MB/sec
IdsBenchmark.traceId_threadLocalRandom:·gc.alloc.rate.norm                                sample       15    104.116 ±   0.012    B/op
IdsBenchmark.traceId_threadLocalRandom:·gc.churn.G1_Eden_Space                            sample       15   3323.120 ± 186.049  MB/sec
IdsBenchmark.traceId_threadLocalRandom:·gc.churn.G1_Eden_Space.norm                       sample       15    105.494 ±   2.853    B/op
IdsBenchmark.traceId_threadLocalRandom:·gc.churn.G1_Old_Gen                               sample       15      0.126 ±   0.278  MB/sec
IdsBenchmark.traceId_threadLocalRandom:·gc.churn.G1_Old_Gen.norm                          sample       15      0.004 ±   0.009    B/op
IdsBenchmark.traceId_threadLocalRandom:·gc.churn.G1_Survivor_Space                        sample       15      1.080 ±   0.076  MB/sec
IdsBenchmark.traceId_threadLocalRandom:·gc.churn.G1_Survivor_Space.norm                   sample       15      0.034 ±   0.004    B/op
IdsBenchmark.traceId_threadLocalRandom:·gc.count                                          sample       15    172.000            counts
IdsBenchmark.traceId_threadLocalRandom:·gc.time                                           sample       15    417.000                ms
IdsBenchmark.traceId_threadLocalSecureRandom                                              sample  4575565     21.635 ±   0.243   us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p0.00        sample               0.016             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p0.50        sample               0.992             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p0.90        sample               6.360             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p0.95        sample              88.576             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p0.99        sample             308.736             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p0.999       sample            1900.544             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p0.9999      sample            3621.753             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:traceId_threadLocalSecureRandom·p1.00        sample           16351.232             us/op
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.alloc.rate                               sample       15    127.276 ±   4.658  MB/sec
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.alloc.rate.norm                          sample       15    167.307 ±   0.399    B/op
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.churn.G1_Eden_Space                      sample       15    130.566 ±  47.507  MB/sec
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.churn.G1_Eden_Space.norm                 sample       15    171.518 ±  61.377    B/op
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.churn.G1_Old_Gen                         sample       15      0.132 ±   0.547  MB/sec
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.churn.G1_Old_Gen.norm                    sample       15      0.188 ±   0.778    B/op
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.churn.G1_Survivor_Space                  sample       15      1.008 ±   1.833  MB/sec
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.churn.G1_Survivor_Space.norm             sample       15      1.316 ±   2.403    B/op
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.count                                    sample       15     19.000            counts
IdsBenchmark.traceId_threadLocalSecureRandom:·gc.time                                     sample       15    189.000                ms
```