### PR TITLE
Fix JSON parsing of GetSamplingRules and SamplingTargets endpoint

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
@@ -17,26 +17,35 @@ package com.amazonaws.xray.internal;
 
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.AmazonWebServiceResult;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.xray.model.GetSamplingRulesRequest;
 import com.amazonaws.services.xray.model.GetSamplingRulesResult;
 import com.amazonaws.services.xray.model.GetSamplingTargetsRequest;
 import com.amazonaws.services.xray.model.GetSamplingTargetsResult;
 import com.amazonaws.xray.config.DaemonConfiguration;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import javax.annotation.Nullable;
 
 /**
@@ -47,11 +56,15 @@ import javax.annotation.Nullable;
  */
 public class UnsignedXrayClient {
 
+    private static final PropertyName HTTP_METHOD = PropertyName.construct("HTTPMethod");
+    private static final PropertyName URL_PATH = PropertyName.construct("URLPath");
+
     // Visible for testing
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .setSerializationInclusion(Include.NON_EMPTY)
             // Use deprecated field to support older Jackson versions for now.
             .setPropertyNamingStrategy(PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE)
+            .registerModule(new SimpleModule().addDeserializer(Date.class, new FloatDateDeserializer()))
             .setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
                 @Override
                 public boolean hasIgnoreMarker(AnnotatedMember m) {
@@ -63,6 +76,17 @@ public class UnsignedXrayClient {
                         return true;
                     }
                     return super.hasIgnoreMarker(m);
+                }
+
+                @Override
+                public PropertyName findNameForDeserialization(Annotated a) {
+                    if (a.getName().equals("hTTPMethod")) {
+                        return HTTP_METHOD;
+                    }
+                    if (a.getName().equals("uRLPath")) {
+                        return URL_PATH;
+                    }
+                    return super.findNameForDeserialization(a);
                 }
             });
     private static final int TIME_OUT_MILLIS = 2000;
