### PR TITLE
Configure maven publishing block.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -195,8 +195,13 @@ allprojects {
 
             repositories {
                 maven {
-                    name = "staging-repo"
-                    url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2")
+                    val repoUrlBase = "https://aws.oss.sonatype.org/content/repositories"
+                    val isSnapshot = version.toString().endsWith("SNAPSHOT")
+                    url = uri("$repoUrlBase/${if (isSnapshot) "snapshots" else "releases"}")
+                    credentials {
+                        username = "${findProperty("aws.sonatype.username")}"
+                        password = "${findProperty("aws.sonatype.password")}"
+                    }
                 }
             }
         }


### PR DESCRIPTION
This configures the repos for maven publishing and reads credentials either from command line properties or preferabley a `~/.gradle/gradle.properties` file.

This doesn't set up signing yet but we can use this to publish snapshots in the meantime. Command is `./gradlew publish`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
