### PR TITLE
added sample rule to beginSegmentWithSampling

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -405,7 +405,12 @@ public class AWSXRayRecorder {
         final SamplingRequest samplingRequest = new SamplingRequest(name, null, null, null, this.origin);
         final SamplingResponse samplingResponse = this.getSamplingStrategy().shouldTrace(samplingRequest);
         if (samplingResponse.isSampled()) {
-            return beginSegment(name);
+            Segment segment = beginSegment(name);
+            if (samplingResponse.getRuleName().isPresent()) {
+                segment.setRuleName(samplingResponse.getRuleName().get());
+            }
+
+            return segment;
         }
 
         return beginNoOpSegment();

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -855,6 +855,8 @@ public class AWSXRayRecorderTest {
 
         Segment segment = AWSXRay.beginSegmentWithSampling("test");
         assertThat(segment.isSampled()).isTrue();
+        assertThat(segment.getAws().get("xray")).isInstanceOfSatisfying(
+            Map.class, xray -> assertThat(xray.get("rule_name")).isEqualTo("rule"));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
While fixing #201, I realized the new `beginSegmentWithSampling` API does not include the `rule_name` attribute in the X-Ray block of its segment. This PR includes the attribute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
