### PR TITLE
Depend on aws sdk modules from instrumentor for runtime rather than c…

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":aws-xray-recorder-sdk-aws-sdk"))
+    implementation(project(":aws-xray-recorder-sdk-aws-sdk"))
 }
 
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK Instrumentor"

--- a/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly(project(":aws-xray-recorder-sdk-aws-sdk-v2"))
+    implementation(project(":aws-xray-recorder-sdk-aws-sdk-v2"))
 }
 
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK V2 Instrumentor"


### PR DESCRIPTION
…ompile only.

The dependencies are needed when a user app runs too, so `compileOnly`, which indicates it's only needed when this module is compiled, wasn't right and would require users to add both dependencies.

Note to prevent confusion as it's happening right now, this does not affect our next release, which we're still using Maven for. It probably would affect the one after that where we should have switched to Gradle by then.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
