### PR TITLE
Use 1 lock to protect entity.subsegments (#181)

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -431,8 +431,11 @@ public abstract class EntityImpl implements Entity {
     @Override
     public void addSubsegment(Subsegment subsegment) {
         checkAlreadyEmitted();
-        synchronized (subsegments) {
+        getSubsegmentsLock().lock();
+        try {
             subsegments.add(subsegment);
+        } finally {
+            getSubsegmentsLock().unlock();
         }
     }
 
@@ -440,8 +443,11 @@ public abstract class EntityImpl implements Entity {
     public void addException(Throwable exception) {
         checkAlreadyEmitted();
         setFault(true);
-        synchronized (subsegments) {
+        getSubsegmentsLock().lock();
+        try {
             cause.addExceptions(creator.getThrowableSerializationStrategy().describeInContext(exception, subsegments));
+        } finally {
+            getSubsegmentsLock().unlock();
         }
     }
 
@@ -606,8 +612,11 @@ public abstract class EntityImpl implements Entity {
 
     @Override
     public void removeSubsegment(Subsegment subsegment) {
-        synchronized (subsegments) {
-            getSubsegments().remove(subsegment);
+        getSubsegmentsLock().lock();
+        try {
+            subsegments.remove(subsegment);
+        } finally {
+            getSubsegmentsLock().unlock();
         }
         getParentSegment().getTotalSize().decrement();
     }


### PR DESCRIPTION
Use only one type of lock to protect entity.subsegments.
In the past two different locking mechanisms were used.  This can cause
a race condition where the subsegments list was being manipulated while
being read.

*Issue #181 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
