### PR TITLE
made SqlSubsegments handle exceptions internally

### DIFF
--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
@@ -36,43 +36,55 @@ public final class SqlSubsegments {
     private static final Log logger = LogFactory.getLog(SqlSubsegments.class);
 
     // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-sql
-    private static final String DEFAULT_DATABASE_NAME = "database";
     private static final String URL = "url";
     private static final String USER = "user";
-    private static final String DRIVER_VERSION = "driver_version";
-    private static final String DATABASE_TYPE = "database_type";
-    private static final String DATABASE_VERSION = "database_version";
-    private static final String SANITIZED_QUERY = "sanitized_query";
+
+    public static final String DRIVER_VERSION = "driver_version";
+    public static final String DATABASE_TYPE = "database_type";
+    public static final String DATABASE_VERSION = "database_version";
+    public static final String SANITIZED_QUERY = "sanitized_query";
+    public static final String DEFAULT_DATABASE_NAME = "database";
 
     /**
      * Begins a {@link Subsegment} populated with data provided by the {@link Connection#getMetaData} method. Includes
-     * the SQL query string if it is non-null, omits it otherwise.
+     * the SQL query string if it is non-null, omits it otherwise. Takes care to swallow any potential
+     * {@link SQLException}s and always start a subsegment for consistency.
      *
      * @param connection the JDBC connection object used for the query this {@link Subsegment} represents.
      * @param query the SQL query string used in this query, or {@code null} if it is not desirable to include in the
      *              subsegment, e.g. for security concerns.
      * @return the created {@link Subsegment}.
-     * @throws SQLException if there is a bad interaction with the {@link Connection}.
      */
-    public static Subsegment forQuery(Connection connection, @Nullable String query) throws SQLException {
-        DatabaseMetaData metadata = connection.getMetaData();
+    public static Subsegment forQuery(Connection connection, @Nullable String query) {
+        DatabaseMetaData metadata = null;
         String subsegmentName = DEFAULT_DATABASE_NAME;
+
         try {
+            metadata = connection.getMetaData();
+            String database = connection.getCatalog();
             URI normalizedUri = new URI(new URI(metadata.getURL()).getSchemeSpecificPart());
-            subsegmentName = connection.getCatalog() + "@" + normalizedUri.getHost();
+            subsegmentName = database + "@" + normalizedUri.getHost();
         } catch (URISyntaxException e) {
             logger.debug("Unable to parse database URI. Falling back to default '" + DEFAULT_DATABASE_NAME
-                    + "' for subsegment name.", e);
+                + "' for subsegment name.", e);
+        } catch (SQLException e) {
+            logger.debug("Encountered exception while retrieving metadata for SQL subsegment "
+                + ", starting blank subsegment instead");
+            return AWSXRay.beginSubsegment(subsegmentName);
         }
 
         Subsegment subsegment = AWSXRay.beginSubsegment(subsegmentName);
-
         subsegment.setNamespace(Namespace.REMOTE.toString());
-        subsegment.putSql(URL, metadata.getURL());
-        subsegment.putSql(USER, metadata.getUserName());
-        subsegment.putSql(DRIVER_VERSION, metadata.getDriverVersion());
-        subsegment.putSql(DATABASE_TYPE, metadata.getDatabaseProductName());
-        subsegment.putSql(DATABASE_VERSION, metadata.getDatabaseProductVersion());
+
+        try {
+            subsegment.putSql(URL, metadata.getURL());
+            subsegment.putSql(USER, metadata.getUserName());
+            subsegment.putSql(DRIVER_VERSION, metadata.getDriverVersion());
+            subsegment.putSql(DATABASE_TYPE, metadata.getDatabaseProductName());
+            subsegment.putSql(DATABASE_VERSION, metadata.getDatabaseProductVersion());
+        } catch (SQLException e) {
+            logger.debug("Encountered exception while populating SQL subsegment metadata", e);
+        }
 
         if (query != null) {
             subsegment.putSql(SANITIZED_QUERY, query);

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
@@ -31,18 +31,46 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Class containing utility method to create fully-populated SQL subsegments.
+ * See https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-sql
  */
 public final class SqlSubsegments {
     private static final Log logger = LogFactory.getLog(SqlSubsegments.class);
 
-    // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-sql
-    private static final String URL = "url";
-    private static final String USER = "user";
+    /**
+     * The URL of the database this query is made on
+     */
+    public static final String URL = "url";
 
+    /**
+     * The database username
+     */
+    public static final String USER = "user";
+
+    /**
+     * The version of the database driver library used for this database
+     */
     public static final String DRIVER_VERSION = "driver_version";
+
+    /**
+     * The type of SQL Database this query is done on, like MySQL or HikariCP
+     */
     public static final String DATABASE_TYPE = "database_type";
+
+    /**
+     * The version of the database product itself, like MySQL 8.0
+     */
     public static final String DATABASE_VERSION = "database_version";
+
+    /**
+     * The SQL query string used in this query. This is not recorded in subsegments by default due to security issues.
+     * SDK users may use this key or {@link #forQuery} to manually record their queries if they wish.
+     * See https://github.com/aws/aws-xray-sdk-java/issues/28
+     */
     public static final String SANITIZED_QUERY = "sanitized_query";
+
+    /**
+     * The fallback name for subsegments representing SQL queries that failed to be named dynamically
+     */
     public static final String DEFAULT_DATABASE_NAME = "database";
 
     /**

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
@@ -110,7 +110,8 @@ public class SqlSubsegmentsTest {
         Subsegment sub = SqlSubsegments.forQuery(connection, SQL);
 
         assertThat(AWSXRay.getCurrentSubsegment()).isEqualTo(sub);
+        assertThat(sub.getName()).isEqualTo(SqlSubsegments.DEFAULT_DATABASE_NAME);
         assertThat(sub.isInProgress()).isTrue();
-        assertThat(sub.getParentSegment().getSubsegments()).containsOnly(sub);
+        assertThat(sub.getParentSegment().getSubsegments()).contains(sub);
     }
 }

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
@@ -71,7 +71,7 @@ public class SqlSubsegmentsTest {
     }
 
     @Test
-    void testCreateSubsegmentWithoutSql() throws SQLException {
+    void testCreateSubsegmentWithoutSql() {
         expectedSqlParams = new HashMap<>();
         expectedSqlParams.put("url", URL);
         expectedSqlParams.put("user", USER);
@@ -87,7 +87,7 @@ public class SqlSubsegmentsTest {
     }
 
     @Test
-    void testCreateSubsegmentWithSql() throws SQLException {
+    void testCreateSubsegmentWithSql() {
         expectedSqlParams = new HashMap<>();
         expectedSqlParams.put("url", URL);
         expectedSqlParams.put("user", USER);
@@ -101,5 +101,16 @@ public class SqlSubsegmentsTest {
         assertThat(sub.getName()).isEqualTo(CATALOG + "@" + HOST);
         assertThat(sub.getNamespace()).isEqualTo(Namespace.REMOTE.toString());
         assertThat(sub.getSql()).containsAllEntriesOf(expectedSqlParams);
+    }
+
+    @Test
+    void testCreateSubsegmentWhenConnectionThrowsException() throws SQLException {
+        when(connection.getMetaData()).thenThrow(new SQLException());
+
+        Subsegment sub = SqlSubsegments.forQuery(connection, SQL);
+
+        assertThat(AWSXRay.getCurrentSubsegment()).isEqualTo(sub);
+        assertThat(sub.isInProgress()).isTrue();
+        assertThat(sub.getParentSegment().getSubsegments()).containsOnly(sub);
     }
 }


### PR DESCRIPTION
*Description of changes:*
Follow up to #186 after actually using the change, I realized that there could be some weird inconsistent state behavior the way I implemented it. An unchecked `SQLException` could be thrown both before and after the subsegment was begun, so it was not a guarantee that calling the method would always create a subsegment. This was a recipe for bad behavior/segment leaks. 

Now, we catch all the SQL Exceptions, log useful messages, and make absolutely sure *some* sort of subsegment is began since that is the expected behavior.

Also exposed some of the SQL subsegment fields, since they are the publicly documented whitelisted values (e.g. won't be changing often).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
