### PR TITLE
fixed flaky custom context test

### DIFF
--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/CustomSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/CustomSegmentContextTest.java
@@ -124,7 +124,7 @@ class CustomSegmentContextTest {
             list.add(i);
         }
 
-        list.parallelStream().forEach(e -> {
+        list.forEach(e -> {
             AWSXRay.setTraceEntity(test);
             AWSXRay.createSubsegment("parallelPrint", (subsegment) -> {
             });

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/CustomSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/CustomSegmentContextTest.java
@@ -126,7 +126,7 @@ class CustomSegmentContextTest {
 
         list.forEach(e -> {
             AWSXRay.setTraceEntity(test);
-            AWSXRay.createSubsegment("parallelPrint", (subsegment) -> {
+            AWSXRay.createSubsegment("print", (subsegment) -> {
             });
         });
 


### PR DESCRIPTION
*Description of changes:*
Fixes a flaky unit test that used `parallelStream` to iterate through the creation of a bunch of subsegments. The test was made in a way that the context could be cleared (and replaced with `null`) before a new subsegment was made when running the operations in parallel, which would cause a NPE and fail the test. Removing parallelism should fix it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