@@ -165,6 +189,39 @@ public class UnsignedXrayClient {
         int b;
         while ((b = is.read()) != -1) {
             os.write(b);
+        }
+    }
+
+    private static class FloatDateDeserializer extends StdDeserializer<Date> {
+
+        private static final int AWS_DATE_MILLI_SECOND_PRECISION = 3;
+
+        private FloatDateDeserializer() {
+            super(Date.class);
+        }
+
+        @Override
+        public Date deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return parseServiceSpecificDate(p.getText());
+        }
+
+        // Copied from AWS SDK https://github.com/aws/aws-sdk-java/blob/7b1e5b87b0bf03456df9e77716b14731adf9a7a7/aws-java-sdk-core/src/main/java/com/amazonaws/util/DateUtils.java#L239https://github.com/aws/aws-sdk-java/blob/7b1e5b87b0bf03456df9e77716b14731adf9a7a7/aws-java-sdk-core/src/main/java/com/amazonaws/util/DateUtils.java#L239
+        /**
+         * Parses the given date string returned by the AWS service into a Date
+         * object.
+         */
+        private static Date parseServiceSpecificDate(String dateString) {
+            if (dateString == null) {
+                return null;
+            }
+            try {
+                BigDecimal dateValue = new BigDecimal(dateString);
+                return new Date(dateValue.scaleByPowerOfTen(
+                    AWS_DATE_MILLI_SECOND_PRECISION).longValue());
+            } catch (NumberFormatException nfe) {
+                throw new SdkClientException("Unable to parse date : "
+                                             + dateString, nfe);
+            }
         }
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/UnsignedXrayClient.java
@@ -102,7 +102,7 @@ public class UnsignedXrayClient {
     UnsignedXrayClient(String endpoint) {
         try {
             getSamplingRulesEndpoint = new URL(endpoint + "/GetSamplingRules");
-            getSamplingTargetsEndpoint = new URL(endpoint + "/GetSamplingTargets");
+            getSamplingTargetsEndpoint = new URL(endpoint + "/SamplingTargets");
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid URL: " + endpoint, e);
         }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
@@ -245,7 +245,7 @@ public class UnsignedXrayClientTest {
         GetSamplingTargetsResult expected = OBJECT_MAPPER.readValue(SAMPLING_TARGETS, GetSamplingTargetsResult.class);
         assertThat(expected).isEqualTo(result);
 
-        verify(postRequestedFor(urlEqualTo("/GetSamplingTargets"))
+        verify(postRequestedFor(urlEqualTo("/SamplingTargets"))
                        .withHeader("Content-Type", equalTo("application/json"))
                        .withRequestBody(equalToJson("{"
                                                     + " \"SamplingStatisticsDocuments\": ["

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/UnsignedXrayClientTest.java
@@ -35,7 +35,6 @@ import com.amazonaws.services.xray.model.GetSamplingTargetsRequest;
 import com.amazonaws.services.xray.model.GetSamplingTargetsResult;
 import com.amazonaws.services.xray.model.SamplingStatisticsDocument;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import java.util.Date;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -44,6 +43,170 @@ public class UnsignedXrayClientTest {
 
     @ClassRule
     public static WireMockClassRule server = new WireMockClassRule(wireMockConfig().dynamicPort());
+
+    private static final String SAMPLING_RULES =
+        "{\n"
+        + "    \"SamplingRuleRecords\": [\n"
+        + "        {\n"
+        + "            \"SamplingRule\": {\n"
+        + "                \"RuleName\": \"Default\",\n"
+        + "                \"RuleARN\": \"arn:aws:xray:us-east-1::sampling-rule/Default\",\n"
+        + "                \"ResourceARN\": \"*\",\n"
+        + "                \"Priority\": 10000,\n"
+        + "                \"FixedRate\": 0.01,\n"
+        + "                \"ReservoirSize\": 0,\n"
+        + "                \"ServiceName\": \"*\",\n"
+        + "                \"ServiceType\": \"*\",\n"
+        + "                \"Host\": \"*\",\n"
+        + "                \"HTTPMethod\": \"*\",\n"
+        + "                \"URLPath\": \"*\",\n"
+        + "                \"Version\": 1,\n"
+        + "                \"Attributes\": {}\n"
+        + "            },\n"
+        + "            \"CreatedAt\": 0.0,\n"
+        + "            \"ModifiedAt\": 1530558121.0\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"SamplingRule\": {\n"
+        + "                \"RuleName\": \"base-scorekeep\",\n"
+        + "                \"RuleARN\": \"arn:aws:xray:us-east-1::sampling-rule/base-scorekeep\",\n"
+        + "                \"ResourceARN\": \"*\",\n"
+        + "                \"Priority\": 9000,\n"
+        + "                \"FixedRate\": 0.1,\n"
+        + "                \"ReservoirSize\": 2,\n"
+        + "                \"ServiceName\": \"Scorekeep\",\n"
+        + "                \"ServiceType\": \"*\",\n"
+        + "                \"Host\": \"*\",\n"
+        + "                \"HTTPMethod\": \"*\",\n"
+        + "                \"URLPath\": \"*\",\n"
+        + "                \"Version\": 1,\n"
+        + "                \"Attributes\": {}\n"
+        + "            },\n"
+        + "            \"CreatedAt\": 1530573954.0,\n"
+        + "            \"ModifiedAt\": 1530920505.0\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"SamplingRule\": {\n"
+        + "                \"RuleName\": \"polling-scorekeep\",\n"
+        + "                \"RuleARN\": \"arn:aws:xray:us-east-1::sampling-rule/polling-scorekeep\",\n"
+        + "                \"ResourceARN\": \"*\",\n"
+        + "                \"Priority\": 5000,\n"
+        + "                \"FixedRate\": 0.003,\n"
+        + "                \"ReservoirSize\": 0,\n"
+        + "                \"ServiceName\": \"Scorekeep\",\n"
+        + "                \"ServiceType\": \"*\",\n"
+        + "                \"Host\": \"*\",\n"
+        + "                \"HTTPMethod\": \"GET\",\n"
+        + "                \"URLPath\": \"/api/state/*\",\n"
+        + "                \"Version\": 1,\n"
+        + "                \"Attributes\": {}\n"
+        + "            },\n"
+        + "            \"CreatedAt\": 1530918163.0,\n"
+        + "            \"ModifiedAt\": 1530918163.0\n"
+        + "        }\n"
+        + "    ]\n"
+        + "}{\n"
+        + "    \"SamplingRuleRecords\": [\n"
+        + "        {\n"
+        + "            \"SamplingRule\": {\n"
+        + "                \"RuleName\": \"Default\",\n"
+        + "                \"RuleARN\": \"arn:aws:xray:us-east-1::sampling-rule/Default\",\n"
+        + "                \"ResourceARN\": \"*\",\n"
+        + "                \"Priority\": 10000,\n"
+        + "                \"FixedRate\": 0.01,\n"
+        + "                \"ReservoirSize\": 0,\n"
+        + "                \"ServiceName\": \"*\",\n"
+        + "                \"ServiceType\": \"*\",\n"
+        + "                \"Host\": \"*\",\n"
+        + "                \"HTTPMethod\": \"*\",\n"
+        + "                \"URLPath\": \"*\",\n"
+        + "                \"Version\": 1,\n"
+        + "                \"Attributes\": {}\n"
+        + "            },\n"
+        + "            \"CreatedAt\": 0.0,\n"
+        + "            \"ModifiedAt\": 1530558121.0\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"SamplingRule\": {\n"
+        + "                \"RuleName\": \"base-scorekeep\",\n"
+        + "                \"RuleARN\": \"arn:aws:xray:us-east-1::sampling-rule/base-scorekeep\",\n"
+        + "                \"ResourceARN\": \"*\",\n"
+        + "                \"Priority\": 9000,\n"
+        + "                \"FixedRate\": 0.1,\n"
+        + "                \"ReservoirSize\": 2,\n"
+        + "                \"ServiceName\": \"Scorekeep\",\n"
+        + "                \"ServiceType\": \"*\",\n"
+        + "                \"Host\": \"*\",\n"
+        + "                \"HTTPMethod\": \"*\",\n"
+        + "                \"URLPath\": \"*\",\n"
+        + "                \"Version\": 1,\n"
+        + "                \"Attributes\": {}\n"
+        + "            },\n"
+        + "            \"CreatedAt\": 1530573954.0,\n"
+        + "            \"ModifiedAt\": 1530920505.0\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"SamplingRule\": {\n"
+        + "                \"RuleName\": \"polling-scorekeep\",\n"
+        + "                \"RuleARN\": \"arn:aws:xray:us-east-1::sampling-rule/polling-scorekeep\",\n"
+        + "                \"ResourceARN\": \"*\",\n"
+        + "                \"Priority\": 5000,\n"
+        + "                \"FixedRate\": 0.003,\n"
+        + "                \"ReservoirSize\": 0,\n"
+        + "                \"ServiceName\": \"Scorekeep\",\n"
+        + "                \"ServiceType\": \"*\",\n"
+        + "                \"Host\": \"*\",\n"
+        + "                \"HTTPMethod\": \"GET\",\n"
+        + "                \"URLPath\": \"/api/state/*\",\n"
+        + "                \"Version\": 1,\n"
+        + "                \"Attributes\": {}\n"
+        + "            },\n"
+        + "            \"CreatedAt\": 1530918163.0,\n"
+        + "            \"ModifiedAt\": 1530918163.0\n"
+        + "        }\n"
+        + "    ]\n"
+        + "}";
+
+    private static final String SAMPLING_TARGETS =
+        "{\n"
+        + "    \"SamplingTargetDocuments\": [\n"
+        + "        {\n"
+        + "            \"RuleName\": \"base-scorekeep\",\n"
+        + "            \"FixedRate\": 0.1,\n"
+        + "            \"ReservoirQuota\": 2,\n"
+        + "            \"ReservoirQuotaTTL\": 1530923107.0,\n"
+        + "            \"Interval\": 10\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"RuleName\": \"polling-scorekeep\",\n"
+        + "            \"FixedRate\": 0.003,\n"
+        + "            \"ReservoirQuota\": 0,\n"
+        + "            \"ReservoirQuotaTTL\": 1530923107.0,\n"
+        + "            \"Interval\": 10\n"
+        + "        }\n"
+        + "    ],\n"
+        + "    \"LastRuleModification\": 1530920505.0,\n"
+        + "    \"UnprocessedStatistics\": []\n"
+        + "}{\n"
+        + "    \"SamplingTargetDocuments\": [\n"
+        + "        {\n"
+        + "            \"RuleName\": \"base-scorekeep\",\n"
+        + "            \"FixedRate\": 0.1,\n"
+        + "            \"ReservoirQuota\": 2,\n"
+        + "            \"ReservoirQuotaTTL\": 1530923107.0,\n"
+        + "            \"Interval\": 10\n"
+        + "        },\n"
+        + "        {\n"
+        + "            \"RuleName\": \"polling-scorekeep\",\n"
+        + "            \"FixedRate\": 0.003,\n"
+        + "            \"ReservoirQuota\": 0,\n"
+        + "            \"ReservoirQuotaTTL\": 1530923107.0,\n"
+        + "            \"Interval\": 10\n"
+        + "        }\n"
+        + "    ],\n"
+        + "    \"LastRuleModification\": 1530920505.0,\n"
+        + "    \"UnprocessedStatistics\": []\n"
+        + "}";
 
     private UnsignedXrayClient client;
 
@@ -54,15 +217,13 @@ public class UnsignedXrayClientTest {
 
     @Test
     public void getSamplingRules() throws Exception {
-        GetSamplingRulesResult expected = new GetSamplingRulesResult();
-        expected.setNextToken("nexttoken");
-
         stubFor(any(anyUrl()).willReturn(aResponse()
                                                  .withStatus(200)
-                                                 .withBody(OBJECT_MAPPER.writeValueAsBytes(expected))));
+                                                 .withBody(SAMPLING_RULES)));
 
         GetSamplingRulesResult result = client.getSamplingRules(new GetSamplingRulesRequest());
 
+        GetSamplingRulesResult expected = OBJECT_MAPPER.readValue(SAMPLING_RULES, GetSamplingRulesResult.class);
         assertThat(expected).isEqualTo(result);
 
         verify(postRequestedFor(urlEqualTo("/GetSamplingRules"))
@@ -72,18 +233,16 @@ public class UnsignedXrayClientTest {
 
     @Test
     public void getSamplingTargets() throws Exception {
-        GetSamplingTargetsResult expected = new GetSamplingTargetsResult();
-        expected.setLastRuleModification(new Date(1000));
-
         stubFor(any(anyUrl()).willReturn(aResponse()
                                                  .withStatus(200)
-                                                 .withBody(OBJECT_MAPPER.writeValueAsBytes(expected))));
+                                                 .withBody(SAMPLING_TARGETS)));
 
         GetSamplingTargetsRequest request = new GetSamplingTargetsRequest()
             .withSamplingStatisticsDocuments(new SamplingStatisticsDocument().withClientID("client-id"));
 
         GetSamplingTargetsResult result = client.getSamplingTargets(request);
 
+        GetSamplingTargetsResult expected = OBJECT_MAPPER.readValue(SAMPLING_TARGETS, GetSamplingTargetsResult.class);
         assertThat(expected).isEqualTo(result);
 
         verify(postRequestedFor(urlEqualTo("/GetSamplingTargets"))


### PR DESCRIPTION
*Issue #, if available:* Fixes #170 

*Description of changes:*

The JSON response for sampling rules uses AWS-specific float values for date/times, not standard strings. Instead of incomplete round-tripping of the POJOs through `OBJECT_MAPPER` it was much more important to use actual strings from the CLI documentation for the unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
