### PR TITLE
Use recycled buffer when serializaing trace header.

### DIFF
--- a/aws-xray-recorder-sdk-benchmark/tst/main/java/com/amazonaws/xray/entities/TraceHeaderBenchmark.java
+++ b/aws-xray-recorder-sdk-benchmark/tst/main/java/com/amazonaws/xray/entities/TraceHeaderBenchmark.java
@@ -35,18 +35,24 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class TraceHeaderBenchmark {
 
-    private static final String HEADER = "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1";
+    private static final String HEADER_STRING = "Root=1-8a3c60f7-d188f8fa79d48a391a778fa6;Parent=53995c3f42cd8ad8;Sampled=1";
+    private static final TraceHeader HEADER = TraceHeader.fromString(HEADER_STRING);
 
     @Benchmark
     public TraceHeader parse() {
-        return TraceHeader.fromString(HEADER);
+        return TraceHeader.fromString(HEADER_STRING);
+    }
+
+    @Benchmark
+    public String serialize() {
+        return HEADER.toString();
     }
 
     // Convenience main entry-point
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
             .addProfiler("gc")
-            .include(".*" + TraceHeaderBenchmark.class.getSimpleName())
+            .include(".*" + TraceHeaderBenchmark.class.getSimpleName() + ".serialize")
             .build();
 
         new Runner(opt).run();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
@@ -15,8 +15,7 @@
 
 package com.amazonaws.xray.entities;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.amazonaws.xray.internal.RecyclableBuffers;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.logging.Log;
@@ -148,18 +147,19 @@ public class TraceHeader {
      */
     @Override
     public String toString() {
-        List<String> parts = new ArrayList<>();
+        StringBuilder buffer = RecyclableBuffers.stringBuilder();
         if (rootTraceId != null) {
-            parts.add(ROOT_PREFIX + rootTraceId);
+            buffer.append(ROOT_PREFIX).append(rootTraceId).append(DELIMITER);
         }
         if (StringValidator.isNotNullOrBlank(parentId)) {
-            parts.add(PARENT_PREFIX + parentId);
+            buffer.append(PARENT_PREFIX).append(parentId).append(DELIMITER);
         }
-        parts.add(sampled.toString());
+        buffer.append(sampled).append(DELIMITER);
         additionalParams.forEach((key, value) -> {
-            parts.add(key + EQUALS + value);
+            buffer.append(key).append(EQUALS).append(value).append(DELIMITER);
         });
-        return String.join(DELIMITER, parts);
+        buffer.setLength(buffer.length() - DELIMITER.length());
+        return buffer.toString();
     }
 
     /**

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/RecyclableBuffers.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/RecyclableBuffers.java
@@ -40,5 +40,6 @@ public final class RecyclableBuffers {
         return buffer;
     }
 
-    private RecyclableBuffers() {}
+    private RecyclableBuffers() {
+    }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/RecyclableBuffers.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/RecyclableBuffers.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.internal;
+
+/**
+ * {@link ThreadLocal} buffers for use when creating new derived objects such as {@link String}s.
+ * These buffers are reused within a single thread - it is _not safe_ to use the buffer to generate
+ * multiple derived objects at the same time because the same memory will be used. In general, you
+ * should get a temporary buffer, fill it with data, and finish by converting into the derived
+ * object within the same method to avoid multiple usages of the same buffer.
+ */
+public final class RecyclableBuffers {
+
+    private static final ThreadLocal<StringBuilder> STRING_BUILDER = new ThreadLocal<>();
+
+    /**
+     * A {@link ThreadLocal} {@link StringBuilder}. Take care when filling a large value into this buffer
+     * because the memory will remain for the lifetime of the thread.
+     */
+    public static StringBuilder stringBuilder() {
+        StringBuilder buffer = STRING_BUILDER.get();
+        if (buffer == null) {
+            buffer = new StringBuilder();
+            STRING_BUILDER.set(buffer);
+        }
+        buffer.setLength(0);
+        return buffer;
+    }
+
+    private RecyclableBuffers() {}
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/RecyclableBuffers.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/RecyclableBuffers.java
@@ -15,6 +15,8 @@
 
 package com.amazonaws.xray.internal;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * {@link ThreadLocal} buffers for use when creating new derived objects such as {@link String}s.
  * These buffers are reused within a single thread - it is _not safe_ to use the buffer to generate
@@ -24,7 +26,7 @@ package com.amazonaws.xray.internal;
  */
 public final class RecyclableBuffers {
 
-    private static final ThreadLocal<StringBuilder> STRING_BUILDER = new ThreadLocal<>();
+    private static final ThreadLocal<@Nullable StringBuilder> STRING_BUILDER = new ThreadLocal<>();
 
     /**
      * A {@link ThreadLocal} {@link StringBuilder}. Take care when filling a large value into this buffer


### PR DESCRIPTION
Many libraries, like Jackson, logging, and other tracing libraries, use a `ThreadLocal` buffer when creating strings. This is because Java will always copy the buffer when creating the `String` so the work of allocating / zeroing an intermediate buffer for filling up the content is completely wasted. 

Using recyclable buffers requires a bit of thought but don't add real complexity to the code so I think they're generally worth it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

About 20% speedup
After
```
Benchmark                                                          Mode     Cnt     Score     Error   Units
TraceHeaderBenchmark.serialize                                   sample  463614     0.781 �   0.055   us/op
TraceHeaderBenchmark.serialize:serialize�p0.00                   sample             0.300             us/op
TraceHeaderBenchmark.serialize:serialize�p0.50                   sample             0.500             us/op
TraceHeaderBenchmark.serialize:serialize�p0.90                   sample             0.900             us/op
TraceHeaderBenchmark.serialize:serialize�p0.95                   sample             1.200             us/op
TraceHeaderBenchmark.serialize:serialize�p0.99                   sample             1.700             us/op
TraceHeaderBenchmark.serialize:serialize�p0.999                  sample            18.880             us/op
TraceHeaderBenchmark.serialize:serialize�p0.9999                 sample           119.964             us/op
TraceHeaderBenchmark.serialize:serialize�p1.00                   sample          2568.192             us/op
TraceHeaderBenchmark.serialize:�gc.alloc.rate                    sample      15  1196.732 � 300.700  MB/sec
TraceHeaderBenchmark.serialize:�gc.alloc.rate.norm               sample      15  1136.309 �  12.570    B/op
TraceHeaderBenchmark.serialize:�gc.churn.G1_Eden_Space           sample      15  1205.300 � 315.077  MB/sec
TraceHeaderBenchmark.serialize:�gc.churn.G1_Eden_Space.norm      sample      15  1143.188 �  73.104    B/op
TraceHeaderBenchmark.serialize:�gc.churn.G1_Survivor_Space       sample      15     0.044 �   0.015  MB/sec
TraceHeaderBenchmark.serialize:�gc.churn.G1_Survivor_Space.norm  sample      15     0.045 �   0.023    B/op
TraceHeaderBenchmark.serialize:�gc.count                         sample      15   126.000            counts
TraceHeaderBenchmark.serialize:�gc.time                          sample      15   217.000                ms
```

Before
```
Benchmark                                                          Mode     Cnt     Score     Error   Units
TraceHeaderBenchmark.serialize                                   sample  422292     0.932 �   0.063   us/op
TraceHeaderBenchmark.serialize:serialize�p0.00                   sample             0.400             us/op
TraceHeaderBenchmark.serialize:serialize�p0.50                   sample             0.700             us/op
TraceHeaderBenchmark.serialize:serialize�p0.90                   sample             1.000             us/op
TraceHeaderBenchmark.serialize:serialize�p0.95                   sample             1.400             us/op
TraceHeaderBenchmark.serialize:serialize�p0.99                   sample             1.900             us/op
TraceHeaderBenchmark.serialize:serialize�p0.999                  sample            20.992             us/op
TraceHeaderBenchmark.serialize:serialize�p0.9999                 sample           133.738             us/op
TraceHeaderBenchmark.serialize:serialize�p1.00                   sample          3518.464             us/op
TraceHeaderBenchmark.serialize:�gc.alloc.rate                    sample      15  1445.319 � 337.310  MB/sec
TraceHeaderBenchmark.serialize:�gc.alloc.rate.norm               sample      15  1664.383 �  12.583    B/op
TraceHeaderBenchmark.serialize:�gc.churn.G1_Eden_Space           sample      15  1459.855 � 339.541  MB/sec
TraceHeaderBenchmark.serialize:�gc.churn.G1_Eden_Space.norm      sample      15  1683.273 �  85.850    B/op
TraceHeaderBenchmark.serialize:�gc.churn.G1_Survivor_Space       sample      15     0.044 �   0.025  MB/sec
TraceHeaderBenchmark.serialize:�gc.churn.G1_Survivor_Space.norm  sample      15     0.051 �   0.025    B/op
TraceHeaderBenchmark.serialize:�gc.count                         sample      15   133.000            counts
TraceHeaderBenchmark.serialize:�gc.time                          sample      15   226.000                ms
```