### PR TITLE
Respect setParent calls for noop subsegments.

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -74,7 +74,7 @@ public class LambdaSegmentContext implements SegmentContext {
             Subsegment parentSubsegment = (Subsegment) entity;
             // Ensure customers have not leaked subsegments across invocations
             TraceID environmentRootTraceId = LambdaSegmentContext.getTraceHeaderFromEnvironment().getRootTraceId();
-            if (null != environmentRootTraceId &&
+            if (environmentRootTraceId != null &&
                 !environmentRootTraceId.equals(parentSubsegment.getParentSegment().getTraceId())) {
                 clearTraceEntity();
                 return beginSubsegment(recorder, name);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 class NoOpSubSegment implements Subsegment {
 
-    private final Segment parent;
+    private final Segment parentSegment;
     private final AWSXRayRecorder creator;
 
-    NoOpSubSegment(Segment parent, AWSXRayRecorder creator) {
-        this.parent = parent;
+    private volatile Entity parent;
+
+    NoOpSubSegment(Segment parentSegment, AWSXRayRecorder creator) {
+        this.parentSegment = parentSegment;
         this.creator = creator;
+        parent = parentSegment;
     }
 
     @Override
@@ -164,6 +167,7 @@ class NoOpSubSegment implements Subsegment {
 
     @Override
     public void setParent(Entity parent) {
+        this.parent = parent;
     }
 
     @Override
@@ -186,7 +190,7 @@ class NoOpSubSegment implements Subsegment {
 
     @Override
     public TraceID getTraceId() {
-        return parent.getTraceId();
+        return parentSegment.getTraceId();
     }
 
     @Override
@@ -213,7 +217,7 @@ class NoOpSubSegment implements Subsegment {
 
     @Override
     public Segment getParentSegment() {
-        return parent;
+        return parentSegment;
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
@@ -15,30 +15,29 @@
 
 package com.amazonaws.xray.contexts;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.emitters.Emitter;
 import com.amazonaws.xray.entities.FacadeSegment;
 import com.amazonaws.xray.entities.Subsegment;
-import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@FixMethodOrder(MethodSorters.JVM)
-@PrepareForTest(LambdaSegmentContext.class)
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.net.ssl.*")
-public class LambdaSegmentContextTest {
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LambdaSegmentContextTest {
 
     private static final String TRACE_HEADER = "Root=1-57ff426a-80c11c39b0c928905eb0828d;Parent=1234abcd1234abcd;Sampled=1";
     private static final String TRACE_HEADER_2 = "Root=1-57ff426a-90c11c39b0c928905eb0828d;Parent=9234abcd1234abcd;Sampled=0";
@@ -46,7 +45,7 @@ public class LambdaSegmentContextTest {
     private static final String MALFORMED_TRACE_HEADER =
         ";;Root=1-57ff426a-80c11c39b0c928905eb0828d;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
 
-    @Before
+    @BeforeEach
     public void setupAWSXRay() {
         Emitter blankEmitter = Mockito.mock(Emitter.class);
         Mockito.doReturn(true).when(blankEmitter).sendSegment(Mockito.anyObject());
@@ -59,55 +58,71 @@ public class LambdaSegmentContextTest {
     }
 
     @Test
-    public void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInADummySegmentParent() {
-        testMockContext(TraceHeader.fromString(null), FacadeSegment.class);
+    void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInADummySegmentParent() {
+        testContextResultsInFacadeSegmentParent();
     }
 
     @Test
-    public void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInADummySegmentParent() {
-        testMockContext(TraceHeader.fromString("a"), FacadeSegment.class);
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = "a")
+    void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInADummySegmentParent() {
+        testContextResultsInFacadeSegmentParent();
     }
 
     @Test
-    public void testBeginSubsegmentWithCompleteTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
-        testMockContext(TraceHeader.fromString(TRACE_HEADER), FacadeSegment.class);
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = TRACE_HEADER)
+    void testBeginSubsegmentWithCompleteTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
+        testContextResultsInFacadeSegmentParent();
     }
 
     @Test
-    public void testBeginSubsegmentWithCompleteButMalformedTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
-        testMockContext(TraceHeader.fromString(MALFORMED_TRACE_HEADER), FacadeSegment.class);
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = MALFORMED_TRACE_HEADER)
+    void testBeginSubsegmentWithCompleteButMalformedTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
+        testContextResultsInFacadeSegmentParent();
     }
 
     @Test
-    public void testLeakedSubsegmentsAreCleanedBetweenInvocations() {
-
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = TRACE_HEADER_2)
+    void testNotSampledSetsParentToSubsegment() {
         LambdaSegmentContext lsc = new LambdaSegmentContext();
-
-        PowerMockito.stub(PowerMockito.method(LambdaSegmentContext.class, "getTraceHeaderFromEnvironment"))
-                    .toReturn(TraceHeader.fromString(TRACE_HEADER));
-        Subsegment firstInvocation = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
-        Assert.assertNotNull(AWSXRay.getTraceEntity());
-
-        PowerMockito.stub(PowerMockito.method(LambdaSegmentContext.class, "getTraceHeaderFromEnvironment"))
-                    .toReturn(TraceHeader.fromString(TRACE_HEADER_2));
-        Subsegment secondInvocation = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
-        Assert.assertNotNull(AWSXRay.getTraceEntity());
-
-        Assert.assertTrue(FacadeSegment.class.isInstance(firstInvocation.getParent()));
-        Assert.assertTrue(FacadeSegment.class.isInstance(secondInvocation.getParent()));
+        lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
+        lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test2");
+        lsc.endSubsegment(AWSXRay.getGlobalRecorder());
+        lsc.endSubsegment(AWSXRay.getGlobalRecorder());
     }
 
-    private void testMockContext(TraceHeader xAmznTraceId, Class<?> instanceOfClass) {
-        LambdaSegmentContext mockContext = mockContext(xAmznTraceId);
-        Assert.assertTrue(
-            instanceOfClass.isInstance(mockContext.beginSubsegment(AWSXRay.getGlobalRecorder(), "test").getParent()));
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    static class LeakedSubsegments {
+        LambdaSegmentContext lsc;
+
+        @BeforeAll
+        void setupContext() {
+            lsc = new LambdaSegmentContext();
+        }
+
+        @Test
+        @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = TRACE_HEADER)
+        void oneInvocationGeneratesSegment() {
+            Subsegment firstInvocation = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
+            assertThat(firstInvocation).isNotNull();
+            assertThat(firstInvocation.getParent()).isInstanceOf(FacadeSegment.class);
+        }
+
+        @Test
+        @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = TRACE_HEADER_2)
+        void anotherInvocationGeneratesSegment() {
+            Subsegment secondInvocation = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
+            assertThat(secondInvocation).isNotNull();
+            assertThat(secondInvocation.getParent()).isInstanceOf(FacadeSegment.class);
+        }
+    }
+
+    private static void testContextResultsInFacadeSegmentParent() {
+        LambdaSegmentContext mockContext = new LambdaSegmentContext();
+        assertThat(mockContext.beginSubsegment(AWSXRay.getGlobalRecorder(), "test").getParent())
+            .isInstanceOf(FacadeSegment.class);
         mockContext.endSubsegment(AWSXRay.getGlobalRecorder());
-        Assert.assertNull(AWSXRay.getTraceEntity());
-    }
-
-    private LambdaSegmentContext mockContext(TraceHeader xAmznTraceId) {
-        PowerMockito.stub(
-            PowerMockito.method(LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(xAmznTraceId);
-        return new LambdaSegmentContext();
+        assertThat(AWSXRay.getTraceEntity()).isNull();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
@@ -58,13 +58,13 @@ class LambdaSegmentContextTest {
     }
 
     @Test
-    void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInADummySegmentParent() {
+    void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
         testContextResultsInFacadeSegmentParent();
     }
 
     @Test
     @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = "a")
-    void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInADummySegmentParent() {
+    void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
         testContextResultsInFacadeSegmentParent();
     }
 
@@ -90,7 +90,8 @@ class LambdaSegmentContextTest {
         lsc.endSubsegment(AWSXRay.getGlobalRecorder());
     }
 
-
+    // We create segments twice with different environment variables for the same context, similar to how Lambda would invoke
+    // a function.
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     static class LeakedSubsegments {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,7 @@ allprojects {
 
         dependencies {
             add("testImplementation", "org.junit.jupiter:junit-jupiter-api")
+            add("testImplementation", "org.junit-pioneer:junit-pioneer")
             add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine")
             add("testRuntimeOnly", "org.junit.vintage:junit-vintage-engine")
             add("testImplementation", "junit:junit")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -26,6 +26,11 @@ val DEPENDENCY_SETS = listOf(
                 listOf("assertj-core")
         ),
         DependencySet(
+                "org.junit-pioneer",
+                "0.9.0",
+                listOf("junit-pioneer")
+        ),
+        DependencySet(
                 "junit",
                 "4.12",
                 listOf("junit")


### PR DESCRIPTION
Fixes #213

I mistook that the parent and parent segment are the same. The API is crufty in setting the parent after construction, even though it's a constant, that could be another improvement for a major version. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
