### PR TITLE
added stacktrace to Log error strat

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/LogErrorContextMissingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/LogErrorContextMissingStrategy.java
@@ -32,7 +32,8 @@ public class LogErrorContextMissingStrategy implements ContextMissingStrategy {
     @Override
     public void contextMissing(String message, Class<? extends RuntimeException> exceptionClass) {
         logger.error("Suppressing AWS X-Ray context missing exception (" + exceptionClass.getSimpleName() + "): " + message);
-        logger.debug(new RuntimeException(message));
+        if (logger.isDebugEnabled()) {
+            logger.debug(new RuntimeException(message));
+        }
     }
-
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/LogErrorContextMissingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/LogErrorContextMissingStrategy.java
@@ -32,6 +32,7 @@ public class LogErrorContextMissingStrategy implements ContextMissingStrategy {
     @Override
     public void contextMissing(String message, Class<? extends RuntimeException> exceptionClass) {
         logger.error("Suppressing AWS X-Ray context missing exception (" + exceptionClass.getSimpleName() + "): " + message);
+        logger.debug(new RuntimeException(message));
     }
 
 }


### PR DESCRIPTION
*Description of changes:*
Adds `debug`-level logging of the stacktrace for context missing exceptions that are suppressed by the Log Error strategy. This could be helpful for both customers and us to debug CME issues, especially in the agent whose default strategy is Log Error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
