### PR TITLE
Add support for JUnit5 and migrate most tests.

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/HttpClientBuilderTest.java
+++ b/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/HttpClientBuilderTest.java
@@ -15,24 +15,20 @@
 
 package com.amazonaws.xray.proxies.apache.http;
 
-import static org.junit.Assert.assertEquals;
-
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.emitters.Emitter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class HttpClientBuilderTest {
+class HttpClientBuilderTest {
 
-    @Before
-    public void setupAWSXRay() {
+    @BeforeEach
+    void setupAWSXRay() {
         // Prevent accidental publish to Daemon
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
@@ -42,9 +38,9 @@ public class HttpClientBuilderTest {
     }
 
     @Test
-    public void testConstructorProtected() throws NoSuchMethodException {
+    void testConstructorProtected() throws NoSuchMethodException {
         // Since the constructor is protected and this is in the same package, we have to test this using reflection.
         Constructor clientBuilderConstructor = HttpClientBuilder.class.getDeclaredConstructor();
-        assertEquals(Modifier.PROTECTED, clientBuilderConstructor.getModifiers()); // PROTECTED = 4;
+        Assertions.assertEquals(Modifier.PROTECTED, clientBuilderConstructor.getModifiers()); // PROTECTED = 4;
     }
 }

--- a/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedResponseHandlerTest.java
+++ b/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedResponseHandlerTest.java
@@ -26,18 +26,15 @@ import org.apache.http.HttpVersion;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class TracedResponseHandlerTest {
+class TracedResponseHandlerTest {
 
-    @Before
-    public void setupAWSXRay() {
+    @BeforeEach
+    void setupAWSXRay() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
         Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.anyObject());
@@ -46,39 +43,39 @@ public class TracedResponseHandlerTest {
     }
 
     @Test
-    public void testHandleResponse200SetsNoFlags() {
+    void testHandleResponse200SetsNoFlags() {
         Segment segment = segmentInResponseToCode(200);
         Subsegment subsegment = segment.getSubsegments().get(0);
-        Assert.assertFalse(subsegment.isFault());
-        Assert.assertFalse(subsegment.isError());
-        Assert.assertFalse(subsegment.isThrottle());
+        Assertions.assertFalse(subsegment.isFault());
+        Assertions.assertFalse(subsegment.isError());
+        Assertions.assertFalse(subsegment.isThrottle());
     }
 
     @Test
-    public void testHandleResponse400SetsErrorFlag() {
+    void testHandleResponse400SetsErrorFlag() {
         Segment segment = segmentInResponseToCode(400);
         Subsegment subsegment = segment.getSubsegments().get(0);
-        Assert.assertFalse(subsegment.isFault());
-        Assert.assertTrue(subsegment.isError());
-        Assert.assertFalse(subsegment.isThrottle());
+        Assertions.assertFalse(subsegment.isFault());
+        Assertions.assertTrue(subsegment.isError());
+        Assertions.assertFalse(subsegment.isThrottle());
     }
 
     @Test
-    public void testHandleResponse429SetsErrorAndThrottleFlag() {
+    void testHandleResponse429SetsErrorAndThrottleFlag() {
         Segment segment = segmentInResponseToCode(429);
         Subsegment subsegment = segment.getSubsegments().get(0);
-        Assert.assertFalse(subsegment.isFault());
-        Assert.assertTrue(subsegment.isError());
-        Assert.assertTrue(subsegment.isThrottle());
+        Assertions.assertFalse(subsegment.isFault());
+        Assertions.assertTrue(subsegment.isError());
+        Assertions.assertTrue(subsegment.isThrottle());
     }
 
     @Test
-    public void testHandleResponse500SetsFaultFlag() {
+    void testHandleResponse500SetsFaultFlag() {
         Segment segment = segmentInResponseToCode(500);
         Subsegment subsegment = segment.getSubsegments().get(0);
-        Assert.assertTrue(subsegment.isFault());
-        Assert.assertFalse(subsegment.isError());
-        Assert.assertFalse(subsegment.isThrottle());
+        Assertions.assertTrue(subsegment.isFault());
+        Assertions.assertFalse(subsegment.isError());
+        Assertions.assertFalse(subsegment.isThrottle());
     }
 
     private static class NoOpResponseHandler implements ResponseHandler<String> {

--- a/aws-xray-recorder-sdk-aws-sdk-core/src/test/java/com/amazonaws/xray/utils/StringTransformTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk-core/src/test/java/com/amazonaws/xray/utils/StringTransformTest.java
@@ -15,23 +15,20 @@
 
 package com.amazonaws.xray.utils;
 
-import org.junit.Assert;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class StringTransformTest {
+class StringTransformTest {
 
     @Test
-    public void testToSnakeCase() {
-        Assert.assertEquals("table_name", StringTransform.toSnakeCase("tableName"));
-        Assert.assertEquals("consumed_capacity", StringTransform.toSnakeCase("ConsumedCapacity"));
-        Assert.assertEquals("item_collection_metrics", StringTransform.toSnakeCase("ItemCollectionMetrics"));
+    void testToSnakeCase() {
+        Assertions.assertEquals("table_name", StringTransform.toSnakeCase("tableName"));
+        Assertions.assertEquals("consumed_capacity", StringTransform.toSnakeCase("ConsumedCapacity"));
+        Assertions.assertEquals("item_collection_metrics", StringTransform.toSnakeCase("ItemCollectionMetrics"));
     }
 
     @Test
-    public void testToSnakeCaseNoExtraUnderscores() {
-        Assert.assertEquals("table_name", StringTransform.toSnakeCase("table_name"));
+    void testToSnakeCaseNoExtraUnderscores() {
+        Assertions.assertEquals("table_name", StringTransform.toSnakeCase("table_name"));
     }
 }

--- a/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerTest.java
@@ -50,19 +50,16 @@ import org.apache.http.impl.io.EmptyInputStream;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.protocol.HttpContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class TracingHandlerTest {
+class TracingHandlerTest {
 
-    @Before
-    public void setupAWSXRay() {
+    @BeforeEach
+    void setupAWSXRay() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
         Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.anyObject());
@@ -94,7 +91,7 @@ public class TracingHandlerTest {
     }
 
     @Test
-    public void testLambdaInvokeSubsegmentContainsFunctionName() {
+    void testLambdaInvokeSubsegmentContainsFunctionName() {
         // Setup test
         AWSLambda lambda = AWSLambdaClientBuilder
             .standard()
@@ -111,13 +108,13 @@ public class TracingHandlerTest {
         request.setFunctionName("testFunctionName");
         lambda.invoke(request);
 
-        Assert.assertEquals(1, segment.getSubsegments().size());
-        Assert.assertEquals("Invoke", segment.getSubsegments().get(0).getAws().get("operation"));
-        Assert.assertEquals("testFunctionName", segment.getSubsegments().get(0).getAws().get("function_name"));
+        Assertions.assertEquals(1, segment.getSubsegments().size());
+        Assertions.assertEquals("Invoke", segment.getSubsegments().get(0).getAws().get("operation"));
+        Assertions.assertEquals("testFunctionName", segment.getSubsegments().get(0).getAws().get("function_name"));
     }
 
     @Test
-    public void testS3PutObjectSubsegmentContainsBucketName() {
+    void testS3PutObjectSubsegmentContainsBucketName() {
         // Setup test
         AmazonS3 s3 = AmazonS3ClientBuilder
             .standard()
@@ -132,14 +129,14 @@ public class TracingHandlerTest {
         // Test logic 
         Segment segment = AWSXRay.beginSegment("test");
         s3.putObject(bucket, key, "This is a test from java");
-        Assert.assertEquals(1, segment.getSubsegments().size());
-        Assert.assertEquals("PutObject", segment.getSubsegments().get(0).getAws().get("operation"));
-        Assert.assertEquals(bucket, segment.getSubsegments().get(0).getAws().get("bucket_name"));
-        Assert.assertEquals(key, segment.getSubsegments().get(0).getAws().get("key"));
+        Assertions.assertEquals(1, segment.getSubsegments().size());
+        Assertions.assertEquals("PutObject", segment.getSubsegments().get(0).getAws().get("operation"));
+        Assertions.assertEquals(bucket, segment.getSubsegments().get(0).getAws().get("bucket_name"));
+        Assertions.assertEquals(key, segment.getSubsegments().get(0).getAws().get("key"));
     }
 
     @Test
-    public void testS3CopyObjectSubsegmentContainsBucketName() {
+    void testS3CopyObjectSubsegmentContainsBucketName() {
         // Setup test
         final String copyResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                     "<CopyObjectResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
@@ -161,16 +158,16 @@ public class TracingHandlerTest {
         // Test logic 
         Segment segment = AWSXRay.beginSegment("test");
         s3.copyObject(bucket, key, dstBucket, dstKey);
-        Assert.assertEquals(1, segment.getSubsegments().size());
-        Assert.assertEquals("CopyObject", segment.getSubsegments().get(0).getAws().get("operation"));
-        Assert.assertEquals(bucket, segment.getSubsegments().get(0).getAws().get("source_bucket_name"));
-        Assert.assertEquals(key, segment.getSubsegments().get(0).getAws().get("source_key"));
-        Assert.assertEquals(dstBucket, segment.getSubsegments().get(0).getAws().get("destination_bucket_name"));
-        Assert.assertEquals(dstKey, segment.getSubsegments().get(0).getAws().get("destination_key"));
+        Assertions.assertEquals(1, segment.getSubsegments().size());
+        Assertions.assertEquals("CopyObject", segment.getSubsegments().get(0).getAws().get("operation"));
+        Assertions.assertEquals(bucket, segment.getSubsegments().get(0).getAws().get("source_bucket_name"));
+        Assertions.assertEquals(key, segment.getSubsegments().get(0).getAws().get("source_key"));
+        Assertions.assertEquals(dstBucket, segment.getSubsegments().get(0).getAws().get("destination_bucket_name"));
+        Assertions.assertEquals(dstKey, segment.getSubsegments().get(0).getAws().get("destination_key"));
     }
 
     @Test
-    public void testSNSPublish() {
+    void testSNSPublish() {
         // Setup test
         // reference : https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
         final String publishResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -189,13 +186,13 @@ public class TracingHandlerTest {
         // Test logic 
         Segment segment = AWSXRay.beginSegment("test");
         sns.publish(new PublishRequest(topicArn, "testMessage"));
-        Assert.assertEquals(1, segment.getSubsegments().size());
-        Assert.assertEquals("Publish", segment.getSubsegments().get(0).getAws().get("operation"));
-        Assert.assertEquals(topicArn, segment.getSubsegments().get(0).getAws().get("topic_arn"));
+        Assertions.assertEquals(1, segment.getSubsegments().size());
+        Assertions.assertEquals("Publish", segment.getSubsegments().get(0).getAws().get("operation"));
+        Assertions.assertEquals(topicArn, segment.getSubsegments().get(0).getAws().get("topic_arn"));
     }
 
     @Test
-    public void testShouldNotTraceXRaySamplingOperations() {
+    void testShouldNotTraceXRaySamplingOperations() {
         com.amazonaws.services.xray.AWSXRay xray = AWSXRayClientBuilder
             .standard()
             .withRequestHandlers(new TracingHandler()).withRegion(Regions.US_EAST_1)
@@ -205,14 +202,14 @@ public class TracingHandlerTest {
 
         Segment segment = AWSXRay.beginSegment("test");
         xray.getSamplingRules(new GetSamplingRulesRequest());
-        Assert.assertEquals(0, segment.getSubsegments().size());
+        Assertions.assertEquals(0, segment.getSubsegments().size());
 
         xray.getSamplingTargets(new GetSamplingTargetsRequest());
-        Assert.assertEquals(0, segment.getSubsegments().size());
+        Assertions.assertEquals(0, segment.getSubsegments().size());
     }
 
     @Test
-    public void testShouldNotThrowContextMissingOnXRaySampling() {
+    void testShouldNotThrowContextMissingOnXRaySampling() {
         com.amazonaws.services.xray.AWSXRay xray = AWSXRayClientBuilder
             .standard()
             .withRequestHandlers(new TracingHandler()).withRegion(Regions.US_EAST_1)
@@ -225,7 +222,7 @@ public class TracingHandlerTest {
     }
 
     @Test
-    public void testRaceConditionOnRecorderInitialization() {
+    void testRaceConditionOnRecorderInitialization() {
         AWSXRay.setGlobalRecorder(null);
         // TracingHandler will not have the initialized recorder
         AWSLambda lambda = AWSLambdaClientBuilder

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/ConcurrencyTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/ConcurrencyTest.java
@@ -21,17 +21,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class ConcurrencyTest {
+class ConcurrencyTest {
 
-    @Before
-    public void setupAWSXRay() {
+    @BeforeEach
+    void setupAWSXRay() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         LocalizedSamplingStrategy defaultSamplingStrategy = new LocalizedSamplingStrategy();
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
@@ -42,7 +39,7 @@ public class ConcurrencyTest {
     }
 
     @Test
-    public void testManyThreads() throws InterruptedException {
+    void testManyThreads() throws InterruptedException {
         ExecutorService pool = Executors.newFixedThreadPool(10);
         CountDownLatch latch = new CountDownLatch(100);
         for (int i = 0; i < 100; i++) {

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/TraceHeaderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/TraceHeaderTest.java
@@ -18,75 +18,72 @@ package com.amazonaws.xray;
 import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.entities.TraceHeader.SampleDecision;
 import com.amazonaws.xray.entities.TraceID;
-import org.junit.Assert;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class TraceHeaderTest {
+class TraceHeaderTest {
 
     private static final String TRACE_ID = "1-57ff426a-80c11c39b0c928905eb0828d";
 
     @Test
-    public void testSampledEqualsOneFromString() {
+    void testSampledEqualsOneFromString() {
         TraceHeader header = TraceHeader.fromString("Sampled=1");
-        Assert.assertEquals(SampleDecision.SAMPLED, header.getSampled());
-        Assert.assertNull(header.getRootTraceId());
-        Assert.assertNull(header.getParentId());
-        Assert.assertTrue(header.getAdditionalParams().isEmpty());
+        Assertions.assertEquals(SampleDecision.SAMPLED, header.getSampled());
+        Assertions.assertNull(header.getRootTraceId());
+        Assertions.assertNull(header.getParentId());
+        Assertions.assertTrue(header.getAdditionalParams().isEmpty());
     }
 
     @Test
-    public void testLongHeaderFromString() {
+    void testLongHeaderFromString() {
         TraceHeader header = TraceHeader.fromString("Sampled=?;Root=" + TRACE_ID + ";Parent=foo;Self=2;Foo=bar");
-        Assert.assertEquals(SampleDecision.REQUESTED, header.getSampled());
-        Assert.assertEquals(TraceID.fromString(TRACE_ID), header.getRootTraceId());
-        Assert.assertEquals("foo", header.getParentId());
-        Assert.assertEquals(1, header.getAdditionalParams().size());
-        Assert.assertEquals("bar", header.getAdditionalParams().get("Foo"));
+        Assertions.assertEquals(SampleDecision.REQUESTED, header.getSampled());
+        Assertions.assertEquals(TraceID.fromString(TRACE_ID), header.getRootTraceId());
+        Assertions.assertEquals("foo", header.getParentId());
+        Assertions.assertEquals(1, header.getAdditionalParams().size());
+        Assertions.assertEquals("bar", header.getAdditionalParams().get("Foo"));
     }
 
     @Test
-    public void testLongHeaderFromStringWithSpaces() {
+    void testLongHeaderFromStringWithSpaces() {
         TraceHeader header = TraceHeader.fromString("Sampled=?; Root=" + TRACE_ID + "; Parent=foo; Self=2; Foo=bar");
-        Assert.assertEquals(SampleDecision.REQUESTED, header.getSampled());
-        Assert.assertEquals(TraceID.fromString(TRACE_ID), header.getRootTraceId());
-        Assert.assertEquals("foo", header.getParentId());
-        Assert.assertEquals(1, header.getAdditionalParams().size());
-        Assert.assertEquals("bar", header.getAdditionalParams().get("Foo"));
+        Assertions.assertEquals(SampleDecision.REQUESTED, header.getSampled());
+        Assertions.assertEquals(TraceID.fromString(TRACE_ID), header.getRootTraceId());
+        Assertions.assertEquals("foo", header.getParentId());
+        Assertions.assertEquals(1, header.getAdditionalParams().size());
+        Assertions.assertEquals("bar", header.getAdditionalParams().get("Foo"));
     }
 
     @Test
-    public void testSampledUnknownToString() {
+    void testSampledUnknownToString() {
         TraceHeader header = new TraceHeader();
         header.setSampled(SampleDecision.UNKNOWN);
-        Assert.assertEquals("", header.toString());
+        Assertions.assertEquals("", header.toString());
     }
 
     @Test
-    public void testSampledEqualsOneWithSamplingRequestedToString() {
+    void testSampledEqualsOneWithSamplingRequestedToString() {
         TraceHeader header = new TraceHeader();
         header.setSampled(SampleDecision.REQUESTED);
         header.setSampled(SampleDecision.SAMPLED);
-        Assert.assertEquals("Sampled=1", header.toString());
+        Assertions.assertEquals("Sampled=1", header.toString());
     }
 
     @Test
-    public void testSampledEqualsOneAndParentToString() {
+    void testSampledEqualsOneAndParentToString() {
         TraceHeader header = new TraceHeader();
         header.setSampled(SampleDecision.SAMPLED);
         header.setParentId("foo");
-        Assert.assertEquals("Parent=foo;Sampled=1", header.toString());
+        Assertions.assertEquals("Parent=foo;Sampled=1", header.toString());
     }
 
     @Test
-    public void testLongHeaderToString() {
+    void testLongHeaderToString() {
         TraceHeader header = new TraceHeader();
         header.setSampled(SampleDecision.SAMPLED);
         header.setRootTraceId(TraceID.fromString(TRACE_ID));
         header.setParentId("foo");
         header.getAdditionalParams().put("Foo", "bar");
-        Assert.assertEquals("Root=" + TRACE_ID + ";Parent=foo;Sampled=1;Foo=bar", header.toString());
+        Assertions.assertEquals("Root=" + TRACE_ID + ";Parent=foo;Sampled=1;Foo=bar", header.toString());
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/CustomSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/CustomSegmentContextTest.java
@@ -29,12 +29,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class CustomSegmentContextTest {
+class CustomSegmentContextTest {
 
     static class GlobalMapSegmentContext implements SegmentContext {
 
@@ -96,8 +96,8 @@ public class CustomSegmentContextTest {
         }
     }
 
-    @Before
-    public void setupAWSXRay() {
+    @BeforeEach
+    void setupAWSXRay() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
         Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.anyObject());
@@ -115,7 +115,7 @@ public class CustomSegmentContextTest {
     }
 
     @Test
-    public void testGlobalMapSegmentContext() {
+    void testGlobalMapSegmentContext() {
         Segment test = AWSXRay.beginSegment("test");
 
 
@@ -130,7 +130,7 @@ public class CustomSegmentContextTest {
             });
         });
 
-        Assert.assertEquals(100, test.getTotalSize().intValue());
+        Assertions.assertEquals(100, test.getTotalSize().intValue());
 
         AWSXRay.endSegment();
     }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/emitters/UDPEmitterTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.amazonaws.xray.config.DaemonConfiguration;
 import com.amazonaws.xray.entities.DummySegment;
 import java.net.SocketException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class UDPEmitterTest {
+class UDPEmitterTest {
 
     @Test
-    public void testCustomAddress() throws SocketException {
+    void testCustomAddress() throws SocketException {
         String address = "123.4.5.6:1234";
         DaemonConfiguration config = getDaemonConfiguration(address);
 
@@ -37,7 +37,7 @@ public class UDPEmitterTest {
 
 
     @Test
-    public void sendingSegmentShouldNotThrowExceptions() throws SocketException {
+    void sendingSegmentShouldNotThrowExceptions() throws SocketException {
         DaemonConfiguration config = getDaemonConfiguration("__udpemittertest_unresolvable__:1234");
         UDPEmitter emitter = new UDPEmitter(config);
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/AWSLogReferenceTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/AWSLogReferenceTest.java
@@ -15,24 +15,19 @@
 
 package com.amazonaws.xray.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
-
-@FixMethodOrder(MethodSorters.JVM)
-public class AWSLogReferenceTest {
+class AWSLogReferenceTest {
 
     AWSLogReference referenceA;
     AWSLogReference referenceB;
     AWSLogReference differentArn;
     AWSLogReference differentGroup;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         referenceA = new AWSLogReference();
         referenceB = new AWSLogReference();
         differentArn = new AWSLogReference();
@@ -54,21 +49,21 @@ public class AWSLogReferenceTest {
     // Test case for equals.
     @SuppressWarnings("SelfEquals")
     @Test
-    public void testEqualityPositive() {
-        assertTrue(referenceA.equals(referenceB));
-        assertTrue(referenceB.equals(referenceA));
-        assertTrue(referenceA.equals(referenceA));
+    void testEqualityPositive() {
+        Assertions.assertTrue(referenceA.equals(referenceB));
+        Assertions.assertTrue(referenceB.equals(referenceA));
+        Assertions.assertTrue(referenceA.equals(referenceA));
     }
 
     @Test
-    public void testEqualityNegativeBecauseArn() {
-        assertEquals(false, referenceA.equals(differentArn));
-        assertEquals(false, differentArn.equals(referenceA));
+    void testEqualityNegativeBecauseArn() {
+        Assertions.assertEquals(false, referenceA.equals(differentArn));
+        Assertions.assertEquals(false, differentArn.equals(referenceA));
     }
 
     @Test
-    public void testEqualityNegativeBecauseGroup() {
-        assertEquals(false, referenceA.equals(differentGroup));
-        assertEquals(false, differentGroup.equals(referenceA));
+    void testEqualityNegativeBecauseGroup() {
+        Assertions.assertEquals(false, referenceA.equals(differentGroup));
+        Assertions.assertEquals(false, differentGroup.equals(referenceA));
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/SearchPatternTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/SearchPatternTest.java
@@ -15,122 +15,119 @@
 
 package com.amazonaws.xray.entities;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class SearchPatternTest {
+class SearchPatternTest {
 
     @Test
-    public void testInvalidArgs() {
-        assertFalse(SearchPattern.wildcardMatch(null, ""));
-        assertFalse(SearchPattern.wildcardMatch("", null));
-        assertFalse(SearchPattern.wildcardMatch("", "whatever"));
+    void testInvalidArgs() {
+        Assertions.assertFalse(SearchPattern.wildcardMatch(null, ""));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("", null));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("", "whatever"));
     }
 
     @Test
-    public void testMatchExactPositive() throws Exception {
+    void testMatchExactPositive() throws Exception {
         final String pat = "foo";
         final String str = "foo";
         assertTrue(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testMatchExactNegative() throws Exception {
+    void testMatchExactNegative() throws Exception {
         final String pat = "foo";
         final String str = "bar";
-        assertFalse(SearchPattern.wildcardMatch(pat, str));
+        Assertions.assertFalse(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testSingleWildcardPositive() throws Exception {
+    void testSingleWildcardPositive() throws Exception {
         final String pat = "fo?";
         final String str = "foo";
         assertTrue(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testSingleWildcardNegative() throws Exception {
+    void testSingleWildcardNegative() throws Exception {
         final String pat = "f?o";
         final String str = "boo";
-        assertFalse(SearchPattern.wildcardMatch(pat, str));
+        Assertions.assertFalse(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testMultipleWildcardPositive() throws Exception {
+    void testMultipleWildcardPositive() throws Exception {
         final String pat = "?o?";
         final String str = "foo";
         assertTrue(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testMultipleWildcardNegative() throws Exception {
+    void testMultipleWildcardNegative() throws Exception {
         final String pat = "f??";
         final String str = "boo";
-        assertFalse(SearchPattern.wildcardMatch(pat, str));
+        Assertions.assertFalse(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testGlobPositive() throws Exception {
+    void testGlobPositive() throws Exception {
         final String pat = "*oo";
         final String str = "foo";
         assertTrue(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testGlobPositiveZeroOrMore() throws Exception {
+    void testGlobPositiveZeroOrMore() throws Exception {
         final String pat = "foo*";
         final String str = "foo";
         assertTrue(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testGlobNegativeZeroOrMore() throws Exception {
+    void testGlobNegativeZeroOrMore() throws Exception {
         final String pat = "foo*";
         final String str = "fo0";
-        assertFalse(SearchPattern.wildcardMatch(pat, str));
+        Assertions.assertFalse(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testGlobNegative() throws Exception {
+    void testGlobNegative() throws Exception {
         final String pat = "fo*";
         final String str = "boo";
-        assertFalse(SearchPattern.wildcardMatch(pat, str));
+        Assertions.assertFalse(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testGlobAndSinglePositive() throws Exception {
+    void testGlobAndSinglePositive() throws Exception {
         final String pat = "*o?";
         final String str = "foo";
         assertTrue(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testGlobAndSingleNegative() throws Exception {
+    void testGlobAndSingleNegative() throws Exception {
         final String pat = "f?*";
         final String str = "boo";
-        assertFalse(SearchPattern.wildcardMatch(pat, str));
+        Assertions.assertFalse(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void testPureWildcard() throws Exception {
+    void testPureWildcard() throws Exception {
         final String pat = "*";
         final String str = "foo";
         assertTrue(SearchPattern.wildcardMatch(pat, str));
     }
 
     @Test
-    public void exactMatch() throws Exception {
+    void exactMatch() throws Exception {
         assertTrue(SearchPattern.wildcardMatch("6543210", "6543210"));
     }
 
     @Test
-    public void testMisc() throws Exception {
+    void testMisc() throws Exception {
         final String animal1 = "?at";
         final String animal2 = "?o?se";
         final String animal3 = "*s";
@@ -147,36 +144,36 @@ public class SearchPatternTest {
 
         assertTrue(SearchPattern.wildcardMatch(vehicle1, "Jeep"));
         assertTrue(SearchPattern.wildcardMatch(vehicle2, "ford"));
-        assertFalse(SearchPattern.wildcardMatch(vehicle2, "chevy"));
+        Assertions.assertFalse(SearchPattern.wildcardMatch(vehicle2, "chevy"));
         assertTrue(SearchPattern.wildcardMatch("*", "cAr"));
 
         assertTrue(SearchPattern.wildcardMatch("*/foo", "/bar/foo"));
     }
 
     @Test
-    public void testCaseInsensitivity() throws Exception {
+    void testCaseInsensitivity() throws Exception {
         assertTrue(SearchPattern.wildcardMatch("Foo", "Foo", false));
         assertTrue(SearchPattern.wildcardMatch("Foo", "Foo", true));
 
-        assertFalse(SearchPattern.wildcardMatch("Foo", "FOO", false));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("Foo", "FOO", false));
         assertTrue(SearchPattern.wildcardMatch("Foo", "FOO", true));
 
         assertTrue(SearchPattern.wildcardMatch("Fo*", "Foo0", false));
         assertTrue(SearchPattern.wildcardMatch("Fo*", "Foo0", true));
 
-        assertFalse(SearchPattern.wildcardMatch("Fo*", "FOo0", false));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("Fo*", "FOo0", false));
         assertTrue(SearchPattern.wildcardMatch("Fo*", "FOO0", true));
 
         assertTrue(SearchPattern.wildcardMatch("Fo?", "Foo", false));
         assertTrue(SearchPattern.wildcardMatch("Fo?", "Foo", true));
 
-        assertFalse(SearchPattern.wildcardMatch("Fo?", "FOo", false));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("Fo?", "FOo", false));
         assertTrue(SearchPattern.wildcardMatch("Fo?", "FoO", false));
         assertTrue(SearchPattern.wildcardMatch("Fo?", "FOO", true));
     }
 
     @Test
-    public void testLongStrings() throws Exception {
+    void testLongStrings() throws Exception {
         // This blew out the stack on a recursive version of wildcardMatch
         final char[] t = new char[] { 'a', 'b', 'c', 'd' };
         StringBuffer text = new StringBuffer("a");
@@ -192,12 +189,12 @@ public class SearchPatternTest {
     }
 
     @Test
-    public void testNoGlobs() throws Exception {
-        assertFalse(SearchPattern.wildcardMatch("abcd", "abc"));
+    void testNoGlobs() throws Exception {
+        Assertions.assertFalse(SearchPattern.wildcardMatch("abcd", "abc"));
     }
 
     @Test
-    public void testEdgeCaseGlobs() throws Exception {
+    void testEdgeCaseGlobs() throws Exception {
         assertTrue(SearchPattern.wildcardMatch("", ""));
         assertTrue(SearchPattern.wildcardMatch("a", "a"));
         assertTrue(SearchPattern.wildcardMatch("*a", "a"));
@@ -211,13 +208,14 @@ public class SearchPatternTest {
         assertTrue(SearchPattern.wildcardMatch("a*a*", "aba"));
         assertTrue(SearchPattern.wildcardMatch("a*a*", "aaa"));
         assertTrue(SearchPattern.wildcardMatch("a*a*", "aaaaaaaaaaaaaaaaaaaaaaa"));
-        assertTrue(SearchPattern.wildcardMatch("a*b*a*b*a*b*a*b*a*",
-                "akljd9gsdfbkjhaabajkhbbyiaahkjbjhbuykjakjhabkjhbabjhkaabbabbaaakljdfsjklababkjbsdabab"));
-        assertFalse(SearchPattern.wildcardMatch("a*na*ha", "anananahahanahana"));
+        assertTrue(SearchPattern.wildcardMatch(
+            "a*b*a*b*a*b*a*b*a*",
+            "akljd9gsdfbkjhaabajkhbbyiaahkjbjhbuykjakjhabkjhbabjhkaabbabbaaakljdfsjklababkjbsdabab"));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("a*na*ha", "anananahahanahana"));
     }
 
     @Test
-    public void testMultiGlobs() throws Exception {
+    void testMultiGlobs() throws Exception {
 
         // Technically, '**' isn't well defined Balsa, but the wildcardMatch should do the right thing with it.
         assertTrue(SearchPattern.wildcardMatch("*a", "a"));
@@ -232,19 +230,19 @@ public class SearchPatternTest {
         assertTrue(SearchPattern.wildcardMatch("*?", "a"));
         assertTrue(SearchPattern.wildcardMatch("*?", "aa"));
         assertTrue(SearchPattern.wildcardMatch("*??", "aa"));
-        assertFalse(SearchPattern.wildcardMatch("*???", "aa"));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("*???", "aa"));
         assertTrue(SearchPattern.wildcardMatch("*?", "aaa"));
 
         assertTrue(SearchPattern.wildcardMatch("?", "a"));
-        assertFalse(SearchPattern.wildcardMatch("??", "a"));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("??", "a"));
 
         assertTrue(SearchPattern.wildcardMatch("?*", "a"));
         assertTrue(SearchPattern.wildcardMatch("*?", "a"));
-        assertFalse(SearchPattern.wildcardMatch("?*?", "a"));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("?*?", "a"));
         assertTrue(SearchPattern.wildcardMatch("?*?", "aa"));
         assertTrue(SearchPattern.wildcardMatch("*?*", "a"));
 
-        assertFalse(SearchPattern.wildcardMatch("*?*a", "a"));
+        Assertions.assertFalse(SearchPattern.wildcardMatch("*?*a", "a"));
         assertTrue(SearchPattern.wildcardMatch("*?*a*", "ba"));
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/listeners/SegmentListenerTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/listeners/SegmentListenerTest.java
@@ -20,12 +20,12 @@ import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.emitters.Emitter;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class SegmentListenerTest {
+class SegmentListenerTest {
     static class CustomSegmentListener implements SegmentListener {
 
         @Override
@@ -63,17 +63,17 @@ public class SegmentListenerTest {
             testVal2 = 1;
         }
 
-        public int getTestVal() {
+        int getTestVal() {
             return testVal;
         }
 
-        public int getTestVal2() {
+        int getTestVal2() {
             return testVal2;
         }
     }
 
-    @Before
-    public void setupAWSXRay() {
+    @BeforeEach
+    void setupAWSXRay() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.any());
         Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.any());
@@ -87,52 +87,52 @@ public class SegmentListenerTest {
     }
 
     @Test
-    public void testOnBeginSegment() {
+    void testOnBeginSegment() {
         Segment test = AWSXRay.beginSegment("test");
         String beginAnnotation = test.getAnnotations().get("beginTest").toString();
 
-        Assert.assertEquals("isPresent", beginAnnotation);
+        Assertions.assertEquals("isPresent", beginAnnotation);
 
         AWSXRay.endSegment();
     }
 
     @Test
-    public void testOnEndSegment() {
+    void testOnEndSegment() {
         Segment test = AWSXRay.beginSegment("test");
         AWSXRay.endSegment();
         String endAnnotation = test.getAnnotations().get("endTest").toString();
 
-        Assert.assertEquals("isPresent", endAnnotation);
+        Assertions.assertEquals("isPresent", endAnnotation);
     }
 
     @Test
-    public void testSubsegmentListeners() {
+    void testSubsegmentListeners() {
         AWSXRay.beginSegment("test");
         Subsegment sub = AWSXRay.beginSubsegment("testSub");
         String beginAnnotation = sub.getAnnotations().get("subAnnotation1").toString();
         AWSXRay.endSubsegment();
         String endAnnotation = sub.getAnnotations().get("subAnnotation2").toString();
 
-        Assert.assertEquals("began", beginAnnotation);
-        Assert.assertEquals("ended", endAnnotation);
+        Assertions.assertEquals("began", beginAnnotation);
+        Assertions.assertEquals("ended", endAnnotation);
     }
 
     @Test
-    public void testMultipleSegmentListeners() {
+    void testMultipleSegmentListeners() {
         SecondSegmentListener secondSegmentListener = new SecondSegmentListener();
         AWSXRay.getGlobalRecorder().addSegmentListener(secondSegmentListener);
         Segment test = AWSXRay.beginSegment("test");
         String beginAnnotation = test.getAnnotations().get("beginTest").toString();
 
 
-        Assert.assertEquals(1, secondSegmentListener.getTestVal());
+        Assertions.assertEquals(1, secondSegmentListener.getTestVal());
 
-        Assert.assertEquals("isPresent", beginAnnotation);
+        Assertions.assertEquals("isPresent", beginAnnotation);
 
         AWSXRay.endSegment();
         String endAnnotation = test.getAnnotations().get("endTest").toString();
 
-        Assert.assertEquals("isPresent", endAnnotation);
-        Assert.assertEquals(1, secondSegmentListener.getTestVal2());
+        Assertions.assertEquals("isPresent", endAnnotation);
+        Assertions.assertEquals(1, secondSegmentListener.getTestVal2());
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/CentralizedReservoirTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/CentralizedReservoirTest.java
@@ -16,13 +16,10 @@
 package com.amazonaws.xray.strategy.sampling;
 
 import com.amazonaws.xray.strategy.sampling.reservoir.Reservoir;
-import org.junit.Assert;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class CentralizedReservoirTest {
+class CentralizedReservoirTest {
 
     private static final int TEST_TIME = 1500;
 
@@ -45,18 +42,18 @@ public class CentralizedReservoirTest {
     }
 
     @Test
-    public void testOnePerSecond() {
+    void testOnePerSecond() {
         int perSecond = 1;
         int taken = takeOverTime(new Reservoir(perSecond), TEST_TIME);
-        Assert.assertTrue(Math.ceil(TEST_TIME / 1000f) <= taken);
-        Assert.assertTrue(Math.ceil(TEST_TIME / 1000f) + perSecond >= taken);
+        Assertions.assertTrue(Math.ceil(TEST_TIME / 1000f) <= taken);
+        Assertions.assertTrue(Math.ceil(TEST_TIME / 1000f) + perSecond >= taken);
     }
 
     @Test
-    public void testTenPerSecond() {
+    void testTenPerSecond() {
         int perSecond = 10;
         int taken = takeOverTime(new Reservoir(perSecond), TEST_TIME);
-        Assert.assertTrue(Math.ceil(TEST_TIME * perSecond / 1000f) <= taken);
-        Assert.assertTrue(Math.ceil(TEST_TIME * perSecond / 1000f) + perSecond >= taken);
+        Assertions.assertTrue(Math.ceil(TEST_TIME * perSecond / 1000f) <= taken);
+        Assertions.assertTrue(Math.ceil(TEST_TIME * perSecond / 1000f) + perSecond >= taken);
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/SamplingRequestTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/SamplingRequestTest.java
@@ -15,13 +15,13 @@
 
 package com.amazonaws.xray.strategy.sampling;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class SamplingRequestTest {
+class SamplingRequestTest {
 
     @Test
-    public void testSuccessfulAccountIdParsing() {
+    void testSuccessfulAccountIdParsing() {
         SamplingRequest req = new SamplingRequest(
                 "arn:aws:iam::123456789123:role/sample-role",
                 null,
@@ -33,7 +33,7 @@ public class SamplingRequestTest {
                 null
         );
 
-        Assert.assertEquals(req.getAccountId().get(), "123456789123");
+        Assertions.assertEquals(req.getAccountId().get(), "123456789123");
     }
 
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifestTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifestTest.java
@@ -26,39 +26,39 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
-public class CentralizedManifestTest {
+class CentralizedManifestTest {
 
     @Test
-    public void testEmptyManifestSize() {
+    void testEmptyManifestSize() {
         CentralizedManifest manifest = new CentralizedManifest();
-        Assert.assertEquals(0, manifest.size());
+        Assertions.assertEquals(0, manifest.size());
     }
 
     @Test
-    public void testExpirationForNewManifest() {
+    void testExpirationForNewManifest() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest manifest = new CentralizedManifest();
-        Assert.assertTrue(manifest.isExpired(now));
+        Assertions.assertTrue(manifest.isExpired(now));
     }
 
     @Test
-    public void testExpirationForNewlyRefreshedManifest() {
+    void testExpirationForNewlyRefreshedManifest() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest manifest = new CentralizedManifest();
         SamplingRule r1 = rule("r1");
         manifest.putRules(Arrays.asList(r1), now);
 
-        Assert.assertFalse(manifest.isExpired(now));
+        Assertions.assertFalse(manifest.isExpired(now));
     }
 
     @Test
-    public void testExpirationForOldManifest() {
+    void testExpirationForOldManifest() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest manifest = new CentralizedManifest();
@@ -68,11 +68,11 @@ public class CentralizedManifestTest {
         // Increment time to be one second past expiration
         now = Instant.ofEpochSecond(1500003601);
 
-        Assert.assertTrue(manifest.isExpired(now));
+        Assertions.assertTrue(manifest.isExpired(now));
     }
 
     @Test
-    public void testPositiveMatch() {
+    void testPositiveMatch() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest manifest = new CentralizedManifest();
@@ -102,11 +102,11 @@ public class CentralizedManifestTest {
             null
         );
 
-        Assert.assertEquals("r1", manifest.match(req, now).sample(now).getRuleName().get());
+        Assertions.assertEquals("r1", manifest.match(req, now).sample(now).getRuleName().get());
     }
 
     @Test
-    public void testPositiveDefaultRuleMatch() {
+    void testPositiveDefaultRuleMatch() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest manifest = new CentralizedManifest();
@@ -130,11 +130,11 @@ public class CentralizedManifestTest {
             null
         );
 
-        Assert.assertEquals(CentralizedRule.DEFAULT_RULE_NAME, manifest.match(req, now).sample(now).getRuleName().get());
+        Assertions.assertEquals(CentralizedRule.DEFAULT_RULE_NAME, manifest.match(req, now).sample(now).getRuleName().get());
     }
 
     @Test
-    public void testPutRules() {
+    void testPutRules() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest manifest = new CentralizedManifest();
@@ -165,11 +165,11 @@ public class CentralizedManifestTest {
             null
         );
 
-        Assert.assertEquals("r1", manifest.match(req, now).sample(now).getRuleName().get());
+        Assertions.assertEquals("r1", manifest.match(req, now).sample(now).getRuleName().get());
     }
 
     @Test
-    public void testRebuildOnNewRule() {
+    void testRebuildOnNewRule() {
         CentralizedManifest manifest = new CentralizedManifest();
 
         manifest.putRules(Arrays.asList(rule("r1")), Instant.now());
@@ -179,14 +179,14 @@ public class CentralizedManifestTest {
         Map<String, CentralizedRule> rules2 = Whitebox.getInternalState(manifest, "rules", CentralizedManifest.class);
 
         // The map of rules should be rebuilt, resulting in a new object
-        Assert.assertFalse(rules1 == rules2);
+        Assertions.assertFalse(rules1 == rules2);
 
-        Assert.assertEquals(1, rules1.size());
-        Assert.assertEquals(2, rules2.size());
+        Assertions.assertEquals(1, rules1.size());
+        Assertions.assertEquals(2, rules2.size());
     }
 
     @Test
-    public void testPutRulesWithoutRebuild() {
+    void testPutRulesWithoutRebuild() {
         CentralizedManifest manifest = new CentralizedManifest();
 
         manifest.putRules(Arrays.asList(rule("r1")), Instant.now());
@@ -198,11 +198,11 @@ public class CentralizedManifestTest {
         Map<String, CentralizedRule> rules2 = Whitebox.getInternalState(manifest, "rules", CentralizedManifest.class);
 
         // The map of rules should not have been rebuilt
-        Assert.assertTrue(rules1 == rules2);
+        Assertions.assertTrue(rules1 == rules2);
     }
 
     @Test
-    public void testRebuildOnPriorityChange() {
+    void testRebuildOnPriorityChange() {
         CentralizedManifest manifest = new CentralizedManifest();
 
         manifest.putRules(Arrays.asList(rule("r1")), Instant.now());
@@ -214,14 +214,14 @@ public class CentralizedManifestTest {
         Map<String, CentralizedRule> rules2 = Whitebox.getInternalState(manifest, "rules", CentralizedManifest.class);
 
         // The map of rules should be rebuilt, resulting in a new object
-        Assert.assertFalse(rules1 == rules2);
+        Assertions.assertFalse(rules1 == rules2);
 
-        Assert.assertEquals(1, rules1.size());
-        Assert.assertEquals(1, rules2.size());
+        Assertions.assertEquals(1, rules1.size());
+        Assertions.assertEquals(1, rules2.size());
     }
 
     @Test
-    public void testManifestSizeWithDefaultRule() {
+    void testManifestSizeWithDefaultRule() {
         CentralizedManifest m = new CentralizedManifest();
 
         SamplingRule r2 = new SamplingRule()
@@ -231,11 +231,11 @@ public class CentralizedManifestTest {
 
         m.putRules(Arrays.asList(rule("r1"), r2), Instant.now());
 
-        Assert.assertEquals(2, m.size());
+        Assertions.assertEquals(2, m.size());
     }
 
     @Test
-    public void testManifestSizeWithoutDefaultRule() {
+    void testManifestSizeWithoutDefaultRule() {
         CentralizedManifest m = new CentralizedManifest();
 
         SamplingRule r1 = new SamplingRule()
@@ -245,11 +245,11 @@ public class CentralizedManifestTest {
 
         m.putRules(Arrays.asList(r1), Instant.now());
 
-        Assert.assertEquals(1, m.size());
+        Assertions.assertEquals(1, m.size());
     }
 
     @Test
-    public void testSnapshotsWithDefaultRule() {
+    void testSnapshotsWithDefaultRule() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest m = new CentralizedManifest();
@@ -267,11 +267,11 @@ public class CentralizedManifestTest {
 
         List<SamplingStatisticsDocument> snapshots = m.snapshots(now);
 
-        Assert.assertEquals(3, snapshots.size());
+        Assertions.assertEquals(3, snapshots.size());
     }
 
     @Test
-    public void testSnapshotsWithoutDefaultRule() {
+    void testSnapshotsWithoutDefaultRule() {
         Instant now = Instant.ofEpochSecond(1500000000);
 
         CentralizedManifest m = new CentralizedManifest();
@@ -285,11 +285,11 @@ public class CentralizedManifestTest {
 
         List<SamplingStatisticsDocument> snapshots = m.snapshots(now);
 
-        Assert.assertEquals(2, snapshots.size());
+        Assertions.assertEquals(2, snapshots.size());
     }
 
     @Test
-    public void testRebuild() {
+    void testRebuild() {
         Map<String, CentralizedRule> rules = new HashMap<>();
         rules.put("r1", new CentralizedRule(rule("r1").withPriority(11), new RandImpl()));
         rules.put("r2", new CentralizedRule(rule("r2"), new RandImpl()));
@@ -302,14 +302,14 @@ public class CentralizedManifestTest {
         CentralizedManifest m = new CentralizedManifest();
         Map<String, CentralizedRule> rebuiltRules = m.rebuild(rules, inputs);
 
-        Assert.assertEquals(3, rebuiltRules.size());
+        Assertions.assertEquals(3, rebuiltRules.size());
 
         String[] orderedList = new String[3];
         rebuiltRules.keySet().toArray(orderedList);
 
-        Assert.assertEquals("r2", orderedList[0]);
-        Assert.assertEquals("r3", orderedList[1]);
-        Assert.assertEquals("r1", orderedList[2]);
+        Assertions.assertEquals("r2", orderedList[0]);
+        Assertions.assertEquals("r3", orderedList[1]);
+        Assertions.assertEquals("r1", orderedList[2]);
     }
 
     private SamplingRule rule(String ruleName) {

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/rule/MatchersTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/rule/MatchersTest.java
@@ -19,13 +19,13 @@ import com.amazonaws.services.xray.model.SamplingRule;
 import com.amazonaws.xray.strategy.sampling.SamplingRequest;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class MatchersTest {
+class MatchersTest {
 
     @Test
-    public void testSimpleMatch() {
+    void testSimpleMatch() {
         SamplingRule rule = new SamplingRule()
             .withAttributes(null)
             .withHost("192.168.1.1")
@@ -48,11 +48,11 @@ public class MatchersTest {
 
         Matchers m = new Matchers(rule);
 
-        Assert.assertTrue(m.match(req));
+        Assertions.assertTrue(m.match(req));
     }
 
     @Test
-    public void testSimpleMismatch() {
+    void testSimpleMismatch() {
         SamplingRule rule = new SamplingRule()
             .withAttributes(null)
             .withHost("192.168.1.1")
@@ -75,11 +75,11 @@ public class MatchersTest {
 
         Matchers m = new Matchers(rule);
 
-        Assert.assertFalse(m.match(req));
+        Assertions.assertFalse(m.match(req));
     }
 
     @Test
-    public void testFullGlobMatch() {
+    void testFullGlobMatch() {
         Map<String, String> ruleAttributes = new HashMap<>();
         ruleAttributes.put("ip", "*");
         ruleAttributes.put("compression", "*");
@@ -111,11 +111,11 @@ public class MatchersTest {
 
         Matchers m = new Matchers(rule);
 
-        Assert.assertTrue(m.match(req));
+        Assertions.assertTrue(m.match(req));
     }
 
     @Test
-    public void testPartialGlobMatch() {
+    void testPartialGlobMatch() {
         Map<String, String> ruleAttributes = new HashMap<>();
         ruleAttributes.put("ip", "127.*.1");
         ruleAttributes.put("compression", "*");
@@ -147,11 +147,11 @@ public class MatchersTest {
 
         Matchers m = new Matchers(rule);
 
-        Assert.assertTrue(m.match(req));
+        Assertions.assertTrue(m.match(req));
     }
 
     @Test
-    public void testPartialGlobMismatch() {
+    void testPartialGlobMismatch() {
         SamplingRule rule = new SamplingRule()
             .withAttributes(null)
             .withHost("*")
@@ -174,11 +174,11 @@ public class MatchersTest {
 
         Matchers m = new Matchers(rule);
 
-        Assert.assertFalse(m.match(req));
+        Assertions.assertFalse(m.match(req));
     }
 
     @Test
-    public void testPartialAttributeGlobMismatch() {
+    void testPartialAttributeGlobMismatch() {
         Map<String, String> ruleAttributes = new HashMap<>();
         ruleAttributes.put("ip", "127.*.0");
         ruleAttributes.put("compression", "*");
@@ -210,11 +210,11 @@ public class MatchersTest {
 
         Matchers m = new Matchers(rule);
 
-        Assert.assertFalse(m.match(req));
+        Assertions.assertFalse(m.match(req));
     }
 
     @Test
-    public void testPartialRequestMismatch() {
+    void testPartialRequestMismatch() {
         SamplingRule rule = new SamplingRule()
             .withAttributes(null)
             .withHost("192.168.1.1")
@@ -237,7 +237,7 @@ public class MatchersTest {
 
         Matchers m = new Matchers(rule);
 
-        Assert.assertFalse(m.match(req));
+        Assertions.assertFalse(m.match(req));
     }
 
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/ByteUtilsTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/ByteUtilsTest.java
@@ -17,15 +17,12 @@ package com.amazonaws.xray.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.Test;
 
-@FixMethodOrder(MethodSorters.JVM)
-public class ByteUtilsTest {
+class ByteUtilsTest {
 
     @Test
-    public void testHexString() {
+    void testHexString() {
         byte[] zeroArray = new byte[16];
         assertThat(ByteUtils.byteArrayToHexString(zeroArray)).isEqualTo("00000000000000000000000000000000");
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/DockerUtilsTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/DockerUtilsTest.java
@@ -16,38 +16,38 @@
 package com.amazonaws.xray.utils;
 
 import java.io.IOException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class DockerUtilsTest {
+class DockerUtilsTest {
     private static final String DOCKER_ID = "79311de543c2b01bdbb7ccaf355e71a02b0726366a1427ecfceb5e1f5be81644";
 
     @Test
-    public void testEmptyCgroupFile() throws IOException {
+    void testEmptyCgroupFile() throws IOException {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource("/com/amazonaws/xray/utils/emptyCgroup"));
         String id = dockerUtils.getContainerId();
-        Assert.assertNull(id);
+        Assertions.assertNull(id);
     }
 
     @Test
-    public void testInvalidCgroupFile() throws IOException {
+    void testInvalidCgroupFile() throws IOException {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource("/com/amazonaws/xray/utils/invalidCgroup"));
         String id = dockerUtils.getContainerId();
-        Assert.assertNull(id);
+        Assertions.assertNull(id);
     }
 
     @Test
-    public void testValidFirstLineCgroupFile() throws IOException {
+    void testValidFirstLineCgroupFile() throws IOException {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource("/com/amazonaws/xray/utils/validCgroup"));
         String id = dockerUtils.getContainerId();
-        Assert.assertEquals(DOCKER_ID, id);
+        Assertions.assertEquals(DOCKER_ID, id);
     }
 
     @Test
-    public void testValidLaterLineCgroupFile() throws IOException {
+    void testValidLaterLineCgroupFile() throws IOException {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource(
             "/com/amazonaws/xray/utils/validSecondCgroup"));
         String id = dockerUtils.getContainerId();
-        Assert.assertEquals(DOCKER_ID, id);
+        Assertions.assertEquals(DOCKER_ID, id);
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/JsonUtilsTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/JsonUtilsTest.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class JsonUtilsTest {
+class JsonUtilsTest {
     private static final String SINGLE_LOG_CONFIG = "[{\"log_group_name\":\"test_group\"}]";
     private static final String MULTI_LOG_CONFIG = "[{\"log_group_name\":\"test_group1\"}, {\"log_group_name\":\"test_group2\"}, "
                                                    + "{\"log_group_name\":\"test_group1\"}]";
@@ -34,33 +34,33 @@ public class JsonUtilsTest {
     private ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    public void testGetLogGroup() throws IOException {
+    void testGetLogGroup() throws IOException {
         JsonNode node = mapper.readTree(SINGLE_LOG_CONFIG);
 
         List<String> groupList = JsonUtils.getMatchingListFromJsonArrayNode(node, LOG_GROUP_NAME);
 
-        Assert.assertEquals(1, groupList.size());
-        Assert.assertEquals("test_group", groupList.get(0));
+        Assertions.assertEquals(1, groupList.size());
+        Assertions.assertEquals("test_group", groupList.get(0));
     }
 
     @Test
-    public void testGetMultipleLogGroups() throws IOException {
+    void testGetMultipleLogGroups() throws IOException {
         JsonNode node = mapper.readTree(MULTI_LOG_CONFIG);
 
         List<String> groupList = JsonUtils.getMatchingListFromJsonArrayNode(node, LOG_GROUP_NAME);
 
-        Assert.assertEquals(3, groupList.size());
-        Assert.assertTrue(groupList.contains("test_group1"));
-        Assert.assertTrue(groupList.contains("test_group2"));
+        Assertions.assertEquals(3, groupList.size());
+        Assertions.assertTrue(groupList.contains("test_group1"));
+        Assertions.assertTrue(groupList.contains("test_group2"));
     }
 
     @Test
-    public void testGetLogGroupWithStreamPresent() throws IOException {
+    void testGetLogGroupWithStreamPresent() throws IOException {
         JsonNode node = mapper.readTree(SINGLE_LOG_CONFIG_WITH_STREAM);
 
         List<String> groupList = JsonUtils.getMatchingListFromJsonArrayNode(node, LOG_GROUP_NAME);
 
-        Assert.assertEquals(1, groupList.size());
-        Assert.assertEquals("test_group", groupList.get(0));
+        Assertions.assertEquals(1, groupList.size());
+        Assertions.assertEquals("test_group", groupList.get(0));
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/LooseValidationsTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/LooseValidationsTest.java
@@ -19,22 +19,22 @@ import static com.amazonaws.xray.utils.LooseValidations.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.xray.utils.LooseValidations.ValidationMode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class LooseValidationsTest {
+class LooseValidationsTest {
 
     @Test
-    public void checkNotNull_notNull() {
+    void checkNotNull_notNull() {
         assertThat(checkNotNull("bar", "foo")).isTrue();
     }
 
     @Test
-    public void checkNotNull_null() {
+    void checkNotNull_null() {
         assertThat(checkNotNull(null, "foo")).isFalse();
     }
 
     @Test
-    public void validationModeParsing() {
+    void validationModeParsing() {
         assertThat(LooseValidations.validationMode("none")).isEqualTo(ValidationMode.NONE);
         assertThat(LooseValidations.validationMode("NONE")).isEqualTo(ValidationMode.NONE);
         assertThat(LooseValidations.validationMode("log")).isEqualTo(ValidationMode.LOG);

--- a/aws-xray-recorder-sdk-log4j/src/test/java/com.amazonaws.xray.log4j/Log4JSegmentListenerTest.java
+++ b/aws-xray-recorder-sdk-log4j/src/test/java/com.amazonaws.xray.log4j/Log4JSegmentListenerTest.java
@@ -24,17 +24,17 @@ import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.SubsegmentImpl;
 import com.amazonaws.xray.entities.TraceID;
 import org.apache.logging.log4j.ThreadContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class Log4JSegmentListenerTest {
+class Log4JSegmentListenerTest {
     private static final TraceID TRACE_ID =  TraceID.fromString("1-1-d0a73661177562839f503b9f");
     private static final String TRACE_ID_KEY = "AWS-XRAY-TRACE-ID";
 
-    @Before
-    public void setupAWSXRay() {
+    @BeforeEach
+    void setupAWSXRay() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.any());
         Mockito.doReturn(true).when(blankEmitter).sendSubsegment(Mockito.any());
@@ -49,49 +49,49 @@ public class Log4JSegmentListenerTest {
     }
 
     @Test
-    public void testDefaultPrefix() {
+    void testDefaultPrefix() {
         Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", TRACE_ID);
 
         listener.onSetEntity(null, seg);
 
-        Assert.assertEquals(TRACE_ID_KEY + ": " + TRACE_ID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assertions.assertEquals(TRACE_ID_KEY + ": " + TRACE_ID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
     }
 
     @Test
-    public void testSetPrefix() {
-        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
-        listener.setPrefix("");
-        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", TRACE_ID);
-
-        listener.onSetEntity(null, seg);
-
-        Assert.assertEquals(TRACE_ID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
-    }
-
-    @Test
-    public void testSegmentInjection() {
+    void testSetPrefix() {
         Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", TRACE_ID);
+
         listener.onSetEntity(null, seg);
 
-        Assert.assertEquals(TRACE_ID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assertions.assertEquals(TRACE_ID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
     }
 
     @Test
-    public void testUnsampledSegmentInjection() {
+    void testSegmentInjection() {
+        Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
+        listener.setPrefix("");
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", TRACE_ID);
+        listener.onSetEntity(null, seg);
+
+        Assertions.assertEquals(TRACE_ID.toString() + "@" + seg.getId(), ThreadContext.get(TRACE_ID_KEY));
+    }
+
+    @Test
+    void testUnsampledSegmentInjection() {
         Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", TRACE_ID);
         seg.setSampled(false);
         listener.onSetEntity(null, seg);
 
-        Assert.assertNull(ThreadContext.get(TRACE_ID_KEY));
+        Assertions.assertNull(ThreadContext.get(TRACE_ID_KEY));
     }
 
     @Test
-    public void testSubsegmentInjection() {
+    void testSubsegmentInjection() {
         Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", TRACE_ID);
@@ -99,11 +99,11 @@ public class Log4JSegmentListenerTest {
         Subsegment sub = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test", seg);
         listener.onSetEntity(seg, sub);
 
-        Assert.assertEquals(TRACE_ID.toString() + "@" + sub.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assertions.assertEquals(TRACE_ID.toString() + "@" + sub.getId(), ThreadContext.get(TRACE_ID_KEY));
     }
 
     @Test
-    public void testNestedSubsegmentInjection() {
+    void testNestedSubsegmentInjection() {
         Log4JSegmentListener listener = (Log4JSegmentListener) AWSXRay.getGlobalRecorder().getSegmentListeners().get(0);
         listener.setPrefix("");
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test", TRACE_ID);
@@ -113,6 +113,6 @@ public class Log4JSegmentListenerTest {
         Subsegment sub2 = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test2", seg);
         listener.onSetEntity(sub1, sub2);
 
-        Assert.assertEquals(TRACE_ID.toString() + "@" + sub2.getId(), ThreadContext.get(TRACE_ID_KEY));
+        Assertions.assertEquals(TRACE_ID.toString() + "@" + sub2.getId(), ThreadContext.get(TRACE_ID_KEY));
     }
 }

--- a/aws-xray-recorder-sdk-metrics/src/test/java/com/amazonaws/xray/metrics/EMFMetricFormatterTest.java
+++ b/aws-xray-recorder-sdk-metrics/src/test/java/com/amazonaws/xray/metrics/EMFMetricFormatterTest.java
@@ -15,17 +15,16 @@
 
 package com.amazonaws.xray.metrics;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.TraceID;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class EMFMetricFormatterTest {
+class EMFMetricFormatterTest {
     private static final String TEST_SERVICE = "testService";
     private static final String TEST_ORIGIN = "Test::Origin";
     private static final double START_TIME = 550378800.0d;
@@ -45,8 +44,8 @@ public class EMFMetricFormatterTest {
     private Segment testSegment;
     private EMFMetricFormatter formatter;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
 
 
         TraceID traceId = TraceID.fromString("1-5759e988-bd862e3fe1be46a994272793");
@@ -66,14 +65,14 @@ public class EMFMetricFormatterTest {
 
 
     @Test
-    public void testJsonFormat() {
+    void testJsonFormat() {
         String json = formatter.formatSegment(testSegment);
-        assertEquals(EXPECTED_JSON, json);
+        Assertions.assertEquals(EXPECTED_JSON, json);
     }
 
     @Test
-    public void jsonContainsNoNewlines() {
+    void jsonContainsNoNewlines() {
         String json = formatter.formatSegment(testSegment);
-        assertFalse(json.contains("\n"));
+        Assertions.assertFalse(json.contains("\n"));
     }
 }

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingConnectionTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingConnectionTest.java
@@ -15,8 +15,6 @@
 
 package com.amazonaws.xray.sql;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -25,15 +23,18 @@ import static org.mockito.Mockito.verify;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
-public class TracingConnectionTest {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TracingConnectionTest {
 
     private Connection connection;
 
@@ -43,12 +44,11 @@ public class TracingConnectionTest {
     public interface ExtraInterface {
     }
 
-
     @Mock
     private OtherWrapper delegate;
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void setup() throws SQLException {
         connection = TracingConnection.decorate(delegate);
         doReturn(false).when(delegate).isWrapperFor(any());
@@ -60,13 +60,13 @@ public class TracingConnectionTest {
     }
 
     @Test
-    public void testDecoration() throws SQLException {
-        assertTrue(connection instanceof TracingConnection);
-        assertTrue(connection.isWrapperFor(Connection.class));
-        assertTrue(connection.isWrapperFor(TracingConnection.class));
-        assertTrue(connection.isWrapperFor(OtherWrapper.class));
-        assertTrue(connection.isWrapperFor(ExtraInterface.class));
-        assertFalse(connection.isWrapperFor(Long.class));
+    void testDecoration() throws SQLException {
+        Assertions.assertTrue(connection instanceof TracingConnection);
+        Assertions.assertTrue(connection.isWrapperFor(Connection.class));
+        Assertions.assertTrue(connection.isWrapperFor(TracingConnection.class));
+        Assertions.assertTrue(connection.isWrapperFor(OtherWrapper.class));
+        Assertions.assertTrue(connection.isWrapperFor(ExtraInterface.class));
+        Assertions.assertFalse(connection.isWrapperFor(Long.class));
         verify(delegate, never()).isWrapperFor(Connection.class);
         verify(delegate, never()).isWrapperFor(TracingConnection.class);
         verify(delegate).isWrapperFor(OtherWrapper.class);
@@ -75,18 +75,18 @@ public class TracingConnectionTest {
     }
 
     @Test
-    public void testUnwrap() throws SQLException {
-        Assert.assertSame(connection, connection.unwrap(Connection.class));
-        Assert.assertSame(connection, connection.unwrap(TracingConnection.class));
-        Assert.assertSame(delegate, connection.unwrap(OtherWrapper.class));
-        Assert.assertSame(delegate, connection.unwrap(ExtraInterface.class));
+    void testUnwrap() throws SQLException {
+        Assertions.assertSame(connection, connection.unwrap(Connection.class));
+        Assertions.assertSame(connection, connection.unwrap(TracingConnection.class));
+        Assertions.assertSame(delegate, connection.unwrap(OtherWrapper.class));
+        Assertions.assertSame(delegate, connection.unwrap(ExtraInterface.class));
         boolean exceptionThrown = false;
         try {
             connection.unwrap(Long.class);
         } catch (final SQLException e) {
             exceptionThrown = true;
         }
-        assertTrue(exceptionThrown);
+        Assertions.assertTrue(exceptionThrown);
         verify(delegate, never()).unwrap(Connection.class);
         verify(delegate, never()).unwrap(TracingConnection.class);
         verify(delegate).unwrap(OtherWrapper.class);
@@ -95,47 +95,47 @@ public class TracingConnectionTest {
     }
 
     @Test
-    public void testCreateStatement() throws Exception {
-        assertTrue(connection.createStatement() != null);
+    void testCreateStatement() throws Exception {
+        Assertions.assertTrue(connection.createStatement() != null);
         verify(delegate).createStatement();
 
-        assertTrue(connection.createStatement(2, 3) != null);
+        Assertions.assertTrue(connection.createStatement(2, 3) != null);
         verify(delegate).createStatement(2, 3);
 
-        assertTrue(connection.createStatement(2, 3, 4) != null);
+        Assertions.assertTrue(connection.createStatement(2, 3, 4) != null);
         verify(delegate).createStatement(2, 3, 4);
     }
 
     @Test
-    public void testPrepareStatement() throws Exception {
-        assertTrue(connection.prepareStatement("foo") != null);
+    void testPrepareStatement() throws Exception {
+        Assertions.assertTrue(connection.prepareStatement("foo") != null);
         verify(delegate).prepareStatement("foo");
 
-        assertTrue(connection.prepareStatement("foo", 2) != null);
+        Assertions.assertTrue(connection.prepareStatement("foo", 2) != null);
         verify(delegate).prepareStatement("foo", 2);
 
-        assertTrue(connection.prepareStatement("foo", new int[] {2, 3}) != null);
+        Assertions.assertTrue(connection.prepareStatement("foo", new int[] {2, 3}) != null);
         verify(delegate).prepareStatement("foo", new int[]{2, 3});
 
-        assertTrue(connection.prepareStatement("foo", new String[] {"bar", "baz"}) != null);
+        Assertions.assertTrue(connection.prepareStatement("foo", new String[] {"bar", "baz"}) != null);
         verify(delegate).prepareStatement("foo", new String[]{"bar", "baz"});
 
-        assertTrue(connection.prepareStatement("foo", 2, 3) != null);
+        Assertions.assertTrue(connection.prepareStatement("foo", 2, 3) != null);
         verify(delegate).prepareStatement("foo", 2, 3);
 
-        assertTrue(connection.prepareStatement("foo", 2, 3, 4) != null);
+        Assertions.assertTrue(connection.prepareStatement("foo", 2, 3, 4) != null);
         verify(delegate).prepareStatement("foo", 2, 3, 4);
     }
 
     @Test
-    public void testPrepareCall() throws Exception {
-        assertTrue(connection.prepareCall("foo") != null);
+    void testPrepareCall() throws Exception {
+        Assertions.assertTrue(connection.prepareCall("foo") != null);
         verify(delegate).prepareCall("foo");
 
-        assertTrue(connection.prepareCall("foo", 2, 3) != null);
+        Assertions.assertTrue(connection.prepareCall("foo", 2, 3) != null);
         verify(delegate).prepareCall("foo", 2, 3);
 
-        assertTrue(connection.prepareCall("foo", 2, 3, 4) != null);
+        Assertions.assertTrue(connection.prepareCall("foo", 2, 3, 4) != null);
         verify(delegate).prepareCall("foo", 2, 3, 4);
     }
 }

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingDataSourceTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/TracingDataSourceTest.java
@@ -15,8 +15,6 @@
 
 package com.amazonaws.xray.sql;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -25,15 +23,18 @@ import static org.mockito.Mockito.verify;
 
 import java.sql.SQLException;
 import javax.sql.DataSource;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
-public class TracingDataSourceTest {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TracingDataSourceTest {
 
     private DataSource dataSource;
 
@@ -47,7 +48,7 @@ public class TracingDataSourceTest {
     private OtherWrapper delegate;
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void setup() throws SQLException {
         dataSource = TracingDataSource.decorate(delegate);
         doReturn(false).when(delegate).isWrapperFor(any());
@@ -59,13 +60,13 @@ public class TracingDataSourceTest {
     }
 
     @Test
-    public void testDecoration() throws SQLException {
-        assertTrue(dataSource instanceof TracingDataSource);
-        assertTrue(dataSource.isWrapperFor(DataSource.class));
-        assertTrue(dataSource.isWrapperFor(TracingDataSource.class));
-        assertTrue(dataSource.isWrapperFor(OtherWrapper.class));
-        assertTrue(dataSource.isWrapperFor(ExtraInterface.class));
-        assertFalse(dataSource.isWrapperFor(Long.class));
+    void testDecoration() throws SQLException {
+        Assertions.assertTrue(dataSource instanceof TracingDataSource);
+        Assertions.assertTrue(dataSource.isWrapperFor(DataSource.class));
+        Assertions.assertTrue(dataSource.isWrapperFor(TracingDataSource.class));
+        Assertions.assertTrue(dataSource.isWrapperFor(OtherWrapper.class));
+        Assertions.assertTrue(dataSource.isWrapperFor(ExtraInterface.class));
+        Assertions.assertFalse(dataSource.isWrapperFor(Long.class));
         verify(delegate, never()).isWrapperFor(DataSource.class);
         verify(delegate, never()).isWrapperFor(TracingDataSource.class);
         verify(delegate).isWrapperFor(OtherWrapper.class);
@@ -74,18 +75,18 @@ public class TracingDataSourceTest {
     }
 
     @Test
-    public void testUnwrap() throws SQLException {
-        Assert.assertSame(dataSource, dataSource.unwrap(DataSource.class));
-        Assert.assertSame(dataSource, dataSource.unwrap(TracingDataSource.class));
-        Assert.assertSame(delegate, dataSource.unwrap(OtherWrapper.class));
-        Assert.assertSame(delegate, dataSource.unwrap(ExtraInterface.class));
+    void testUnwrap() throws SQLException {
+        Assertions.assertSame(dataSource, dataSource.unwrap(DataSource.class));
+        Assertions.assertSame(dataSource, dataSource.unwrap(TracingDataSource.class));
+        Assertions.assertSame(delegate, dataSource.unwrap(OtherWrapper.class));
+        Assertions.assertSame(delegate, dataSource.unwrap(ExtraInterface.class));
         boolean exceptionThrown = false;
         try {
             dataSource.unwrap(Long.class);
         } catch (final SQLException e) {
             exceptionThrown = true;
         }
-        assertTrue(exceptionThrown);
+        Assertions.assertTrue(exceptionThrown);
         verify(delegate, never()).unwrap(DataSource.class);
         verify(delegate, never()).unwrap(TracingDataSource.class);
         verify(delegate).unwrap(OtherWrapper.class);
@@ -96,11 +97,11 @@ public class TracingDataSourceTest {
     ;
 
     @Test
-    public void testGetConnection() throws Exception {
-        assertTrue(dataSource.getConnection() instanceof TracingConnection);
+    void testGetConnection() throws Exception {
+        Assertions.assertTrue(dataSource.getConnection() instanceof TracingConnection);
         verify(delegate).getConnection();
 
-        assertTrue(dataSource.getConnection("foo", "bar") instanceof TracingConnection);
+        Assertions.assertTrue(dataSource.getConnection("foo", "bar") instanceof TracingConnection);
         verify(delegate).getConnection("foo", "bar");
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,9 +103,14 @@ allprojects {
         }
 
         dependencies {
+            add("testImplementation", "org.junit.jupiter:junit-jupiter-api")
+            add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine")
+            add("testRuntimeOnly", "org.junit.vintage:junit-vintage-engine")
             add("testImplementation", "junit:junit")
+
             add("testImplementation", "org.assertj:assertj-core")
             add("testImplementation", "org.mockito:mockito-core")
+            add("testImplementation", "org.mockito:mockito-junit-jupiter")
 
             add("compileOnly", "org.checkerframework:checker-qual:3.4.1")
             add("testImplementation", "org.checkerframework:checker-qual:3.4.1")
@@ -159,6 +164,8 @@ allprojects {
             }
 
             withType<Test> {
+                useJUnitPlatform()
+
                 testLogging {
                     exceptionFormat = TestExceptionFormat.FULL
                     showStackTraces = true

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-    "com.fasterxml.jackson:jackson-bom:2.11.0"
+        "com.fasterxml.jackson:jackson-bom:2.11.0",
+        "org.junit:junit-bom:5.6.2"
 )
 
 val DEPENDENCY_SETS = listOf(
@@ -32,7 +33,7 @@ val DEPENDENCY_SETS = listOf(
         DependencySet(
                 "org.mockito",
                 "2.28.2",
-                listOf("mockito-all", "mockito-core")
+                listOf("mockito-all", "mockito-core", "mockito-junit-jupiter")
         )
 )
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
         <type>pom</type>
       </dependency>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.6.2</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-jre8</artifactId>
         <version>2.26.3</version>
@@ -77,6 +84,27 @@
       <artifactId>checker-qual</artifactId>
       <version>3.4.1</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>2.28.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <distributionManagement>


### PR DESCRIPTION
JUnit5 is the currently maintained JUnit and has a lot of nice features on top of JUnit4. We don't have that many tests right now (unfortunately) so now is a good time to migrate.

Can't migrate powermock and wiremock tests yet, will work on adding a wiremock jupiter extension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
