### PR TITLE
Use dynamic version based on previous git tag and add task for releas…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,1 @@
-version = 2.6.2-SNAPSHOT
-
 org.gradle.parallel=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,8 @@ pluginManagement {
     plugins {
         id("com.github.hierynomus.license") version "0.15.0"
         id("net.ltgt.errorprone") version "1.2.1"
+        id("org.ajoberstar.grgit") version "4.0.2"
+        id("org.ajoberstar.reckon") version "0.12.0"
         id("org.checkerframework") version "0.5.4"
     }
 }


### PR DESCRIPTION
…ing.

This sets the version of the project automatically based on latest tag

- Normal: Increment minor version and suffix with -SNAPSHOT
- With `-Preckon.stage=final` parameter: Increment minor version

The `release` tag fills the version into `README.md`, commits it, and builds / publishes. In a followup I will wire up the benchmarks as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
