### PR TITLE
Improve ID generation performance

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
@@ -16,7 +16,8 @@
 package com.amazonaws.xray;
 
 import com.amazonaws.xray.entities.Entity;
-import java.security.SecureRandom;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -25,8 +26,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 @Deprecated
 public class ThreadLocalStorage {
-
-    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     static class LocalEntity extends ThreadLocal<@Nullable Entity> {
         @Override
@@ -59,7 +58,7 @@ public class ThreadLocalStorage {
         CURRENT_ENTITY.remove();
     }
 
-    public static SecureRandom getRandom() {
-        return SECURE_RANDOM;
+    public static Random getRandom() {
+        return ThreadLocalRandom.current();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
@@ -28,11 +28,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public interface Entity extends AutoCloseable {
 
     static String generateId() {
-        String id = Long.toString(ThreadLocalStorage.getRandom().nextLong() >>> 1, 16);
+        StringBuilder id = new StringBuilder(Long.toString(ThreadLocalStorage.getRandom().nextLong() >>> 1, 16));
         while (id.length() < 16) {
-            id = '0' + id;
+            id.insert(0, '0');
         }
-        return id;
+        return id.toString();
     }
 
     String getName();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -18,8 +18,8 @@ package com.amazonaws.xray.entities;
 import com.amazonaws.xray.ThreadLocalStorage;
 import com.amazonaws.xray.internal.RecyclableBuffers;
 import java.math.BigInteger;
-import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Random;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TraceID {
@@ -101,7 +101,7 @@ public class TraceID {
      */
     @Deprecated
     public TraceID(long startTime) {
-        SecureRandom random = ThreadLocalStorage.getRandom();
+        Random random = ThreadLocalStorage.getRandom();
 
         // nextBytes much faster than calling nextInt multiple times when using SecureRandom
         byte[] randomBytes = RecyclableBuffers.bytes(12);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-java/issues/216

*Description of changes:*
All segment and trace IDs are randomly generated with a SecureRandom when a normal Random would suffice. IDs do not need to be cryptographically secure, so the additional expense of generating a high-quality random sequence is wasted here. The simpler ThreadLocalRandom would provide a significant performance boost. In my test service, the X-Ray SDK was spending about 25% of its time here.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
