### PR TITLE
Add a configurable randomness source

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -206,7 +206,7 @@ public class AWSXRay {
     public static boolean sendSubegment(Subsegment subsegment) {
         return AWSXRay.sendSubsegment(subsegment);
     }
-    
+
     public static boolean sendSubsegment(Subsegment subsegment) {
         return globalRecorder.sendSubsegment(subsegment);
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -29,6 +29,9 @@ import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceID;
 import com.amazonaws.xray.exceptions.SegmentNotFoundException;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
+import com.amazonaws.xray.internal.FastIdGenerator;
+import com.amazonaws.xray.internal.IdGenerator;
+import com.amazonaws.xray.internal.SecureIdGenerator;
 import com.amazonaws.xray.listeners.SegmentListener;
 import com.amazonaws.xray.strategy.ContextMissingStrategy;
 import com.amazonaws.xray.strategy.DefaultContextMissingStrategy;
@@ -117,6 +120,7 @@ public class AWSXRayRecorder {
     private PrioritizationStrategy prioritizationStrategy;
     private ThrowableSerializationStrategy throwableSerializationStrategy;
     private ContextMissingStrategy contextMissingStrategy;
+    private IdGenerator idGenerator;
 
     private SegmentContextResolverChain segmentContextResolverChain;
 
@@ -137,6 +141,7 @@ public class AWSXRayRecorder {
         prioritizationStrategy = new DefaultPrioritizationStrategy();
         throwableSerializationStrategy = new DefaultThrowableSerializationStrategy();
         contextMissingStrategy = new DefaultContextMissingStrategy();
+        idGenerator = new SecureIdGenerator();
 
         logReferences = new HashSet<>();
 
@@ -940,6 +945,39 @@ public class AWSXRayRecorder {
      */
     public void setOrigin(String origin) {
         this.origin = origin;
+    }
+
+    /**
+     * Configures this {@code AWSXRayRecorder} to use a fast but cryptographically insecure random number
+     * generator for generating random IDs. This option should be preferred if your application does not
+     * rely on AWS X-Ray Trace IDs being generated from a cryptographically secure random number generator.
+     *
+     * @see #useSecureIdGenerator()
+     */
+    public final void useFastIdGenerator() {
+        this.idGenerator = new FastIdGenerator();
+    }
+
+    /**
+     * Configures this {@code AWSXRayRecorder} to use a cryptographically secure random generator for
+     * generating random IDs. Unless your application in some way relies on AWS X-Ray trace IDs
+     * being generated from a cryptographically secure random number source, you should prefer
+     * to use {@linkplain #useFastIdGenerator() the fast ID generator}.
+     *
+     * @see #useFastIdGenerator()
+     */
+    public final void useSecureIdGenerator() {
+        this.idGenerator = new SecureIdGenerator();
+    }
+
+    /**
+     * Gets this {@code AWSXRayRecorder} instance's ID generator. This method is intended for
+     * internal use only.
+     *
+     * @return the configured ID generator
+     */
+    public final IdGenerator getIdGenerator() {
+        return idGenerator;
     }
 
     /**

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
@@ -80,6 +80,8 @@ public class AWSXRayRecorderBuilder {
     @Nullable
     private Emitter emitter;
 
+    private boolean useFastIdGenerator = false;
+
 
     private AWSXRayRecorderBuilder() {
         plugins = new HashSet<>();
@@ -221,6 +223,31 @@ public class AWSXRayRecorderBuilder {
     }
 
     /**
+     * Prepares this builder to build an {@code AWSXRayRecorder} which uses a fast but cryptographically insecure
+     * random number generator for generating random IDs. This option should be preferred unless your application
+     * relies on AWS X-Ray trace IDs being generated from a cryptographically secure random number source.
+     *
+     * @see #withSecureIdGenerator() ()
+     */
+    public AWSXRayRecorderBuilder withFastIdGenerator() {
+        this.useFastIdGenerator = true;
+        return this;
+    }
+
+    /**
+     * Prepares this builder to build an {@code AWSXRayRecorder} which uses a cryptographically secure random
+     * generator for generating random IDs. Unless your application relies on AWS X-Ray trace IDs
+     * being generated from a cryptographically secure random number source, you should prefer
+     * to use {@linkplain #withFastIdGenerator() the fast ID generator}.
+     *
+     * @see #withFastIdGenerator()
+     */
+    public AWSXRayRecorderBuilder withSecureIdGenerator() {
+        this.useFastIdGenerator = false;
+        return this;
+    }
+
+    /**
      * Constructs and returns an AWSXRayRecorder with the provided configuration.
      *
      * @return a configured instance of AWSXRayRecorder
@@ -256,6 +283,12 @@ public class AWSXRayRecorderBuilder {
 
         if (!segmentListeners.isEmpty()) {
             client.addAllSegmentListeners(segmentListeners);
+        }
+
+        if (useFastIdGenerator) {
+            client.useFastIdGenerator();
+        } else {
+            client.useSecureIdGenerator();
         }
 
         plugins.stream().filter(Objects::nonNull).filter(p -> p.isEnabled()).forEach(plugin -> {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/ThreadLocalStorage.java
@@ -59,6 +59,7 @@ public class ThreadLocalStorage {
         CURRENT_ENTITY.remove();
     }
 
+    @Deprecated
     public static SecureRandom getRandom() {
         return SECURE_RANDOM;
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -49,7 +49,7 @@ public class LambdaSegmentContext implements SegmentContext {
         if (isInitializing(traceHeader)) {
             logger.warn(LAMBDA_TRACE_HEADER_KEY + " is missing a trace ID, parent ID, or sampling decision. Subsegment "
                         + name + " discarded.");
-            return new FacadeSegment(recorder, TraceID.create(), "", SampleDecision.NOT_SAMPLED);
+            return new FacadeSegment(recorder, TraceID.create(recorder), "", SampleDecision.NOT_SAMPLED);
         }
         return new FacadeSegment(recorder, traceHeader.getRootTraceId(), traceHeader.getParentId(), traceHeader.getSampled());
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextResolverChain.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/SegmentContextResolverChain.java
@@ -17,12 +17,11 @@ package com.amazonaws.xray.contexts;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SegmentContextResolverChain implements ResolverChain<SegmentContext> {
 
-    private List<SegmentContextResolver> resolvers = new ArrayList<>();
+    private final List<SegmentContextResolver> resolvers = new ArrayList<>();
 
     public void addResolver(SegmentContextResolver resolver) {
         resolvers.add(resolver);
@@ -31,13 +30,13 @@ public class SegmentContextResolverChain implements ResolverChain<SegmentContext
     @Override
     @Nullable
     public SegmentContext resolve() {
-        Optional<SegmentContextResolver> firstResolver = resolvers.stream()
-                                                                  .filter(resolver -> resolver.resolve() != null)
-                                                                  .findFirst();
-
-        if (firstResolver.isPresent()) {
-            return firstResolver.get().resolve();
+        for (SegmentContextResolver resolver : resolvers) {
+            SegmentContext ctx = resolver.resolve();
+            if (ctx != null) {
+                return ctx;
+            }
         }
+
         return null;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
@@ -58,7 +58,7 @@ public class DummySegment implements Segment {
     }
 
     public DummySegment(AWSXRayRecorder creator) {
-        this(creator, TraceID.create());
+        this(creator, TraceID.create(creator));
     }
 
     public DummySegment(AWSXRayRecorder creator, TraceID traceId) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
@@ -44,7 +44,7 @@ public class DummySubsegment implements Subsegment {
     private Segment parentSegment;
 
     public DummySubsegment(AWSXRayRecorder creator) {
-        this(creator, TraceID.create());
+        this(creator, TraceID.create(creator));
     }
 
     public DummySubsegment(AWSXRayRecorder creator, TraceID traceId) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
@@ -15,8 +15,8 @@
 
 package com.amazonaws.xray.entities;
 
+import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorder;
-import com.amazonaws.xray.ThreadLocalStorage;
 import com.amazonaws.xray.exceptions.AlreadyEmittedException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
@@ -27,12 +27,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Entity extends AutoCloseable {
 
+    /**
+     * @deprecated Use the {@link com.amazonaws.xray.internal.IdGenerator ID generator} configured on this
+     * entity's creator instead
+     */
+    @Deprecated
     static String generateId() {
-        String id = Long.toString(ThreadLocalStorage.getRandom().nextLong() >>> 1, 16);
-        while (id.length() < 16) {
-            id = '0' + id;
-        }
-        return id;
+        return AWSXRay.getGlobalRecorder().getIdGenerator().newEntityId();
     }
 
     String getName();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -176,7 +176,7 @@ public abstract class EntityImpl implements Entity {
         this.annotations = new ConcurrentHashMap<>();
         this.metadata = new ConcurrentHashMap<>();
         this.startTime = Instant.now().toEpochMilli() / 1000.0d;
-        this.id = Entity.generateId();
+        this.id = creator.getIdGenerator().newEntityId();
         this.inProgress = true;
         this.referenceCount = new LongAdder();
         this.totalSize = new LongAdder();
@@ -445,7 +445,8 @@ public abstract class EntityImpl implements Entity {
         setFault(true);
         getSubsegmentsLock().lock();
         try {
-            cause.addExceptions(creator.getThrowableSerializationStrategy().describeInContext(exception, subsegments));
+            cause.addExceptions(creator.getThrowableSerializationStrategy()
+                .describeInContext(this, exception, subsegments));
         } finally {
             getSubsegmentsLock().unlock();
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
@@ -42,7 +42,7 @@ public class SegmentImpl extends EntityImpl implements Segment {
     // it makes the code to hard to reason about e.g., nullness.
     @SuppressWarnings("nullness")
     public SegmentImpl(AWSXRayRecorder creator, String name) {
-        this(creator, name, TraceID.create());
+        this(creator, name, TraceID.create(creator));
     }
 
     // TODO(anuraaga): Refactor the entity relationship. There isn't a great reason to use a type hierarchy for data classes and
@@ -50,6 +50,9 @@ public class SegmentImpl extends EntityImpl implements Segment {
     @SuppressWarnings("nullness")
     public SegmentImpl(AWSXRayRecorder creator, String name, TraceID traceId) {
         super(creator, name);
+        if (traceId == null) {
+            traceId = TraceID.create(creator);
+        }
         setTraceId(traceId);
 
         this.service = new ConcurrentHashMap<>();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/FastIdGenerator.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/FastIdGenerator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.internal;
+
+import com.amazonaws.xray.utils.ByteUtils;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Generates random IDs using a fast but cryptographically insecure random number
+ * generator. This should be the default random generator, unless your application
+ * relies on AWS X-Ray trace IDs being generated from a cryptographically secure random number
+ * source.
+ *
+ * <p>This class is internal-only and its API may receive breaking changes at any time. Do not directly
+ * depend on or use this class.
+ *
+ * @see SecureIdGenerator
+ */
+public final class FastIdGenerator extends IdGenerator {
+    @Override
+    public String newTraceId() {
+        Random random = ThreadLocalRandom.current();
+        return ByteUtils.numberToBase16String(random.nextInt(), random.nextLong());
+    }
+
+    @Override
+    protected long getRandomEntityId() {
+        return ThreadLocalRandom.current().nextLong();
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/IdGenerator.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/IdGenerator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.internal;
+
+import java.util.Arrays;
+
+/**
+ * An internal base class for unifying the potential ID generators.
+ *
+ * <p>This class is internal-only and its API may receive breaking changes at any time. Do not directly
+ * depend on or use this class.
+ */
+public abstract class IdGenerator {
+    /**
+     * @return a new ID suitable for use in a {@link com.amazonaws.xray.entities.TraceID TraceID}
+     */
+    public abstract String newTraceId();
+
+    /**
+     * @return a new ID suitable for use in any {@link com.amazonaws.xray.entities.Entity Entity} implementation
+     */
+    public final String newEntityId() {
+        String id = Long.toString(getRandomEntityId() >>> 1, 16);
+        int idLength = id.length();
+        if (idLength >= 16) {
+            return id;
+        }
+
+        StringBuilder idWithPad = new StringBuilder(16);
+        int padLength = 16 - idLength;
+        char[] pad = RecyclableBuffers.chars(padLength);
+        Arrays.fill(pad, 0, padLength, '0');
+        idWithPad.append(pad, 0, padLength);
+        idWithPad.append(id);
+        return idWithPad.toString();
+    }
+
+    /**
+     * @return a random long to use as an entity ID
+     */
+    protected abstract long getRandomEntityId();
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/SecureIdGenerator.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/SecureIdGenerator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.internal;
+
+import static com.amazonaws.xray.utils.ByteUtils.bytesToBase16String;
+
+import com.amazonaws.xray.ThreadLocalStorage;
+
+/**
+ * Generates for IDs using a cryptographically secure random number generator.
+ * This can be much more expensive than the alternative {@linkplain FastIdGenerator}. This
+ * generator should only be used if your application relies on AWS X-Ray IDs being
+ * generated from a cryptographically secure random number source.
+ *
+ * <p>This class is internal-only and its API may receive breaking changes at any time. Do not directly
+ * depend on or use this class.
+ *
+ * @see FastIdGenerator
+ */
+public final class SecureIdGenerator extends IdGenerator {
+    @Override
+    public String newTraceId() {
+        // nextBytes much faster than calling nextInt multiple times when using SecureRandom
+        byte[] randomBytes = RecyclableBuffers.bytes(12);
+        ThreadLocalStorage.getRandom().nextBytes(randomBytes);
+        return bytesToBase16String(randomBytes);
+    }
+
+    @Override
+    protected long getRandomEntityId() {
+        return ThreadLocalStorage.getRandom().nextLong();
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/ThrowableSerializationStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/ThrowableSerializationStrategy.java
@@ -15,9 +15,11 @@
 
 package com.amazonaws.xray.strategy;
 
+import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.ThrowableDescription;
 import java.util.List;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface ThrowableSerializationStrategy {
     /**
@@ -32,4 +34,25 @@ public interface ThrowableSerializationStrategy {
      * @return a list of {@code ThrowableDescription}s which represent the provided {@code Throwable}
      */
     List<ThrowableDescription> describeInContext(Throwable throwable, List<Subsegment> subsegments);
+
+    /**
+     * Serializes a {@code Throwable} into a {@code ThrowableDescription}. Uses the provided subsegments to chain exceptions where
+     * possible.
+     *
+     * @param entity
+     *            the current entity. May be null.
+     * @param throwable
+     *            the Throwable to serialize
+     * @param subsegments
+     *            the list of subsegment children in which to look for the same {@code Throwable} object, for chaining
+     *
+     * @return a list of {@code ThrowableDescription}s which represent the provided {@code Throwable}
+     */
+    default List<ThrowableDescription> describeInContext(
+        @Nullable Entity entity,
+        Throwable throwable,
+        List<Subsegment> subsegments
+    ) {
+        return describeInContext(throwable, subsegments);
+    }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/ByteUtils.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/ByteUtils.java
@@ -15,11 +15,25 @@
 
 package com.amazonaws.xray.utils;
 
+import com.amazonaws.xray.internal.RecyclableBuffers;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 public class ByteUtils {
     static final String HEXES = "0123456789ABCDEF";
+
+    private static final int BYTE_BASE16 = 2;
+    private static final String ALPHABET = "0123456789abcdef";
+    private static final char[] ENCODING = buildEncodingArray();
+
+    private static char[] buildEncodingArray() {
+        char[] encoding = new char[512];
+        for (int i = 0; i < 256; ++i) {
+            encoding[i] = ALPHABET.charAt(i >>> 4);
+            encoding[i | 0x100] = ALPHABET.charAt(i & 0xF);
+        }
+        return encoding;
+    }
 
     /**
      * ref: https://stackoverflow.com/questions/9655181/how-to-convert-a-byte-array-to-a-hex-string-in-java
@@ -38,5 +52,49 @@ public class ByteUtils {
             hex.append(HEXES.charAt((b & 0xF0) >> 4)).append(HEXES.charAt((b & 0x0F)));
         }
         return hex.toString();
+    }
+
+    public static String bytesToBase16String(byte[] bytes) {
+        char[] dest = RecyclableBuffers.chars(24);
+        for (int i = 0; i < 12; i++) {
+            byteToBase16(bytes[i], dest, i * BYTE_BASE16);
+        }
+
+        return new String(dest, 0, 24);
+    }
+
+    public static String numberToBase16String(int hi, long lo) {
+        char[] dest = RecyclableBuffers.chars(24);
+
+        byteToBase16((byte) (hi >> 24 & 0xFFL), dest, 0);
+        byteToBase16((byte) (hi >> 16 & 0xFFL), dest, BYTE_BASE16);
+        byteToBase16((byte) (hi >> 8 & 0xFFL), dest, 2 * BYTE_BASE16);
+        byteToBase16((byte) (hi & 0xFFL), dest, 3 * BYTE_BASE16);
+
+        byteToBase16((byte) (lo >> 56 & 0xFFL), dest, 4 * BYTE_BASE16);
+        byteToBase16((byte) (lo >> 48 & 0xFFL), dest, 5 * BYTE_BASE16);
+        byteToBase16((byte) (lo >> 40 & 0xFFL), dest, 6 * BYTE_BASE16);
+        byteToBase16((byte) (lo >> 32 & 0xFFL), dest, 7 * BYTE_BASE16);
+        byteToBase16((byte) (lo >> 24 & 0xFFL), dest, 8 * BYTE_BASE16);
+        byteToBase16((byte) (lo >> 16 & 0xFFL), dest, 9 * BYTE_BASE16);
+        byteToBase16((byte) (lo >> 8 & 0xFFL), dest, 10 * BYTE_BASE16);
+        byteToBase16((byte) (lo & 0xFFL), dest, 11 * BYTE_BASE16);
+
+        return new String(dest, 0, 24);
+    }
+
+    public static String intToBase16String(long value) {
+        char[] dest = RecyclableBuffers.chars(8);
+        byteToBase16((byte) (value >> 24 & 0xFFL), dest, 0);
+        byteToBase16((byte) (value >> 16 & 0xFFL), dest, BYTE_BASE16);
+        byteToBase16((byte) (value >> 8 & 0xFFL), dest, 2 * BYTE_BASE16);
+        byteToBase16((byte) (value & 0xFFL), dest, 3 * BYTE_BASE16);
+        return new String(dest, 0, 8);
+    }
+
+    private static void byteToBase16(byte value, char[] dest, int destOffset) {
+        int b = value & 0xFF;
+        dest[destOffset] = ENCODING[b];
+        dest[destOffset + 1] = ENCODING[b | 0x100];
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/TraceIDTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/TraceIDTest.java
@@ -17,13 +17,21 @@ package com.amazonaws.xray.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import java.time.Instant;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 class TraceIDTest {
 
-    // Chance this test passes once even when broken but unconceivable to pass several times.
+    @BeforeAll
+    static void beforeAll() {
+        AWSXRay.setGlobalRecorder(AWSXRayRecorderBuilder.defaultRecorder());
+    }
+
+    // Chance this test passes once even when broken but inconceivable to pass several times.
     @RepeatedTest(10)
     void create() {
         int startTimeSecs = (int) Instant.now().getEpochSecond();

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/IdGeneratorTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/internal/IdGeneratorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.internal;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class IdGeneratorTest {
+    @Test
+    public void testEntityIdPadding() {
+        Assert.assertEquals("0000000000000123", new TestIdGenerator(0x123L).newEntityId());
+        Assert.assertEquals(Long.toString(Long.MAX_VALUE, 16), new TestIdGenerator(Long.MAX_VALUE).newEntityId());
+    }
+
+    private static class TestIdGenerator extends IdGenerator {
+        private final long entityId;
+
+        private TestIdGenerator(long entityId) {
+            this.entityId = entityId << 1; // offset the signed right shift in `IdGenerator`
+        }
+
+        @Override
+        public String newTraceId() {
+            return "trace id";
+        }
+
+        @Override
+        protected long getRandomEntityId() {
+            return entityId;
+        }
+    }
+}


### PR DESCRIPTION
I had two goals for this change:

1. Expose the configuration option without exposing any new classes or
interfaces. We should be in strict control of possible randomness
sources so we can guarantee that they actually do provide random values
and that they provide randomness efficiently. I didn't want it to be
possible for users to tank performance by inadvertently using a single
`Random` instance.
2. Make the random source configurable and scoped to each
`AWSXRayRecorder` instance. I didn't want to introduce any more global
shared state, so this unfortunately meant I wasn't able to remove the
global SecureRandom usage in two places: `TraceId#fromString` and
`DefaultThrowableSerializationStrategy#describeInContext`. The latter is
at least aware of the local segment context and will try to use the
random generator from its creator when possible, but the former is
unresolvable without either adding more global shared state or exposing
the `RandomGenerator` class.

This commit adds the following public APIs:

* `AWSXRayRecorder#useFastRandomGenerator` and
`AWSXRayRecorder#useSecureRandomGenerator`: for configuring the behavior
of each `AWSXRayRecorder` instance.
* `AWSXRayRecorderBuilder#useFastRandomGenerator` and
`AWSXRayRecorderBuilder#useSecureRandomGenerator`: same as above
* `ThrowableSerializationStrategy#describeInContext(SegmentContext,
Throwable, List<Subsegment>)`: a new method that allows the current
segment context to be provided to `ThrowableSerializationStrategy`. This
is currently only useful for getting the ID generator from the current
segment's creator, but I can imagine there being other uses for this
later.

I unfortunately had to add two internal-only public methods to
`AWSXRayRecorder` for actually getting random values from its configured
random generator. Adding methods there allowed me to keep the
`RandomGenerator` class hidden from users.

There are some other minor changes in this PR:

* Removed quadratic String concatenation in `Entity#generateId`
* `SegmentContextResolverChain` no longer double-resolves contexts

*Issue #, if available:*
#216 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
