### PR TITLE
Added Begin segment with sampling

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -92,6 +92,10 @@ public class AWSXRay {
         globalRecorder.createSubsegment(name, runnable);
     }
 
+    public static Segment beginSegmentWithSampling(String name) {
+        return globalRecorder.beginSegmentWithSampling(name);
+    }
+
     public static Segment beginSegment(String name) {
         return globalRecorder.beginSegment(name);
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
@@ -63,7 +63,6 @@ public class AWSLogReference {
 
     /**
      * Compares ARN and log group between references to determine equality.
-     * @param reference
      * @return
      */
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/CentralizedSamplingStrategy.java
@@ -98,8 +98,19 @@ public class CentralizedSamplingStrategy implements SamplingStrategy {
             if (!applicable) {
                 continue;
             }
-            logger.debug("Applicable rule:" + rule.getName());
-            return rule.sample(Instant.now());
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Applicable rule:" + rule.getName());
+            }
+
+            SamplingResponse response = rule.sample(Instant.now());
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Segment " + samplingRequest.getService().orElse("") + " has" +
+                    (response.isSampled() ? " " : " NOT ") + "been sampled.");
+            }
+
+            return response;
         }
 
         // Match against default rule

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
@@ -199,14 +199,18 @@ public class CentralizedRule implements Rule, Comparable<CentralizedRule> {
             // Attempt to borrow request
 
             if (centralizedReservoir.isBorrow(now)) {
-                logger.debug("Sampling target has expired for rule " + getName() + ". Burrowing a request.");
+                logger.debug("Sampling target has expired for rule " + getName() + ". Borrowing a request.");
                 statistics.incBorrowed();
                 res.setSampled(true);
 
                 return res;
             }
 
-            logger.debug("Sampling target has expired for rule " + getName() + ". Using fixed rate.");
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("Sampling target has expired for rule %s. Using fixed rate of %d percent.",
+                    getName(), (int) (fixedRate*100)));
+            }
+
             // Fallback to bernoulli sampling
             if (random < fixedRate) {
                 statistics.incSampled();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
@@ -207,8 +207,8 @@ public class CentralizedRule implements Rule, Comparable<CentralizedRule> {
             }
 
             if (logger.isDebugEnabled()) {
-                logger.debug(String.format("Sampling target has expired for rule %s. Using fixed rate of %d percent.",
-                    getName(), (int) (fixedRate * 100)));
+                logger.debug("Sampling target has expired for rule " + getName() + ". Using fixed rate of " +
+                    (int) (fixedRate * 100) + " percent.");
             }
 
             // Fallback to bernoulli sampling

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/rule/CentralizedRule.java
@@ -208,7 +208,7 @@ public class CentralizedRule implements Rule, Comparable<CentralizedRule> {
 
             if (logger.isDebugEnabled()) {
                 logger.debug(String.format("Sampling target has expired for rule %s. Using fixed rate of %d percent.",
-                    getName(), (int) (fixedRate*100)));
+                    getName(), (int) (fixedRate * 100)));
             }
 
             // Fallback to bernoulli sampling


### PR DESCRIPTION
*Issue #, if available:*
#74 

*Description of changes:*
Added an API to begin a segment and apply the recorder's sampling strategy to it. In the future, this API will be deprecated and this will be the default behavior of `beginSegment`. Tested on my sample app with centralized sampling.

Also improved debug logging within the centralized sampling module, and added a fast-fail to the `endSegment` to make sure we don't emit weird logs when ending a no-op segment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
