### PR TITLE
Add checker framework nullness checker to core package.

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/build.gradle.kts
+++ b/aws-xray-recorder-sdk-apache-http/build.gradle.kts
@@ -7,9 +7,6 @@ dependencies {
     api(project(":aws-xray-recorder-sdk-core"))
 
     api("org.apache.httpcomponents:httpclient:4.5.2")
-
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-all:1.10.19")
 }
 
 description = "AWS X-Ray Recorder SDK for Java - Apache HTTP Client Proxy"

--- a/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
@@ -7,8 +7,6 @@ dependencies {
     compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.11.0")
 
     testImplementation("com.fasterxml.jackson.core:jackson-databind")
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-all:1.10.19")
 }
 
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK Core"

--- a/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
@@ -10,8 +10,6 @@ dependencies {
 
     api("software.amazon.awssdk:aws-core:2.2.0")
 
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-all:1.10.19")
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
     testImplementation("software.amazon.awssdk:dynamodb:2.2.0")
     testImplementation("software.amazon.awssdk:lambda:2.2.0")

--- a/aws-xray-recorder-sdk-aws-sdk-v2/pom.xml
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/pom.xml
@@ -55,8 +55,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
@@ -63,7 +63,6 @@ public class TracingInterceptorTest {
     public void setup() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
-        Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.anyObject());
 
         AWSXRay.setGlobalRecorder(
                 AWSXRayRecorderBuilder.standard()
@@ -102,8 +101,8 @@ public class TracingInterceptorTest {
         SdkAsyncHttpClient mockClient = Mockito.mock(SdkAsyncHttpClient.class);
         Mockito.when(mockClient.execute(Mockito.any(AsyncExecuteRequest.class)))
                .thenAnswer((Answer<CompletableFuture<Void>>) invocationOnMock -> {
-                   SdkAsyncHttpResponseHandler handler =
-                       invocationOnMock.getArgumentAt(0, AsyncExecuteRequest.class).responseHandler();
+                   AsyncExecuteRequest request = invocationOnMock.getArgument(0);
+                   SdkAsyncHttpResponseHandler handler = request.responseHandler();
                    handler.onHeaders(response);
                    handler.onStream(new EmptyPublisher<>());
 

--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -10,8 +10,7 @@ dependencies {
 
     api("com.amazonaws:aws-java-sdk:1.11.398")
 
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-all:1.10.19")
+    testImplementation("org.powermock:powermock-reflect:2.0.2")
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk/pom.xml
+++ b/aws-xray-recorder-sdk-aws-sdk/pom.xml
@@ -53,6 +53,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-reflect</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <version>1.3.0</version>

--- a/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerTest.java
@@ -56,7 +56,7 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.powermock.reflect.Whitebox;
 
 @FixMethodOrder(MethodSorters.JVM)
 public class TracingHandlerTest {

--- a/aws-xray-recorder-sdk-benchmark/pom.xml
+++ b/aws-xray-recorder-sdk-benchmark/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jmh.version>1.8</jmh.version>
+        <jmh.version>1.23</jmh.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -11,12 +11,9 @@ dependencies {
 
     testImplementation("com.github.stefanbirkner:system-rules:1.16.0")
     testImplementation("com.github.tomakehurst:wiremock-jre8:2.26.3")
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.assertj:assertj-core:3.16.1")
     testImplementation("org.openjdk.jmh:jmh-core:1.19")
-    testImplementation("org.mockito:mockito-core:2.23.4")
-    testImplementation("org.powermock:powermock-module-junit4:2.0.2")
-    testImplementation("org.powermock:powermock-api-mockito2:2.0.2")
+    testImplementation("org.powermock:powermock-module-junit4:2.0.7")
+    testImplementation("org.powermock:powermock-api-mockito2:2.0.7")
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
 }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Static helper class which holds reference to a global client and provides a static interface for invoking methods on the
@@ -57,11 +57,11 @@ public class AWSXRay {
     }
 
     @Nullable
-    public static <R> R createSegment(String name, Function<Segment, R> function) {
+    public static <R> R createSegment(String name, Function<@Nullable Segment, @Nullable R> function) {
         return globalRecorder.createSegment(name, function);
     }
 
-    public static void createSegment(String name, Consumer<Segment> consumer) {
+    public static void createSegment(String name, Consumer<@Nullable Segment> consumer) {
         globalRecorder.createSegment(name, consumer);
     }
 
@@ -75,11 +75,11 @@ public class AWSXRay {
     }
 
     @Nullable
-    public static <R> R createSubsegment(String name, Function<Subsegment, R> function) {
+    public static <R> R createSubsegment(String name, Function<@Nullable Subsegment, @Nullable R> function) {
         return globalRecorder.createSubsegment(name, function);
     }
 
-    public static void createSubsegment(String name, Consumer<Subsegment> consumer) {
+    public static void createSubsegment(String name, Consumer<@Nullable Subsegment> consumer) {
         globalRecorder.createSubsegment(name, consumer);
     }
 
@@ -130,10 +130,12 @@ public class AWSXRay {
         return globalRecorder.currentTraceId();
     }
 
+    @Nullable
     public static String currentFormattedId() {
         return globalRecorder.currentFormattedId();
     }
 
+    @Nullable
     public static Segment getCurrentSegment() {
         return globalRecorder.getCurrentSegment();
     }
@@ -142,6 +144,7 @@ public class AWSXRay {
         return globalRecorder.getCurrentSegmentOptional();
     }
 
+    @Nullable
     public static Subsegment getCurrentSubsegment() {
         return globalRecorder.getCurrentSubsegment();
     }
@@ -162,6 +165,7 @@ public class AWSXRay {
      * @deprecated use {@link #getTraceEntity()} instead
      */
     @Deprecated
+    @Nullable
     public static Entity getThreadLocal() {
         return globalRecorder.getThreadLocal();
     }
@@ -178,6 +182,7 @@ public class AWSXRay {
         globalRecorder.setTraceEntity(entity);
     }
 
+    @Nullable
     public static Entity getTraceEntity() {
         return globalRecorder.getTraceEntity();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 /**
  * Static helper class which holds reference to a global client and provides a static interface for invoking methods on the
@@ -55,6 +56,7 @@ public class AWSXRay {
         AWSXRay.globalRecorder = globalRecorder;
     }
 
+    @Nullable
     public static <R> R createSegment(String name, Function<Segment, R> function) {
         return globalRecorder.createSegment(name, function);
     }
@@ -63,6 +65,7 @@ public class AWSXRay {
         globalRecorder.createSegment(name, consumer);
     }
 
+    @Nullable
     public static <R> R createSegment(String name, Supplier<R> supplier) {
         return globalRecorder.createSegment(name, supplier);
     }
@@ -71,6 +74,7 @@ public class AWSXRay {
         globalRecorder.createSegment(name, runnable);
     }
 
+    @Nullable
     public static <R> R createSubsegment(String name, Function<Subsegment, R> function) {
         return globalRecorder.createSubsegment(name, function);
     }
@@ -79,6 +83,7 @@ public class AWSXRay {
         globalRecorder.createSubsegment(name, consumer);
     }
 
+    @Nullable
     public static <R> R createSubsegment(String name, Supplier<R> supplier) {
         return globalRecorder.createSubsegment(name, supplier);
     }
@@ -87,14 +92,17 @@ public class AWSXRay {
         globalRecorder.createSubsegment(name, runnable);
     }
 
+    @Nullable
     public static Segment beginSegment(String name) {
         return globalRecorder.beginSegment(name);
     }
 
+    @Nullable
     public static Segment beginSegment(String name, TraceID traceId, String parentId) {
         return globalRecorder.beginSegment(name, traceId, parentId);
     }
 
+    @Nullable
     public static Segment beginDummySegment() {
         return globalRecorder.beginDummySegment();
     }
@@ -103,6 +111,7 @@ public class AWSXRay {
         globalRecorder.endSegment();
     }
 
+    @Nullable
     public static Subsegment beginSubsegment(String name) {
         return globalRecorder.beginSubsegment(name);
     }
@@ -111,10 +120,12 @@ public class AWSXRay {
         globalRecorder.endSubsegment();
     }
 
+    @Nullable
     public String currentEntityId() {
         return globalRecorder.currentEntityId();
     }
 
+    @Nullable
     public TraceID currentTraceId() {
         return globalRecorder.currentTraceId();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
@@ -17,6 +17,7 @@ package com.amazonaws.xray;
 
 import com.amazonaws.xray.entities.Entity;
 import java.security.SecureRandom;
+import javax.annotation.Nullable;
 
 /**
  * @deprecated For internal use only.
@@ -36,6 +37,7 @@ public class ThreadLocalStorage {
 
     private static final LocalEntity CURRENT_ENTITY = new LocalEntity();
 
+    @Nullable
     public static Entity get() {
         return CURRENT_ENTITY.get();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
@@ -17,7 +17,7 @@ package com.amazonaws.xray;
 
 import com.amazonaws.xray.entities.Entity;
 import java.security.SecureRandom;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * @deprecated For internal use only.
@@ -28,8 +28,9 @@ public class ThreadLocalStorage {
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-    static class LocalEntity extends ThreadLocal<Entity> {
+    static class LocalEntity extends ThreadLocal<@Nullable Entity> {
         @Override
+        @Nullable
         protected Entity initialValue() {
             return null;
         }
@@ -46,7 +47,7 @@ public class ThreadLocalStorage {
         return CURRENT_ENTITY.get() != null;
     }
 
-    public static void set(Entity entity) {
+    public static void set(@Nullable Entity entity) {
         CURRENT_ENTITY.set(entity);
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -54,8 +54,8 @@ public class LambdaSegmentContext implements SegmentContext {
         if (logger.isDebugEnabled()) {
             logger.debug("Beginning subsegment named: " + name);
         }
-        if (null == getTraceEntity()) { // First subsgment of a subsegment branch.
-            Segment parentSegment = null;
+        if (getTraceEntity() == null) { // First subsgment of a subsegment branch.
+            final Segment parentSegment;
             if (LambdaSegmentContext.isInitializing(LambdaSegmentContext.getTraceHeaderFromEnvironment())) {
                 logger.warn(LAMBDA_TRACE_HEADER_KEY + " is missing a trace ID, parent ID, or sampling decision. Subsegment "
                             + name + " discarded.");

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -41,11 +41,16 @@ public class LambdaSegmentContext implements SegmentContext {
     }
 
     private static boolean isInitializing(TraceHeader traceHeader) {
-        return null == traceHeader.getRootTraceId() || null == traceHeader.getSampled() || null == traceHeader.getParentId();
+        return traceHeader.getRootTraceId() == null || traceHeader.getSampled() == null || traceHeader.getParentId() == null;
     }
 
-    private static FacadeSegment newFacadeSegment(AWSXRayRecorder recorder) {
+    private static FacadeSegment newFacadeSegment(AWSXRayRecorder recorder, String name) {
         TraceHeader traceHeader = getTraceHeaderFromEnvironment();
+        if (isInitializing(traceHeader)) {
+            logger.warn(LAMBDA_TRACE_HEADER_KEY + " is missing a trace ID, parent ID, or sampling decision. Subsegment "
+                        + name + " discarded.");
+            return new FacadeSegment(recorder, TraceID.create(), "", SampleDecision.NOT_SAMPLED);
+        }
         return new FacadeSegment(recorder, traceHeader.getRootTraceId(), traceHeader.getParentId(), traceHeader.getSampled());
     }
 
@@ -54,15 +59,9 @@ public class LambdaSegmentContext implements SegmentContext {
         if (logger.isDebugEnabled()) {
             logger.debug("Beginning subsegment named: " + name);
         }
-        if (getTraceEntity() == null) { // First subsgment of a subsegment branch.
-            final Segment parentSegment;
-            if (LambdaSegmentContext.isInitializing(LambdaSegmentContext.getTraceHeaderFromEnvironment())) {
-                logger.warn(LAMBDA_TRACE_HEADER_KEY + " is missing a trace ID, parent ID, or sampling decision. Subsegment "
-                            + name + " discarded.");
-                parentSegment = new FacadeSegment(recorder, TraceID.create(), "", SampleDecision.NOT_SAMPLED);
-            } else {
-                parentSegment = LambdaSegmentContext.newFacadeSegment(recorder);
-            }
+        Entity entity = getTraceEntity();
+        if (entity == null) { // First subsgment of a subsegment branch.
+            Segment parentSegment = newFacadeSegment(recorder, name);
             Subsegment subsegment = new SubsegmentImpl(recorder, name, parentSegment);
             subsegment.setParent(parentSegment);
             // Enable FacadeSegment to keep track of its subsegments for subtree streaming
@@ -70,7 +69,7 @@ public class LambdaSegmentContext implements SegmentContext {
             setTraceEntity(subsegment);
             return subsegment;
         } else { // Continuation of a subsegment branch.
-            Subsegment parentSubsegment = (Subsegment) getTraceEntity();
+            Subsegment parentSubsegment = (Subsegment) entity;
             // Ensure customers have not leaked subsegments across invocations
             TraceID environmentRootTraceId = LambdaSegmentContext.getTraceHeaderFromEnvironment().getRootTraceId();
             if (null != environmentRootTraceId &&

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContextResolver.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContextResolver.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class LambdaSegmentContextResolver implements SegmentContextResolver {
     private static final Log logger = LogFactory.getLog(LambdaSegmentContextResolver.class);
@@ -36,7 +37,10 @@ public class LambdaSegmentContextResolver implements SegmentContextResolver {
             boolean success = true;
             long now = System.currentTimeMillis();
             File f = new File(SDK_INITIALIZED_FILE_LOCATION);
-            f.getParentFile().mkdirs();
+            File dir = f.getParentFile();
+            if (dir != null) {
+                dir.mkdirs();
+            }
             try {
                 OutputStream out = new FileOutputStream(f);
                 out.close();
@@ -50,11 +54,13 @@ public class LambdaSegmentContextResolver implements SegmentContextResolver {
         }
     }
 
+    @Nullable
     private static String getLambdaTaskRoot() {
         return System.getenv(LambdaSegmentContextResolver.LAMBDA_TASK_ROOT_KEY);
     }
 
     @Override
+    @Nullable
     public SegmentContext resolve() {
         String lambdaTaskRootValue = LambdaSegmentContextResolver.getLambdaTaskRoot();
         if (StringValidator.isNotNullOrBlank(lambdaTaskRootValue)) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ResolverChain.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ResolverChain.java
@@ -15,6 +15,9 @@
 
 package com.amazonaws.xray.contexts;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public interface ResolverChain<T> {
+    @Nullable
     T resolve();
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContext.java
@@ -21,6 +21,7 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -38,6 +39,7 @@ public interface SegmentContext {
     default void endSegment(AWSXRayRecorder recorder) {
     }
 
+    @Nullable
     default Entity getTraceEntity() {
         return ThreadLocalStorage.get();
     }
@@ -61,6 +63,7 @@ public interface SegmentContext {
         ThreadLocalStorage.clear();
     }
 
+    @Nullable
     Subsegment beginSubsegment(AWSXRayRecorder recorder, String name);
 
     void endSubsegment(AWSXRayRecorder recorder);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContext.java
@@ -21,9 +21,9 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import java.util.Objects;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface SegmentContext {
     /**
@@ -44,7 +44,7 @@ public interface SegmentContext {
         return ThreadLocalStorage.get();
     }
 
-    default void setTraceEntity(Entity entity) {
+    default void setTraceEntity(@Nullable Entity entity) {
         if (entity != null && entity.getCreator() != null) {
             entity.getCreator().getSegmentListeners().stream().filter(Objects::nonNull).forEach(l -> {
                 l.onSetEntity(ThreadLocalStorage.get(), entity);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextExecutors.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextExecutors.java
@@ -22,7 +22,7 @@ import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
 import java.util.concurrent.Executor;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * {@link Executor}s that will mount a segment before running a command. When switching threads, for example when instrumenting an

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextResolver.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextResolver.java
@@ -15,6 +15,9 @@
 
 package com.amazonaws.xray.contexts;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public interface SegmentContextResolver {
+    @Nullable
     SegmentContext resolve();
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextResolverChain.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextResolverChain.java
@@ -18,6 +18,7 @@ package com.amazonaws.xray.contexts;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SegmentContextResolverChain implements ResolverChain<SegmentContext> {
 
@@ -28,10 +29,11 @@ public class SegmentContextResolverChain implements ResolverChain<SegmentContext
     }
 
     @Override
+    @Nullable
     public SegmentContext resolve() {
-        Optional<SegmentContextResolver> firstResolver = resolvers.stream().filter(resolver -> {
-            return null != resolver.resolve();
-        }).findFirst();
+        Optional<SegmentContextResolver> firstResolver = resolvers.stream()
+                                                                  .filter(resolver -> resolver.resolve() != null)
+                                                                  .findFirst();
 
         if (firstResolver.isPresent()) {
             return firstResolver.get().resolve();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ThreadLocalSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ThreadLocalSegmentContext.java
@@ -36,7 +36,7 @@ public class ThreadLocalSegmentContext implements SegmentContext {
     @Override
     public Subsegment beginSubsegment(AWSXRayRecorder recorder, String name) {
         Entity current = getTraceEntity();
-        if (null == current) {
+        if (current == null) {
             recorder.getContextMissingStrategy().contextMissing("Failed to begin subsegment named '" + name
                                                                 + "': segment cannot be found.", SegmentNotFoundException.class);
             return null;
@@ -44,7 +44,7 @@ public class ThreadLocalSegmentContext implements SegmentContext {
         if (logger.isDebugEnabled()) {
             logger.debug("Beginning subsegment named: " + name);
         }
-        Segment parentSegment = getTraceEntity().getParentSegment();
+        Segment parentSegment = current.getParentSegment();
         Subsegment subsegment = new SubsegmentImpl(recorder, name, parentSegment);
         subsegment.setParent(current);
         current.addSubsegment(subsegment);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ThreadLocalSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ThreadLocalSegmentContext.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ThreadLocalSegmentContext implements SegmentContext {
     private static final Log logger =
@@ -34,6 +35,7 @@ public class ThreadLocalSegmentContext implements SegmentContext {
 
 
     @Override
+    @Nullable
     public Subsegment beginSubsegment(AWSXRayRecorder recorder, String name) {
         Entity current = getTraceEntity();
         if (current == null) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
@@ -17,6 +17,7 @@ package com.amazonaws.xray.entities;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents a link between a trace segment and supporting CloudWatch logs.
@@ -25,20 +26,21 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AWSLogReference {
 
+    @Nullable
     private String logGroup;
+    @Nullable
     private String arn;
 
     /**
      * Returns the log group name associated with the segment.
-     * @return
      */
+    @Nullable
     public String getLogGroup() {
         return logGroup;
     }
 
     /**
      * Set the log group for this reference.
-     * @param logGroup
      */
     public void setLogGroup(final String logGroup) {
         this.logGroup = logGroup;
@@ -46,43 +48,44 @@ public class AWSLogReference {
 
     /**
      * Returns the ARN of the log group associated with this reference, or null if not provided by the AWS Runtime.
-     * @return
      */
+    @Nullable
     public String getArn() {
         return arn;
     }
 
     /**
      * Set the ARN for this reference.
-     * @param arn
      */
     public void setArn(final String arn) {
         this.arn = arn;
     }
 
-    @Override
     /**
      * Compares ARN and log group between references to determine equality.
      * @param reference
      * @return
      */
-    public boolean equals(Object o) {
+    @Override
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof AWSLogReference)) { return false; }
         AWSLogReference reference = (AWSLogReference) o;
         return (Objects.equals(getArn(), reference.getArn()) && Objects.equals(getLogGroup(), reference.getLogGroup()));
     }
 
-    @Override
     /**
      * Generates unique hash for each LogReference object. Used to check equality in Sets.
      */
+    @Override
     public int hashCode() {
-        if (arn == null && logGroup == null) {
-            return "".hashCode();
-        } else if (arn == null) {
+        String arn = this.arn;
+        String logGroup = this.logGroup;
+        if (arn != null) {
+            return arn.hashCode();
+        } else if (logGroup != null) {
             return logGroup.hashCode();
         } else {
-            return arn.hashCode();
+            return "".hashCode();
         }
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Cause.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Cause.java
@@ -38,7 +38,7 @@ public class Cause {
 
     private Collection<String> paths;
 
-    private List<ThrowableDescription> exceptions;
+    private final List<ThrowableDescription> exceptions;
 
     public Cause() {
         //id = Entity.generateId();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Cause.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Cause.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A representation of what issues caused this (sub)segment to include a failure / error. Can include exceptions or references to
@@ -30,12 +31,16 @@ public class Cause {
     private static final Log logger =
         LogFactory.getLog(Cause.class);
 
+    @Nullable
     private String workingDirectory;
 
+    @Nullable
     private String id;
 
+    @Nullable
     private String message;
 
+    @Nullable
     private Collection<String> paths;
 
     private final List<ThrowableDescription> exceptions;
@@ -49,6 +54,7 @@ public class Cause {
     /**
      * @return the workingDirectory
      */
+    @Nullable
     public String getWorkingDirectory() {
         return workingDirectory;
     }
@@ -56,13 +62,14 @@ public class Cause {
     /**
      * @param workingDirectory the workingDirectory to set
      */
-    public void setWorkingDirectory(String workingDirectory) {
+    public void setWorkingDirectory(@Nullable String workingDirectory) {
         this.workingDirectory = workingDirectory;
     }
 
     /**
      * @return the id
      */
+    @Nullable
     public String getId() {
         return id;
     }
@@ -77,6 +84,7 @@ public class Cause {
     /**
      * @return the message
      */
+    @Nullable
     public String getMessage() {
         return message;
     }
@@ -91,6 +99,7 @@ public class Cause {
     /**
      * @return the paths
      */
+    @Nullable
     public Collection<String> getPaths() {
         return paths;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class DummySegment implements Segment {
     private Cause cause = new Cause();
@@ -229,7 +230,7 @@ public class DummySegment implements Segment {
     }
 
     @Override
-    public void setParentId(String parentId) {
+    public void setParentId(@Nullable String parentId) {
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class DummySubsegment implements Subsegment {
 
@@ -210,7 +211,7 @@ public class DummySubsegment implements Subsegment {
     }
 
     @Override
-    public void setParentId(String parentId) {
+    public void setParentId(@Nullable String parentId) {
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Entity extends AutoCloseable {
 
@@ -121,6 +122,7 @@ public interface Entity extends AutoCloseable {
     /**
      * @return the namespace
      */
+    @Nullable
     String getNamespace();
 
     /**
@@ -304,6 +306,7 @@ public interface Entity extends AutoCloseable {
     /**
      * @return the parentId
      */
+    @Nullable
     String getParentId();
 
     /**
@@ -315,7 +318,7 @@ public interface Entity extends AutoCloseable {
      *             AWSXRayRecorder used to create this entity is configured to throw exceptions
      *
      */
-    void setParentId(String parentId);
+    void setParentId(@Nullable String parentId);
 
     /**
      * @return the creator

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -42,6 +42,8 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * The base class from which {@code Segment} and {@code Subsegment} extend.
@@ -73,6 +75,7 @@ public abstract class EntityImpl implements Entity {
 
     private String name;
     private String id;
+    @Nullable
     private String parentId;
     private double startTime;
 
@@ -92,6 +95,7 @@ public abstract class EntityImpl implements Entity {
     @JsonInclude(Include.NON_DEFAULT)
     private boolean inProgress;
 
+    @Nullable
     private String namespace;
 
     // TODO(anuraaga): Check final for other variables, for now this is most important since it's also a lock.
@@ -148,11 +152,15 @@ public abstract class EntityImpl implements Entity {
 
     // default constructor for Jackson, so it can understand the default values to compare when using the Include.NON_DEFAULT
     // annotation.
+    @SuppressWarnings("nullness")
     protected EntityImpl() {
         // TODO(anuraaga): Check this is working as intended, empty lists are currently serialized.
         subsegments = null;
     }
 
+    // TODO(anuraaga): Refactor the entity relationship. There isn't a great reason to use a type hierarchy for data classes and
+    // it makes the code to hard to reason about e.g., nullness.
+    @SuppressWarnings("nullness")
     protected EntityImpl(AWSXRayRecorder creator, String name) {
         StringValidator.throwIfNullOrBlank(name, "(Sub)segment name cannot be null or blank.");
         validateNotNull(creator);
@@ -250,6 +258,7 @@ public abstract class EntityImpl implements Entity {
     }
 
     @Override
+    @Nullable
     public String getNamespace() {
         return namespace;
     }
@@ -391,18 +400,20 @@ public abstract class EntityImpl implements Entity {
     }
 
     @Override
+    @EnsuresNonNull("this.traceId")
     public void setTraceId(TraceID traceId) {
         checkAlreadyEmitted();
         this.traceId = traceId;
     }
 
     @Override
+    @Nullable
     public String getParentId() {
         return parentId;
     }
 
     @Override
-    public void setParentId(String parentId) {
+    public void setParentId(@Nullable String parentId) {
         checkAlreadyEmitted();
         this.parentId = parentId;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/FacadeSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/FacadeSegment.java
@@ -19,6 +19,7 @@ import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.TraceHeader.SampleDecision;
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class FacadeSegment extends EntityImpl implements Segment {
 
@@ -31,12 +32,20 @@ public class FacadeSegment extends EntityImpl implements Segment {
 
     protected Map<String, Object> service;
 
-    private boolean sampled;
+    private final boolean sampled;
 
-    public FacadeSegment(AWSXRayRecorder recorder, TraceID traceId, String id, SampleDecision sampleDecision) {
+    // TODO(anuraaga): Refactor the entity relationship. There isn't a great reason to use a type hierarchy for data classes and
+    // it makes the code to hard to reason about e.g., nullness.
+    @SuppressWarnings("nullness")
+    public FacadeSegment(
+        AWSXRayRecorder recorder, @Nullable TraceID traceId, @Nullable String id, @Nullable SampleDecision sampleDecision) {
         super(recorder, "facade");
-        super.setTraceId(traceId);
-        super.setId(id);
+        if (traceId != null) {
+            super.setTraceId(traceId);
+        }
+        if (id != null) {
+            super.setId(id);
+        }
         this.sampled = (SampleDecision.SAMPLED == sampleDecision);
     }
 
@@ -299,7 +308,7 @@ public class FacadeSegment extends EntityImpl implements Segment {
      * @throws UnsupportedOperationException in all cases
      */
     @Override
-    public void setTraceId(TraceID traceId) {
+    public void setTraceId(@Nullable TraceID traceId) {
         throw new UnsupportedOperationException(MUTATION_UNSUPPORTED_MESSAGE);
     }
 
@@ -308,7 +317,7 @@ public class FacadeSegment extends EntityImpl implements Segment {
      * @throws UnsupportedOperationException in all cases
      */
     @Override
-    public void setParentId(String parentId) {
+    public void setParentId(@Nullable String parentId) {
         throw new UnsupportedOperationException(MUTATION_UNSUPPORTED_MESSAGE);
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SearchPattern.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SearchPattern.java
@@ -15,6 +15,8 @@
 
 package com.amazonaws.xray.entities;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * @deprecated For internal use only.
  */
@@ -36,11 +38,11 @@ public class SearchPattern {
      *            the string to compare against the pattern
      * @return whether the text matches the pattern
      */
-    public static boolean wildcardMatch(String pattern, String text) {
+    public static boolean wildcardMatch(@Nullable String pattern, @Nullable String text) {
         return wildcardMatch(pattern, text, true);
     }
 
-    public static boolean wildcardMatch(String pattern, String text, boolean caseInsensitive) {
+    public static boolean wildcardMatch(@Nullable String pattern, @Nullable String text, boolean caseInsensitive) {
         if (pattern == null || text == null) {
             return false;
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
@@ -33,15 +33,21 @@ public class SegmentImpl extends EntityImpl implements Segment {
     @JsonIgnore
     private boolean sampled;
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings({ "unused", "nullness" })
     private SegmentImpl() {
         super();
     } // default constructor for jackson
 
+    // TODO(anuraaga): Refactor the entity relationship. There isn't a great reason to use a type hierarchy for data classes and
+    // it makes the code to hard to reason about e.g., nullness.
+    @SuppressWarnings("nullness")
     public SegmentImpl(AWSXRayRecorder creator, String name) {
         this(creator, name, TraceID.create());
     }
 
+    // TODO(anuraaga): Refactor the entity relationship. There isn't a great reason to use a type hierarchy for data classes and
+    // it makes the code to hard to reason about e.g., nullness.
+    @SuppressWarnings("nullness")
     public SegmentImpl(AWSXRayRecorder creator, String name, TraceID traceId) {
         super(creator, name);
         setTraceId(traceId);
@@ -139,7 +145,10 @@ public class SegmentImpl extends EntityImpl implements Segment {
         if (getAws().get("xray") instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> a = (HashMap<String, Object>) getAws().get("xray");
-            HashMap<String, Object> referA = new HashMap<String, Object>(a);
+            HashMap<String, Object> referA = new HashMap<>();
+            if (a != null) {
+                referA.putAll(a);
+            }
             referA.put("rule_name", ruleName);
             this.putAws("xray", referA);
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/StringValidator.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/StringValidator.java
@@ -16,6 +16,7 @@
 package com.amazonaws.xray.entities;
 
 import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 
 /**
  * @deprecated For internal use only.
@@ -24,10 +25,12 @@ import javax.annotation.Nullable;
 @Deprecated
 public class StringValidator {
 
+    @EnsuresNonNullIf(expression = "#1", result = true)
     public static boolean isNotNullOrBlank(@Nullable String string) {
         return string != null && !string.trim().isEmpty();
     }
 
+    @EnsuresNonNullIf(expression = "#1", result = false)
     public static boolean isNullOrBlank(@Nullable String string) {
         return string == null || string.trim().isEmpty();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/StringValidator.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/StringValidator.java
@@ -15,6 +15,8 @@
 
 package com.amazonaws.xray.entities;
 
+import javax.annotation.Nullable;
+
 /**
  * @deprecated For internal use only.
  */
@@ -22,16 +24,16 @@ package com.amazonaws.xray.entities;
 @Deprecated
 public class StringValidator {
 
-    public static boolean isNotNullOrBlank(String string) {
-        return null != string && !string.trim().isEmpty();
+    public static boolean isNotNullOrBlank(@Nullable String string) {
+        return string != null && !string.trim().isEmpty();
     }
 
-    public static boolean isNullOrBlank(String string) {
-        return null == string || string.trim().isEmpty();
+    public static boolean isNullOrBlank(@Nullable String string) {
+        return string == null || string.trim().isEmpty();
     }
 
-    public static void throwIfNullOrBlank(String string, String validationErrorMessage) {
-        if (null == string || string.trim().isEmpty()) {
+    public static void throwIfNullOrBlank(@Nullable String string, String validationErrorMessage) {
+        if (string == null || string.trim().isEmpty()) {
             throw new RuntimeException(validationErrorMessage);
         }
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/StringValidator.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/StringValidator.java
@@ -15,8 +15,8 @@
 
 package com.amazonaws.xray.entities;
 
-import javax.annotation.Nullable;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * @deprecated For internal use only.

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
@@ -16,6 +16,7 @@
 package com.amazonaws.xray.entities;
 
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 
 public interface Subsegment extends Entity {
@@ -32,6 +33,7 @@ public interface Subsegment extends Entity {
      * @return the namespace
      */
     @Override
+    @Nullable
     String getNamespace();
 
     /**

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
@@ -23,16 +23,19 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SubsegmentImpl extends EntityImpl implements Subsegment {
     private static final Log logger = LogFactory.getLog(SubsegmentImpl.class);
 
+    @Nullable
     private String namespace;
 
     private Segment parentSegment;
 
     private Set<String> precursorIds;
 
+    @SuppressWarnings("nullness")
     private SubsegmentImpl() {
         super();
     } // default constructor for jackson
@@ -64,6 +67,7 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
     }
 
     @Override
+    @Nullable
     public String getNamespace() {
         return namespace;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/ThrowableDescription.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/ThrowableDescription.java
@@ -16,7 +16,7 @@
 package com.amazonaws.xray.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class ThrowableDescription {
     @Nullable
@@ -34,11 +34,16 @@ public class ThrowableDescription {
     private String cause;
     
     @JsonIgnore
+    @Nullable
     private Throwable throwable;
 
+    // TODO(anuraaga): Investigate why stack is not being treated as nullable
+    @SuppressWarnings("nullness:initialization.fields.uninitialized")
     public ThrowableDescription() {
     }
 
+    // TODO(anuraaga): Investigate why stack is not being treated as nullable
+    @SuppressWarnings("nullness:initialization.fields.uninitialized")
     public ThrowableDescription(Throwable throwable) {
         this.throwable = throwable;
     }
@@ -113,7 +118,7 @@ public class ThrowableDescription {
     /**
      * @param stack the stack to set
      */
-    public void setStack(StackTraceElement[] stack) {
+    public void setStack(@Nullable StackTraceElement[] stack) {
         this.stack = stack;
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/ThrowableDescription.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/ThrowableDescription.java
@@ -16,15 +16,21 @@
 package com.amazonaws.xray.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.annotation.Nullable;
 
 public class ThrowableDescription {
+    @Nullable
     private String id;
+    @Nullable
     private String message;
+    @Nullable
     private String type;
     private boolean remote;
+    @Nullable
     private StackTraceElement[] stack;
     private int truncated;
     private int skipped;
+    @Nullable
     private String cause;
     
     @JsonIgnore
@@ -40,6 +46,7 @@ public class ThrowableDescription {
     /**
      * @return the id
      */
+    @Nullable
     public String getId() {
         return id;
     }
@@ -54,6 +61,7 @@ public class ThrowableDescription {
     /**
      * @return the message
      */
+    @Nullable
     public String getMessage() {
         return message;
     }
@@ -61,13 +69,14 @@ public class ThrowableDescription {
     /**
      * @param message the message to set
      */
-    public void setMessage(String message) {
+    public void setMessage(@Nullable String message) {
         this.message = message;
     }
 
     /**
      * @return the type
      */
+    @Nullable
     public String getType() {
         return type;
     }
@@ -96,6 +105,7 @@ public class ThrowableDescription {
     /**
      * @return the stack
      */
+    @Nullable
     public StackTraceElement[] getStack() {
         return stack;
     }
@@ -138,6 +148,7 @@ public class ThrowableDescription {
     /**
      * @return the cause
      */
+    @Nullable
     public String getCause() {
         return cause;
     }
@@ -145,13 +156,14 @@ public class ThrowableDescription {
     /**
      * @param cause the cause to set
      */
-    public void setCause(String cause) {
+    public void setCause(@Nullable String cause) {
         this.cause = cause;
     }
 
     /**
      * @return the throwable
      */
+    @Nullable
     public Throwable getThrowable() {
         return throwable;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
@@ -19,9 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TraceHeader {
     public static final String HEADER_KEY = "X-Amzn-Trace-Id";

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -53,18 +54,18 @@ public class TraceHeader {
         }
 
         public static SampleDecision fromString(String text) {
-            if (null != text) {
-                for (SampleDecision decision : SampleDecision.values()) {
-                    if (decision.toString().equalsIgnoreCase(text)) {
-                        return decision;
-                    }
+            for (SampleDecision decision : SampleDecision.values()) {
+                if (decision.toString().equalsIgnoreCase(text)) {
+                    return decision;
                 }
             }
-            return null;
+            return UNKNOWN;
         }
     }
 
+    @Nullable
     private TraceID rootTraceId;
+    @Nullable
     private String parentId;
     private SampleDecision sampled;
 
@@ -74,19 +75,19 @@ public class TraceHeader {
         this(null, null, SampleDecision.UNKNOWN);
     }
 
-    public TraceHeader(TraceID rootTraceId) {
+    public TraceHeader(@Nullable TraceID rootTraceId) {
         this(rootTraceId, null, SampleDecision.UNKNOWN);
     }
 
-    public TraceHeader(TraceID rootTraceId, String parentId) {
+    public TraceHeader(@Nullable TraceID rootTraceId, @Nullable String parentId) {
         this(rootTraceId, parentId, SampleDecision.UNKNOWN);
     }
 
-    public TraceHeader(TraceID rootTraceId, String parentId, SampleDecision sampled) {
+    public TraceHeader(@Nullable TraceID rootTraceId, @Nullable String parentId, SampleDecision sampled) {
         this.rootTraceId = rootTraceId;
         this.parentId = parentId;
         this.sampled = sampled;
-        if (null == sampled) {
+        if (sampled == null) {
             throw new IllegalArgumentException("Sample decision can not be null.");
         }
     }
@@ -98,7 +99,7 @@ public class TraceHeader {
      *            the string from an incoming trace-id header
      * @return the TraceHeader object
      */
-    public static TraceHeader fromString(String string) {
+    public static TraceHeader fromString(@Nullable String string) {
         TraceHeader traceHeader = new TraceHeader();
 
         if (string == null) {
@@ -148,15 +149,13 @@ public class TraceHeader {
     @Override
     public String toString() {
         List<String> parts = new ArrayList<>();
-        if (null != rootTraceId) {
+        if (rootTraceId != null) {
             parts.add(ROOT_PREFIX + rootTraceId);
         }
         if (StringValidator.isNotNullOrBlank(parentId)) {
             parts.add(PARENT_PREFIX + parentId);
         }
-        if (null != sampled) {
-            parts.add(sampled.toString());
-        }
+        parts.add(sampled.toString());
         additionalParams.forEach((key, value) -> {
             parts.add(key + EQUALS + value);
         });
@@ -166,6 +165,7 @@ public class TraceHeader {
     /**
      * @return the rootTraceId
      */
+    @Nullable
     public TraceID getRootTraceId() {
         return rootTraceId;
     }
@@ -180,6 +180,7 @@ public class TraceHeader {
     /**
      * @return the parentId
      */
+    @Nullable
     public String getParentId() {
         return parentId;
     }
@@ -207,7 +208,7 @@ public class TraceHeader {
      *             if sampled is null
      */
     public void setSampled(SampleDecision sampled) {
-        if (null == sampled) {
+        if (sampled == null) {
             throw new IllegalArgumentException("Sample decision can not be null. Please use SampleDecision.UNKNOWN instead.");
         }
         this.sampled = sampled;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -18,7 +18,7 @@ package com.amazonaws.xray.entities;
 import com.amazonaws.xray.ThreadLocalStorage;
 import java.math.BigInteger;
 import java.time.Instant;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TraceID {
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -18,7 +18,7 @@ package com.amazonaws.xray.entities;
 import com.amazonaws.xray.ThreadLocalStorage;
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.Objects;
+import javax.annotation.Nullable;
 
 public class TraceID {
 
@@ -117,8 +117,10 @@ public class TraceID {
      * @deprecated TraceID is effectively immutable and this will be removed
      */
     @Deprecated
-    public void setNumber(BigInteger number) {
-        this.number = number;
+    public void setNumber(@Nullable BigInteger number) {
+        if (number != null) {
+            this.number = number;
+        }
     }
 
     /**
@@ -147,7 +149,7 @@ public class TraceID {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }
@@ -155,6 +157,6 @@ public class TraceID {
             return false;
         }
         TraceID other = (TraceID) obj;
-        return Objects.equals(number, other.number) && startTime == other.startTime;
+        return number.equals(other.number) && startTime == other.startTime;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
@@ -46,7 +46,7 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A simple client for sending API requests via the X-Ray daemon. Requests do not have to be
@@ -211,16 +211,11 @@ public class UnsignedXrayClient {
          * object.
          */
         private static Date parseServiceSpecificDate(String dateString) {
-            if (dateString == null) {
-                return null;
-            }
             try {
                 BigDecimal dateValue = new BigDecimal(dateString);
-                return new Date(dateValue.scaleByPowerOfTen(
-                    AWS_DATE_MILLI_SECOND_PRECISION).longValue());
+                return new Date(dateValue.scaleByPowerOfTen(AWS_DATE_MILLI_SECOND_PRECISION).longValue());
             } catch (NumberFormatException nfe) {
-                throw new SdkClientException("Unable to parse date : "
-                                             + dateString, nfe);
+                throw new SdkClientException("Unable to parse date : " + dateString, nfe);
             }
         }
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletAsyncListener.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletAsyncListener.java
@@ -21,15 +21,20 @@ import com.amazonaws.xray.entities.Entity;
 import java.io.IOException;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
+import org.checkerframework.checker.initialization.qual.UnderInitialization;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 class AWSXRayServletAsyncListener implements AsyncListener {
 
     public static final String ENTITY_ATTRIBUTE_KEY = "com.amazonaws.xray.entities.Entity";
 
+    @Nullable
     private AWSXRayRecorder recorder;
-    private AWSXRayServletFilter filter;
+    private final AWSXRayServletFilter filter;
 
-    AWSXRayServletAsyncListener(AWSXRayServletFilter filter, AWSXRayRecorder recorder) {
+    // TODO(anuraaga): Better define lifecycle relationship between this listener and the filter.
+    @SuppressWarnings("nullness")
+    AWSXRayServletAsyncListener(@UnderInitialization AWSXRayServletFilter filter, @Nullable AWSXRayRecorder recorder) {
         this.filter = filter;
         this.recorder = recorder;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/listeners/SegmentListener.java
@@ -18,6 +18,7 @@ package com.amazonaws.xray.listeners;
 import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An interface to intercept lifecycle events, namely the beginning and ending, of segments produced by the AWSXRayRecorder.
@@ -101,7 +102,7 @@ public interface SegmentListener {
      * @param previousEntity
      * @param newEntity
      */
-    default void onSetEntity(Entity previousEntity, Entity newEntity) {
+    default void onSetEntity(@Nullable Entity previousEntity, Entity newEntity) {
 
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
@@ -30,9 +30,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 class EC2MetadataFetcher {
     private static final Log logger = LogFactory.getLog(EC2MetadataFetcher.class);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
@@ -53,7 +53,7 @@ class EC2MetadataFetcher {
     private final URL tokenUrl;
 
     EC2MetadataFetcher() {
-        this(System.getenv("IMDS_ENDPOINT") != null ? System.getenv("IMDS_ENDPOINT") : DEFAULT_IMDS_ENDPOINT);
+        this(getEndpoint());
     }
 
     EC2MetadataFetcher(String endpoint) {
@@ -196,4 +196,8 @@ class EC2MetadataFetcher {
         }
     }
 
+    private static String getEndpoint() {
+        String endpointFromEnv = System.getenv("IMDS_ENDPOINT");
+        return endpointFromEnv != null ? endpointFromEnv :  DEFAULT_IMDS_ENDPOINT;
+    }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2Plugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2Plugin.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -163,7 +164,7 @@ public class EC2Plugin implements Plugin {
      * Determine equality of plugins using origin to uniquely identify them
      */
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof Plugin)) { return false; }
         return this.getOrigin().equals(((Plugin) o).getOrigin());
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2Plugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2Plugin.java
@@ -28,9 +28,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A plugin, for use with the {@code AWSXRayRecorderBuilder} class, which will add EC2 instance information to segments generated
@@ -55,7 +55,7 @@ public class EC2Plugin implements Plugin {
     private static final String LINUX_ROOT = "/";
     private static final String LINUX_PATH = "opt/aws/amazon-cloudwatch-agent/etc/log-config.json";
 
-    private final Map<String, Object> runtimeContext;
+    private final Map<String, @Nullable Object> runtimeContext;
 
     private final Set<AWSLogReference> logReferences;
 
@@ -95,7 +95,7 @@ public class EC2Plugin implements Plugin {
     }
 
     @Override
-    public Map<String, Object> getRuntimeContext() {
+    public Map<String, @Nullable Object> getRuntimeContext() {
         populateRuntimeContext();
         return runtimeContext;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
@@ -21,9 +21,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A plugin, for use with the {@code AWSXRayRecorderBuilder} class, which will add ECS container information to segments generated
@@ -42,7 +42,7 @@ public class ECSPlugin implements Plugin {
     private static final String HTTP_PREFIX = "http://";
     private static final String CONTAINER_ID_KEY = "containerId";
 
-    private final HashMap<String, Object> runtimeContext;
+    private final HashMap<String, @Nullable Object> runtimeContext;
     private final DockerUtils dockerUtils;
 
     public ECSPlugin() {
@@ -83,7 +83,7 @@ public class ECSPlugin implements Plugin {
     }
 
     @Override
-    public Map<String, Object> getRuntimeContext() {
+    public Map<String, @Nullable Object> getRuntimeContext() {
         populateRuntimeContext();
         return runtimeContext;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -41,8 +42,8 @@ public class ECSPlugin implements Plugin {
     private static final String HTTP_PREFIX = "http://";
     private static final String CONTAINER_ID_KEY = "containerId";
 
-    private HashMap<String, Object> runtimeContext;
-    private DockerUtils dockerUtils;
+    private final HashMap<String, Object> runtimeContext;
+    private final DockerUtils dockerUtils;
 
     public ECSPlugin() {
         runtimeContext = new HashMap<>();
@@ -92,22 +93,20 @@ public class ECSPlugin implements Plugin {
         return ORIGIN;
     }
 
-    @Override
     /**
      * Determine equality of plugins using origin to uniquely identify them
      */
-    public boolean equals(Object o) {
+    @Override
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof Plugin)) { return false; }
         return this.getOrigin().equals(((Plugin) o).getOrigin());
     }
 
-    @Override
     /**
      * Hash plugin object using origin to uniquely identify them
      */
+    @Override
     public int hashCode() {
         return this.getOrigin().hashCode();
     }
-
-
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EKSPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EKSPlugin.java
@@ -25,9 +25,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 
 /**
@@ -47,8 +47,9 @@ public class EKSPlugin implements Plugin {
 
     private static final Log logger = LogFactory.getLog(EKSPlugin.class);
 
+    @Nullable
     private String clusterName;
-    private final Map<String, Object> runtimeContext;
+    private final Map<String, @Nullable Object> runtimeContext;
     private final Set<AWSLogReference> logReferences;
     private final DockerUtils dockerUtils;
 
@@ -56,8 +57,10 @@ public class EKSPlugin implements Plugin {
         this(ContainerInsightsUtil.getClusterName());
     }
 
-    public EKSPlugin(final String clusterName) {
-        this.clusterName = clusterName;
+    public EKSPlugin(@Nullable String clusterName) {
+        if (clusterName != null) {
+            this.clusterName = clusterName;
+        }
         this.runtimeContext = new HashMap<>();
         this.logReferences = new HashSet<>();
         this.dockerUtils = new DockerUtils();
@@ -83,7 +86,7 @@ public class EKSPlugin implements Plugin {
     }
 
     @Override
-    public Map<String, Object> getRuntimeContext() {
+    public Map<String, @Nullable Object> getRuntimeContext() {
         if (runtimeContext.isEmpty()) {
             populateRuntimeContext();
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EKSPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EKSPlugin.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -47,9 +48,9 @@ public class EKSPlugin implements Plugin {
     private static final Log logger = LogFactory.getLog(EKSPlugin.class);
 
     private String clusterName;
-    private Map<String, Object> runtimeContext;
-    private Set<AWSLogReference> logReferences;
-    private DockerUtils dockerUtils;
+    private final Map<String, Object> runtimeContext;
+    private final Set<AWSLogReference> logReferences;
+    private final DockerUtils dockerUtils;
 
     public EKSPlugin() {
         this(ContainerInsightsUtil.getClusterName());
@@ -131,19 +132,19 @@ public class EKSPlugin implements Plugin {
         return ORIGIN;
     }
 
-    @Override
     /**
      * Determine equality of plugins using origin to uniquely identify them
      */
-    public boolean equals(Object o) {
+    @Override
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof Plugin)) { return false; }
         return this.getOrigin().equals(((Plugin) o).getOrigin());
     }
 
-    @Override
     /**
      * Hash plugin object using origin to uniquely identify them
      */
+    @Override
     public int hashCode() {
         return this.getOrigin().hashCode();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ElasticBeanstalkPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ElasticBeanstalkPlugin.java
@@ -22,9 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A plugin, for use with the {@code AWSXRayRecorderBuilder} class, which will add Elastic Beanstalk environment information to
@@ -78,12 +78,12 @@ public class ElasticBeanstalkPlugin implements Plugin {
     }
 
     @Override
-    public Map<String, Object> getRuntimeContext() {
+    public Map<String, @Nullable Object> getRuntimeContext() {
         if (runtimeContext.isEmpty()) {
             populateRuntimeContext();
         }
 
-        return runtimeContext;
+        return (Map<String, @Nullable Object>) runtimeContext;
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ElasticBeanstalkPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ElasticBeanstalkPlugin.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -38,14 +39,14 @@ public class ElasticBeanstalkPlugin implements Plugin {
     private static final Log logger =
         LogFactory.getLog(ElasticBeanstalkPlugin.class);
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private static final String CONF_PATH = "/var/elasticbeanstalk/xray/environment.conf";
     private static final String SERVICE_NAME = "elastic_beanstalk";
 
-    private ObjectMapper objectMapper;
     private Map<String, Object> runtimeContext;
 
     public ElasticBeanstalkPlugin() {
-        objectMapper = new ObjectMapper();
         runtimeContext = new HashMap<>();
     }
 
@@ -69,7 +70,7 @@ public class ElasticBeanstalkPlugin implements Plugin {
         }
         try {
             TypeReference<HashMap<String, Object>> typeReference = new TypeReference<HashMap<String, Object>>() {};
-            runtimeContext = objectMapper.readValue(manifestBytes, typeReference);
+            runtimeContext = OBJECT_MAPPER.readValue(manifestBytes, typeReference);
         } catch (IOException e) {
             logger.warn("Unable to read Beanstalk configuration at path " + CONF_PATH + " : " + e.getMessage());
             return;
@@ -90,19 +91,19 @@ public class ElasticBeanstalkPlugin implements Plugin {
         return ORIGIN;
     }
 
-    @Override
     /**
      * Determine equality of plugins using origin to uniquely identify them
      */
-    public boolean equals(Object o) {
+    @Override
+    public boolean equals(@Nullable Object o) {
         if (!(o instanceof Plugin)) { return false; }
         return this.getOrigin().equals(((Plugin) o).getOrigin());
     }
 
-    @Override
     /**
      * Hash plugin object using origin to uniquely identify them
      */
+    @Override
     public int hashCode() {
         return this.getOrigin().hashCode();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/Plugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/Plugin.java
@@ -19,6 +19,7 @@ import com.amazonaws.xray.entities.AWSLogReference;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Plugin {
 
@@ -40,7 +41,7 @@ public interface Plugin {
         return true;
     }
 
-    Map<String, Object> getRuntimeContext();
+    Map<String, @Nullable Object> getRuntimeContext();
 
     default Set<AWSLogReference> getLogReferences() {
         return Collections.emptySet();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/CauseSerializer.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/CauseSerializer.java
@@ -44,8 +44,9 @@ public class CauseSerializer extends JsonSerializer<Cause> {
     public void serialize(Cause cause, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         if (!cause.getExceptions().isEmpty()) {
             ThrowableDescription first = cause.getExceptions().get(0);
-            if (first.getId() == null && first.getCause() != null) {
-                jsonGenerator.writeString(first.getCause());
+            String causeDescription = first.getCause();
+            if (first.getId() == null && causeDescription != null) {
+                jsonGenerator.writeString(causeDescription);
                 return;
             }
         } 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/CauseSerializer.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/CauseSerializer.java
@@ -24,8 +24,14 @@ import java.io.IOException;
 
 public class CauseSerializer extends JsonSerializer<Cause> {
 
-    private JsonSerializer<Object> objectSerializer;
+    private final JsonSerializer<Object> objectSerializer;
 
+    /**
+     * @deprecated Use {@link #CauseSerializer(JsonSerializer)}.
+     */
+    @Deprecated
+    // This constructor that is breaking our nullness requirements shouldn't be used and will be deleted.
+    @SuppressWarnings("nullness")
     public CauseSerializer() {
         this(null);
     }
@@ -38,7 +44,7 @@ public class CauseSerializer extends JsonSerializer<Cause> {
     public void serialize(Cause cause, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         if (!cause.getExceptions().isEmpty()) {
             ThrowableDescription first = cause.getExceptions().get(0);
-            if (null == first.getId() && null != first.getCause()) {
+            if (first.getId() == null && first.getCause() != null) {
                 jsonGenerator.writeString(first.getCause());
                 return;
             }
@@ -48,7 +54,7 @@ public class CauseSerializer extends JsonSerializer<Cause> {
 
     @Override
     public boolean isEmpty(SerializerProvider serializerProvider, Cause cause) {
-        return null == cause || (cause.getExceptions().isEmpty() && null == cause.getId() && null == cause.getMessage());
+        return cause == null || (cause.getExceptions().isEmpty() && cause.getId() == null && cause.getMessage() == null);
     }
 
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/CauseSerializer.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/CauseSerializer.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class CauseSerializer extends JsonSerializer<Cause> {
 
@@ -54,7 +55,7 @@ public class CauseSerializer extends JsonSerializer<Cause> {
     }
 
     @Override
-    public boolean isEmpty(SerializerProvider serializerProvider, Cause cause) {
+    public boolean isEmpty(SerializerProvider serializerProvider, @Nullable Cause cause) {
         return cause == null || (cause.getExceptions().isEmpty() && cause.getId() == null && cause.getMessage() == null);
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/StackTraceElementSerializer.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/serializers/StackTraceElementSerializer.java
@@ -30,7 +30,12 @@ public class StackTraceElementSerializer extends JsonSerializer<StackTraceElemen
     public void serialize(
         StackTraceElement element, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         jsonGenerator.writeStartObject();
-        jsonGenerator.writeStringField("path", element.getFileName());
+        String filename = element.getFileName();
+        if (filename != null) {
+            jsonGenerator.writeStringField("path", filename);
+        } else {
+            jsonGenerator.writeNullField("path");
+        }
         jsonGenerator.writeNumberField("line", element.getLineNumber());
         jsonGenerator.writeStringField("label", element.getClassName() + "." + element.getMethodName());
         jsonGenerator.writeEndObject();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DynamicSegmentNamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DynamicSegmentNamingStrategy.java
@@ -21,12 +21,16 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+/**
+ * @deprecated Use {@link SegmentNamingStrategy#dynamic(String)}.
+ */
+@Deprecated
 public class DynamicSegmentNamingStrategy implements SegmentNamingStrategy {
     private static final Log logger =
         LogFactory.getLog(DynamicSegmentNamingStrategy.class);
 
-    private String recognizedHosts;
-    private String fallbackName;
+    private final String recognizedHosts;
+    private final String fallbackName;
 
     /**
      * Creates an instance of {@code DynamicSegmentNamingStrategy} with the provided {@code fallbackName} and a
@@ -36,7 +40,10 @@ public class DynamicSegmentNamingStrategy implements SegmentNamingStrategy {
      *  the fallback segment name used when no host header is included in the incoming request. This will be overriden by the
      *  value of the {@code AWS_XRAY_TRACING_NAME} environment variable or {@code com.amazonaws.xray.strategy.tracingName} system
      *  property, if either are set to a non-empty value.
+     *
+     * @deprecated Use {@link SegmentNamingStrategy#dynamic(String)}.
      */
+    @Deprecated
     public DynamicSegmentNamingStrategy(String fallbackName) {
         this(fallbackName, "*");
     }
@@ -52,11 +59,17 @@ public class DynamicSegmentNamingStrategy implements SegmentNamingStrategy {
      * @param recognizedHosts
      *  the pattern to match the incoming host header value against. This pattern is compared against the incoming host header
      *  using the {@link com.amazonaws.xray.entities.SearchPattern#wildcardMatch(String, String)} method.
+     *
+     * @deprecated Use {@link SegmentNamingStrategy#dynamic(String, String)}.
      */
+    // Instance method is called before the class is initialized. This can cause undefined behavior, e.g., if getOverrideName
+    // accesses fallbackName. This class doesn't really need to be exposed to users so we suppress for now and will clean up after
+    // hiding.
+    @SuppressWarnings("nullness")
+    @Deprecated
     public DynamicSegmentNamingStrategy(String fallbackName, String recognizedHosts) {
-        this.fallbackName = fallbackName;
         String overrideName = getOverrideName();
-        if (null != overrideName) {
+        if (overrideName != null) {
             this.fallbackName = getOverrideName();
             if (logger.isInfoEnabled()) {
                 logger.info("Environment variable " + NAME_OVERRIDE_ENVIRONMENT_VARIABLE_KEY + " or system property "
@@ -65,6 +78,8 @@ public class DynamicSegmentNamingStrategy implements SegmentNamingStrategy {
                             + "strategy will be named: " + this.fallbackName
                             + " when the host header is unavilable or does not match the provided recognizedHosts pattern.");
             }
+        } else {
+            this.fallbackName = fallbackName;
         }
 
         this.recognizedHosts = recognizedHosts;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/FixedSegmentNamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/FixedSegmentNamingStrategy.java
@@ -19,24 +19,27 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+/**
+ * @deprecated Use {@link SegmentNamingStrategy#fixed(String)}.
+ */
+@Deprecated
 public class FixedSegmentNamingStrategy implements SegmentNamingStrategy {
     private static final Log logger =
         LogFactory.getLog(FixedSegmentNamingStrategy.class);
 
-    private String fixedName;
+    private final String fixedName;
 
     /**
-     *
-     *
-     * @param fixedName
-     *  the fixed name to use for all segments generated for incoming requests. This will be overriden by the value of the
-     *  {@code AWS_XRAY_TRACING_NAME} environment variable or {@code com.amazonaws.xray.strategy.tracingName} system property,
-     *  if either are set to a non-empty value.
+     * @deprecated Use {@link SegmentNamingStrategy#fixed(String)}.
      */
-    public FixedSegmentNamingStrategy(String fixedName) {
-        this.fixedName = fixedName;
+    // Instance method is called before the class is initialized. This can cause undefined behavior, e.g., if getOverrideName
+    // accesses fixedName. This class doesn't really need to be exposed to users so we suppress for now and will clean up after
+    // hiding.
+    @SuppressWarnings("nullness")
+    @Deprecated
+    public FixedSegmentNamingStrategy(String name) {
         String overrideName = getOverrideName();
-        if (null != overrideName) {
+        if (overrideName != null) {
             this.fixedName = overrideName;
             if (logger.isInfoEnabled()) {
                 logger.info("Environment variable " + NAME_OVERRIDE_ENVIRONMENT_VARIABLE_KEY + " or system property "
@@ -44,6 +47,8 @@ public class FixedSegmentNamingStrategy implements SegmentNamingStrategy {
                             + " set. Overriding FixedSegmentNamingStrategy constructor argument. Segments generated with this "
                             + "strategy will be named: " + this.fixedName + ".");
             }
+        } else {
+            this.fixedName = name;
         }
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/SegmentNamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/SegmentNamingStrategy.java
@@ -22,6 +22,18 @@ import javax.servlet.http.HttpServletRequest;
 public interface SegmentNamingStrategy {
 
     /**
+     * Environment variable key used to override the default segment name used by implementors of {@code SegmentNamingStrategy}.
+     * Takes precedence over any system property, web.xml configuration value, or constructor value used for a fixed segment name.
+     */
+    String NAME_OVERRIDE_ENVIRONMENT_VARIABLE_KEY = "AWS_XRAY_TRACING_NAME";
+
+    /**
+     * System property key used to override the default segment name used by implementors of {@code SegmentNamingStrategy}.
+     * Takes precedence over any web.xml configuration value or constructor value used for a fixed segment name.
+     */
+    String NAME_OVERRIDE_SYSTEM_PROPERTY_KEY = "com.amazonaws.xray.strategy.tracingName";
+
+    /**
      * Returns a {@link SegmentNamingStrategy} that assigns the provided {@code name} to all segments generated for incoming
      * requests. This will be ignored and will use the the value of the {@code AWS_XRAY_TRACING_NAME} environment variable or
      * {@code com.amazonaws.xray.strategy.tracingName} system property if set.
@@ -58,18 +70,6 @@ public interface SegmentNamingStrategy {
     static SegmentNamingStrategy dynamic(String fallbackName, String recognizedHosts) {
         return new DynamicSegmentNamingStrategy(fallbackName, recognizedHosts);
     }
-
-    /**
-     * Environment variable key used to override the default segment name used by implementors of {@code SegmentNamingStrategy}.
-     * Takes precedence over any system property, web.xml configuration value, or constructor value used for a fixed segment name.
-     */
-    String NAME_OVERRIDE_ENVIRONMENT_VARIABLE_KEY = "AWS_XRAY_TRACING_NAME";
-
-    /**
-     * System property key used to override the default segment name used by implementors of {@code SegmentNamingStrategy}.
-     * Takes precedence over any web.xml configuration value or constructor value used for a fixed segment name.
-     */
-    String NAME_OVERRIDE_SYSTEM_PROPERTY_KEY = "com.amazonaws.xray.strategy.tracingName";
 
     String nameForRequest(HttpServletRequest request);
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/SegmentNamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/SegmentNamingStrategy.java
@@ -16,8 +16,8 @@
 package com.amazonaws.xray.strategy;
 
 import com.amazonaws.xray.entities.StringValidator;
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface SegmentNamingStrategy {
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/SegmentNamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/SegmentNamingStrategy.java
@@ -16,9 +16,48 @@
 package com.amazonaws.xray.strategy;
 
 import com.amazonaws.xray.entities.StringValidator;
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 
 public interface SegmentNamingStrategy {
+
+    /**
+     * Returns a {@link SegmentNamingStrategy} that assigns the provided {@code name} to all segments generated for incoming
+     * requests. This will be ignored and will use the the value of the {@code AWS_XRAY_TRACING_NAME} environment variable or
+     * {@code com.amazonaws.xray.strategy.tracingName} system property if set.
+     */
+    static SegmentNamingStrategy fixed(String name) {
+        return new FixedSegmentNamingStrategy(name);
+    }
+
+    /**
+     * Returns a {@link SegmentNamingStrategy} that names segments based on the {@code Host} header of incoming requests,
+     * accepting any {@code Host} header value.
+     *
+     * @param fallbackName
+     *  the fallback segment name used when no host header is included in the incoming request or the incoming host header value
+     *  does not match the provided pattern. This will be overriden by the value of the {@code AWS_XRAY_TRACING_NAME} environment
+     *  variable or {@code com.amazonaws.xray.strategy.tracingName} system property, if either are set to a non-empty value.
+     */
+    static SegmentNamingStrategy dynamic(String fallbackName) {
+        return dynamic(fallbackName, "*");
+    }
+
+    /**
+     * Returns a {@link SegmentNamingStrategy} that names segments based on the {@code Host} header of incoming requests,
+     * accepting only recognized {@code Host} header values.
+     *
+     * @param fallbackName
+     *  the fallback segment name used when no host header is included in the incoming request or the incoming host header value
+     *  does not match the provided pattern. This will be overriden by the value of the {@code AWS_XRAY_TRACING_NAME} environment
+     *  variable or {@code com.amazonaws.xray.strategy.tracingName} system property, if either are set to a non-empty value.
+     * @param recognizedHosts
+     *  the pattern to match the incoming host header value against. This pattern is compared against the incoming host header
+     *  using the {@link com.amazonaws.xray.entities.SearchPattern#wildcardMatch(String, String)} method.
+     */
+    static SegmentNamingStrategy dynamic(String fallbackName, String recognizedHosts) {
+        return new DynamicSegmentNamingStrategy(fallbackName, recognizedHosts);
+    }
 
     /**
      * Environment variable key used to override the default segment name used by implementors of {@code SegmentNamingStrategy}.
@@ -34,6 +73,7 @@ public interface SegmentNamingStrategy {
 
     String nameForRequest(HttpServletRequest request);
 
+    @Nullable
     default String getOverrideName() {
         String environmentNameOverrideValue = System.getenv(NAME_OVERRIDE_ENVIRONMENT_VARIABLE_KEY);
         String systemNameOverrideValue = System.getProperty(NAME_OVERRIDE_SYSTEM_PROPERTY_KEY);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
@@ -27,6 +27,7 @@ import java.time.Clock;
 import java.time.Instant;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class CentralizedSamplingStrategy implements SamplingStrategy {
     private static final Log logger = LogFactory.getLog(TargetPoller.class);
@@ -38,7 +39,12 @@ public class CentralizedSamplingStrategy implements SamplingStrategy {
         SecureRandom rand = new SecureRandom();
         byte[] bytes = new byte[12];
         rand.nextBytes(bytes);
-        clientID = ByteUtils.byteArrayToHexString(bytes);
+        String clientId = ByteUtils.byteArrayToHexString(bytes);
+        if (clientId == null) {
+            // Satisfy checker framework.
+            throw new IllegalStateException();
+        }
+        clientID = clientId;
     }
 
     private final CentralizedManifest manifest;
@@ -64,6 +70,7 @@ public class CentralizedSamplingStrategy implements SamplingStrategy {
         this.targetPoller = new TargetPoller(client, manifest, Clock.systemUTC());
     }
 
+    @Nullable
     public URL getSamplingManifestURL() {
         return this.fallback.getSamplingManifestURL();
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/LocalizedSamplingStrategy.java
@@ -34,8 +34,16 @@ public class LocalizedSamplingStrategy implements SamplingStrategy {
     private static final Log logger =
         LogFactory.getLog(LocalizedSamplingStrategy.class);
 
-    private static final URL DEFAULT_RULES =
-        LocalizedSamplingStrategy.class.getResource("/com/amazonaws/xray/strategy/sampling/DefaultSamplingRules.json");
+    private static final URL DEFAULT_RULES;
+    static {
+        URL defaultRules =
+            LocalizedSamplingStrategy.class.getResource("/com/amazonaws/xray/strategy/sampling/DefaultSamplingRules.json");
+        if (defaultRules == null) {
+            throw new IllegalStateException("Could not find DefaultSamplingRules.json on the classpath. This is a packaging bug "
+                                            + "- did you correctly shade this library?");
+        }
+        DEFAULT_RULES = defaultRules;
+    }
 
     private static final ObjectMapper MAPPER =
         new ObjectMapper()

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingRequest.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingRequest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents the input request to the sampler. Contains attributes relevant to
@@ -31,19 +32,25 @@ public class SamplingRequest {
 
     private String roleArn;
 
+    @Nullable
     private String resourceArn;
 
-    private String service;
+    @Nullable
+    private final String service;
 
-    private String host;
+    @Nullable
+    private final String host;
 
-    private String method;
+    @Nullable
+    private final String method;
 
-    private String url;
+    @Nullable
+    private final String url;
 
+    @Nullable
     private String serviceType;
 
-    private Map<String, String> attributes;
+    private final Map<String, String> attributes;
 
     /**
      * @param roleArn
@@ -68,13 +75,13 @@ public class SamplingRequest {
      */
     public SamplingRequest(
             String roleArn,
-            String resourceArn,
-            String service,
-            String host,
-            String method,
-            String url,
-            String serviceType,
-            Map<String, String> attributes
+            @Nullable String resourceArn,
+            @Nullable String service,
+            @Nullable String host,
+            @Nullable String method,
+            @Nullable String url,
+            @Nullable String serviceType,
+            @Nullable Map<String, String> attributes
     ) {
         Objects.requireNonNull(roleArn, "RoleARN can not be null");
 
@@ -88,12 +95,20 @@ public class SamplingRequest {
         this.attributes = attributes != null ? attributes : Collections.emptyMap();
     }
 
-    public SamplingRequest(String service, String host, String url, String method, String serviceType) {
+    public SamplingRequest(
+        @Nullable String service,
+        @Nullable String host,
+        @Nullable String url,
+        @Nullable String method,
+        @Nullable String serviceType) {
         this.service = service;
         this.host = host;
         this.url = url;
         this.method = method;
         this.serviceType = serviceType;
+
+        roleArn = "";
+        attributes = Collections.emptyMap();
     }
 
     public Optional<String> getAccountId() {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingResponse.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/SamplingResponse.java
@@ -16,6 +16,7 @@
 package com.amazonaws.xray.strategy.sampling;
 
 import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents the sampling decision output by the sampler. Used by the SDK to
@@ -25,6 +26,7 @@ public class SamplingResponse {
 
     private boolean sampled;
 
+    @Nullable
     private String ruleName;
 
     /**

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifest.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifest.java
@@ -30,6 +30,8 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 public class CentralizedManifest implements Manifest {
 
@@ -39,6 +41,7 @@ public class CentralizedManifest implements Manifest {
     private volatile LinkedHashMap<String, CentralizedRule> rules;
 
     // Customer default rule that matches against everything.
+    @MonotonicNonNull
     private volatile CentralizedRule defaultRule;
 
     // Timestamp of last known valid refresh. Kept volatile for swapping with new timestamp on refresh.
@@ -70,6 +73,8 @@ public class CentralizedManifest implements Manifest {
     }
 
     @Override
+    // TODO(anuraaga): It seems like this should never return null, check where defaultRule is guaranteed to be present and remove
+    @Nullable
     public Rule match(SamplingRequest req, Instant now) {
         for (CentralizedRule r : rules.values()) {
             if (!r.match(req)) {
@@ -79,12 +84,7 @@ public class CentralizedManifest implements Manifest {
             return r;
         }
 
-        CentralizedRule r = defaultRule;
-        if (r != null) {
-            return r;
-        }
-
-        return null;
+        return defaultRule;
     }
 
     public void putRules(List<SamplingRule> inputs, Instant now) {
@@ -177,11 +177,8 @@ public class CentralizedManifest implements Manifest {
             if (i.getRuleName().equals(CentralizedRule.DEFAULT_RULE_NAME)) {
                 continue;
             }
-            CentralizedRule r;
-
-            if (old.containsKey(i.getRuleName())) {
-                r = old.get(i.getRuleName());
-            } else {
+            CentralizedRule r = old.get(i.getRuleName());
+            if (r == null) {
                 r = new CentralizedRule(i, new RandImpl());
             }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifest.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifest.java
@@ -30,8 +30,8 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class CentralizedManifest implements Manifest {
 
@@ -56,6 +56,7 @@ public class CentralizedManifest implements Manifest {
         return rules;
     }
 
+    @Nullable
     public CentralizedRule getDefaultRule() {
         return defaultRule;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/Manifest.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/Manifest.java
@@ -18,7 +18,9 @@ package com.amazonaws.xray.strategy.sampling.manifest;
 import com.amazonaws.xray.strategy.sampling.SamplingRequest;
 import com.amazonaws.xray.strategy.sampling.rule.Rule;
 import java.time.Instant;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Manifest {
+    @Nullable
     Rule match(SamplingRequest req, Instant now);
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/SamplingRuleManifest.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/SamplingRuleManifest.java
@@ -18,17 +18,21 @@ package com.amazonaws.xray.strategy.sampling.manifest;
 import com.amazonaws.xray.strategy.sampling.rule.SamplingRule;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SamplingRuleManifest {
+    @Nullable
     private List<SamplingRule> rules;
 
     @JsonProperty("default") // default is a reserved word
+    @Nullable
     private SamplingRule defaultRule;
     private int version;
 
     /**
      * @return the rules
      */
+    @Nullable
     public List<SamplingRule> getRules() {
         return rules;
     }
@@ -43,6 +47,7 @@ public class SamplingRuleManifest {
     /**
      * @return the defaultRule
      */
+    @Nullable
     public SamplingRule getDefaultRule() {
         return defaultRule;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
@@ -33,9 +33,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class RulePoller {
     private static final Log logger = LogFactory.getLog(RulePoller.class);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
@@ -29,9 +29,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TargetPoller {
     private static final Log logger = LogFactory.getLog(TargetPoller.class);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Represents a customer-defined sampling rule. A rule contains the matchers
@@ -49,19 +50,20 @@ public class CentralizedRule implements Rule, Comparable<CentralizedRule> {
     private int priority = 10000; // Default
 
     // Rule Name identifying this rule.
-    private String name;
+    private final String name;
 
-    private CentralizedReservoir centralizedReservoir;
+    private final CentralizedReservoir centralizedReservoir;
     private double fixedRate;
 
-    private Statistics statistics;
+    private final Statistics statistics;
 
     // Null for customer default rule.
+    @Nullable
     private Matchers matchers;
 
-    private Rand rand;
+    private final Rand rand;
 
-    private ReadWriteLock lock;
+    private final ReadWriteLock lock;
 
     public CentralizedRule(SamplingRule input, Rand rand) {
         this.name = input.getRuleName();
@@ -257,7 +259,7 @@ public class CentralizedRule implements Rule, Comparable<CentralizedRule> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) {
             return true;
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/Matchers.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/Matchers.java
@@ -61,8 +61,6 @@ public class Matchers {
             if (!SearchPattern.wildcardMatch(a.getValue(), requestAttributes.get(a.getKey()))) {
                 return false;
             }
-
-            continue;
         }
 
         // Missing string parameters from the sampling request are replaced with ""s to ensure they match against *

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/SamplingRule.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/SamplingRule.java
@@ -17,12 +17,17 @@ package com.amazonaws.xray.strategy.sampling.rule;
 
 import com.amazonaws.xray.entities.SearchPattern;
 import com.amazonaws.xray.strategy.sampling.reservoir.Reservoir;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SamplingRule {
 
+    @Nullable
     private String host;
+    @Nullable
     private String serviceName;
+    @Nullable
     private String httpMethod;
+    @Nullable
     private String urlPath;
     private int fixedTarget = -1;
     private float rate = -1.0f;
@@ -64,6 +69,7 @@ public class SamplingRule {
     /**
      * @return the serviceName
      */
+    @Nullable
     public String getServiceName() {
         return serviceName;
     }
@@ -79,6 +85,7 @@ public class SamplingRule {
     /**
      * @return the host
      */
+    @Nullable
     public String getHost() {
         return host;
     }
@@ -87,13 +94,14 @@ public class SamplingRule {
      * @param host
      *            the host to set
      */
-    public void setHost(String host) {
+    public void setHost(@Nullable String host) {
         this.host = host;
     }
 
     /**
      * @return the httpMethod
      */
+    @Nullable
     public String getHttpMethod() {
         return httpMethod;
     }
@@ -109,6 +117,7 @@ public class SamplingRule {
     /**
      * @return the urlPath
      */
+    @Nullable
     public String getUrlPath() {
         return urlPath;
     }
@@ -179,9 +188,9 @@ public class SamplingRule {
      * @return whether or not this rule applies to the incoming request
      */
     public boolean appliesTo(String requestHost, String requestPath, String requestMethod) {
-        return (null == requestHost || SearchPattern.wildcardMatch(host, requestHost)) &&
-            (null == requestPath || SearchPattern.wildcardMatch(urlPath, requestPath)) &&
-            (null == requestMethod || SearchPattern.wildcardMatch(httpMethod, requestMethod));
+        return (requestHost == null || SearchPattern.wildcardMatch(host, requestHost)) &&
+               (requestPath == null || SearchPattern.wildcardMatch(urlPath, requestPath)) &&
+               (requestMethod == null || SearchPattern.wildcardMatch(httpMethod, requestMethod));
     }
 
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/ByteUtils.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/ByteUtils.java
@@ -15,6 +15,8 @@
 
 package com.amazonaws.xray.utils;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 public class ByteUtils {
     static final String HEXES = "0123456789ABCDEF";
@@ -26,6 +28,7 @@ public class ByteUtils {
      * @param raw - Byte array
      * @return String - Hexadecimal representation of the byte array.
      */
+    @Nullable
     public static String byteArrayToHexString(byte[] raw) {
         if (raw == null) {
             return null;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/ContainerInsightsUtil.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/ContainerInsightsUtil.java
@@ -46,6 +46,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Utility class for querying configuration information from ContainerInsights enabled Kubernetes clusters.
@@ -71,13 +72,15 @@ public class ContainerInsightsUtil {
      *
      * @return the name
      */
+    @Nullable
     public static String getClusterName() {
         if (isK8s()) {
             CloseableHttpClient client = getHttpClient();
             HttpGet getRequest = new HttpGet(K8S_URL + CI_CONFIGMAP_PATH);
 
-            if (getK8sCredentialHeader() != null) {
-                getRequest.setHeader(AUTH_HEADER_NAME, getK8sCredentialHeader());
+            String k8sCredentialHeader = getK8sCredentialHeader();
+            if (k8sCredentialHeader != null) {
+                getRequest.setHeader(AUTH_HEADER_NAME, k8sCredentialHeader);
             }
 
             try {
@@ -137,6 +140,7 @@ public class ContainerInsightsUtil {
         return HttpClientBuilder.create().setDefaultRequestConfig(config).build();
     }
 
+    @Nullable
     private static KeyStore getK8sKeystore() {
 
         InputStream certificateFile = null;
@@ -181,6 +185,7 @@ public class ContainerInsightsUtil {
         }
     }
 
+    @Nullable
     private static String getK8sCredentialHeader() {
 
         BufferedReader tokenReader = null;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/DockerUtils.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/DockerUtils.java
@@ -25,10 +25,10 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import javax.annotation.Nullable;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Utility class to get metadata for dockerized containers

--- a/aws-xray-recorder-sdk-log4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-log4j/build.gradle.kts
@@ -8,9 +8,7 @@ dependencies {
 
     compileOnly("org.apache.logging.log4j:log4j-api:2.13.3")
 
-    testImplementation("junit:junit:4.12")
     testImplementation("org.apache.logging.log4j:log4j-api:2.13.3")
-    testImplementation("org.mockito:mockito-core:2.23.4")
 }
 
 description = "AWS X-Ray Recorder SDK for Java – Log4J Trace ID Injection"

--- a/aws-xray-recorder-sdk-metrics/build.gradle.kts
+++ b/aws-xray-recorder-sdk-metrics/build.gradle.kts
@@ -9,8 +9,6 @@ dependencies {
     implementation(project(":aws-xray-recorder-sdk-aws-sdk-core"))
 
     testImplementation("com.github.stefanbirkner:system-rules:1.16.0")
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-core:2.23.4")
     testImplementation("org.powermock:powermock-module-junit4:2.0.2")
     testImplementation("org.powermock:powermock-api-mockito2:2.0.2")
 }

--- a/aws-xray-recorder-sdk-slf4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-slf4j/build.gradle.kts
@@ -9,8 +9,6 @@ dependencies {
     compileOnly("org.slf4j:slf4j-api:1.7.30")
 
     testImplementation("ch.qos.logback:logback-classic:1.3.0-alpha5")
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-core:2.23.4")
 }
 
 description = "AWS X-Ray Recorder SDK for Java - SLF4J Trace ID Injection"

--- a/aws-xray-recorder-sdk-spring/build.gradle.kts
+++ b/aws-xray-recorder-sdk-spring/build.gradle.kts
@@ -14,9 +14,6 @@ dependencies {
     implementation("org.springframework:spring-aspects:4.3.12.RELEASE")
 
     compileOnly("org.springframework.data:spring-data-commons:2.0.0.RELEASE")
-
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-all:1.10.19")
 }
 
 description = "AWS X-Ray Recorder SDK for Java - Spring Framework Interceptors"

--- a/aws-xray-recorder-sdk-spring/src/test/java/com/amazonaws/xray/spring/aop/BaseAbstractXRayInterceptorTest.java
+++ b/aws-xray-recorder-sdk-spring/src/test/java/com/amazonaws/xray/spring/aop/BaseAbstractXRayInterceptorTest.java
@@ -29,13 +29,16 @@ import java.util.Optional;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-@RunWith(MockitoJUnitRunner.class)
 public class BaseAbstractXRayInterceptorTest {
+
+    @Rule
+    public MockitoRule mocks = MockitoJUnit.rule();
 
     static class ImplementedXRayInterceptor extends BaseAbstractXRayInterceptor {
         @Override

--- a/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 dependencies {
     implementation(project(":aws-xray-recorder-sdk-core"))
 
-    testImplementation("junit:junit:4.12")
-
     compileOnly("org.apache.tomcat:tomcat-jdbc:8.0.36")
 }
 

--- a/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
@@ -7,8 +7,6 @@ dependencies {
     implementation(project(":aws-xray-recorder-sdk-core"))
 
     compileOnly("org.apache.tomcat:tomcat-jdbc:8.0.36")
-
-    testImplementation("junit:junit:4.12")
 }
 
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK PostgreSQL Interceptor"

--- a/aws-xray-recorder-sdk-sql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 
 dependencies {
     implementation(project(":aws-xray-recorder-sdk-core"))
-
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-all:1.10.19")
 }
 
 description = "AWS X-Ray Recorder SDK for Java - SQL Interceptor"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,11 @@ allprojects {
         }
 
         dependencies {
+            add("compileOnly", "org.checkerframework:checker-qual:3.4.1")
+            add("testCompileOnly", "org.checkerframework:checker-qual:3.4.1")
+            add("checkerFramework", "org.checkerframework:checker:3.4.1")
+
+
             add("errorprone", "com.google.errorprone:error_prone_core:2.4.0")
             if (!JavaVersion.current().isJava9Compatible) {
                 add("errorproneJavac", "com.google.errorprone:javac:9+181-r4173-1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ allprojects {
             excludeTests = true
 
             // TODO(anuraaga): Enable on all projects.
-            skipCheckerFramework = project.name != "aws-xray-recorder-sdk-core"
+            skipCheckerFramework = project.name != "aws-xray-recorder-sdk-core" || JavaVersion.current() != JavaVersion.VERSION_11
         }
 
         dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,15 @@ allprojects {
 
         configure<CheckerFrameworkExtension> {
             checkers = listOf("org.checkerframework.checker.nullness.NullnessChecker")
+
+            extraJavacArgs = listOf(
+                    "-AsuppressWarnings=type.anno.before.modifier"
+            )
+
+            excludeTests = true
+
+            // TODO(anuraaga): Enable on all projects.
+            skipCheckerFramework = project.name != "aws-xray-recorder-sdk-core"
         }
 
         dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,12 @@
 import net.ltgt.gradle.errorprone.errorprone
 
 import nl.javadude.gradle.plugins.license.LicenseExtension
-
+import org.checkerframework.gradle.plugin.CheckerFrameworkExtension
 
 plugins {
     id("com.github.hierynomus.license") apply false
     id("net.ltgt.errorprone") apply false
+    id("org.checkerframework") apply false
 }
 
 allprojects {
@@ -46,6 +47,7 @@ allprojects {
     plugins.withId("java-library") {
         plugins.apply("checkstyle")
         plugins.apply("net.ltgt.errorprone")
+        plugins.apply("org.checkerframework")
 
         configure<JavaPluginExtension> {
             sourceCompatibility = JavaVersion.VERSION_1_8
@@ -63,6 +65,10 @@ allprojects {
                     output.dir(mapOf("builtBy" to "generateProperties"), propertiesDir)
                 }
             }
+        }
+
+        configure<CheckerFrameworkExtension> {
+            checkers = listOf("org.checkerframework.checker.nullness.NullnessChecker")
         }
 
         dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,8 +81,12 @@ allprojects {
         }
 
         dependencies {
+            add("testImplementation", "junit:junit")
+            add("testImplementation", "org.assertj:assertj-core")
+            add("testImplementation", "org.mockito:mockito-core")
+
             add("compileOnly", "org.checkerframework:checker-qual:3.4.1")
-            add("testCompileOnly", "org.checkerframework:checker-qual:3.4.1")
+            add("testImplementation", "org.checkerframework:checker-qual:3.4.1")
             add("checkerFramework", "org.checkerframework:checker:3.4.1")
 
 

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -23,6 +23,16 @@ val DEPENDENCY_SETS = listOf(
                 "org.assertj",
                 "3.16.1",
                 listOf("assertj-core")
+        ),
+        DependencySet(
+                "junit",
+                "4.12",
+                listOf("junit")
+        ),
+        DependencySet(
+                "org.mockito",
+                "2.28.2",
+                listOf("mockito-all", "mockito-core")
         )
 )
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,14 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+      <version>3.4.1</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
   <distributionManagement>
     <repository>
       <id>sonatype-nexus-staging</id>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ pluginManagement {
     plugins {
         id("com.github.hierynomus.license") version "0.15.0"
         id("net.ltgt.errorprone") version "1.2.1"
+        id("org.checkerframework") version "0.5.4"
     }
 }
 


### PR DESCRIPTION
Adding a nullness checker makes it mostly impossible for our code to throw NPE, except for some occasional suppressions. That still doesn't mean it can't ever crash based on how an app calls the functions, but it's a good check either way.

While going through all the checks, I added some general cleanups as well, most of them are IntelliJ's automatic cleanups like marking final variables as final. Also made some private constants immutable and changed a lot of `null != foo` to `foo != null`.

Vast majority is adding annotations, but there are a few places where a missing null check was added, mostly exceptional branches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
