### PR TITLE
Reduced timeout and log output for IMDS timeout

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
@@ -25,6 +25,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -46,7 +47,7 @@ class EC2MetadataFetcher {
         AMI_ID,
     }
 
-    private static final int TIMEOUT_MILLIS = 2000;
+    private static final int TIMEOUT_MILLIS = 100;
     private static final String DEFAULT_IMDS_ENDPOINT = "169.254.169.254";
 
     private final URL identityDocumentUrl;
@@ -156,7 +157,11 @@ class EC2MetadataFetcher {
         try {
             responseCode = connection.getResponseCode();
         } catch (Exception e) {
-            logger.warn("Error connecting to IMDS.", e);
+            if (e instanceof SocketTimeoutException) {
+                logger.debug("Timed out trying to connect to IMDS, likely not operating in EC2 environment");
+            } else {
+                logger.warn("Error connecting to IMDS.", e);
+            }
             return "";
         }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/EC2MetadataFetcher.java
@@ -47,7 +47,8 @@ class EC2MetadataFetcher {
         AMI_ID,
     }
 
-    private static final int TIMEOUT_MILLIS = 100;
+    private static final int CONNECT_TIMEOUT_MILLIS = 100;
+    private static final int READ_TIMEOUT_MILLIS = 1000;
     private static final String DEFAULT_IMDS_ENDPOINT = "169.254.169.254";
 
     private final URL identityDocumentUrl;
@@ -143,8 +144,8 @@ class EC2MetadataFetcher {
             return "";
         }
 
-        connection.setConnectTimeout(TIMEOUT_MILLIS);
-        connection.setReadTimeout(TIMEOUT_MILLIS);
+        connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+        connection.setReadTimeout(READ_TIMEOUT_MILLIS);
 
         if (includeTtl) {
             connection.setRequestProperty("X-aws-ec2-metadata-token-ttl-seconds", "60");


### PR DESCRIPTION
*Description of changes:*
Currently, `EC2Plugin.isEnabled` calls the IMDS endpoint to determine whether it is operating on EC2. This is fine when we are operating on EC2, since from my tests it takes <3 milliseconds to reach IMDS on an instance.

However, this is problematic as we move toward an opt-out plugin model. In this model, we check `isEnabled` for each plugin regardless of environment, so both failing and passing should be fast. Currently `EC2Plugin.isEnabled()` takes 4 seconds to fail, because the timeout for the IMDS endpoint check is 2 seconds and it checks IMDSv1 and v2 before failing. This is far too long for non-EC2 customers using opt-out plugins.

This PR lowers the timeout quite a bit and suppresses logging if we hit it to be friendlier to non-EC2, opt-out plugin customers. Given how fast successful IMDS requests are, the lower timeout should not impact the plugin's detection ability. To be even faster, we could avoid checking the second check to IMDSv1 when the v2 request times out, but that would require a bit of weird throwing logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
