### PR TITLE
Removed some powermock

### DIFF
--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/ECSPluginTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/ECSPluginTest.java
@@ -15,39 +15,41 @@
 
 package com.amazonaws.xray.plugins;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ECSPlugin.class)
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.BeforeEach;
+
 public class ECSPluginTest {
+    @Rule
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
     private static final String ECS_METADATA_KEY = "ECS_CONTAINER_METADATA_URI";
+    private static final String GOOD_URI = "http://172.0.0.1";
+    private static final String BAD_URI = "Not a URL";
 
     private final ECSPlugin plugin = new ECSPlugin();
 
+    @BeforeEach
+    public void setup() {
+        environmentVariables.set(ECS_METADATA_KEY, null);
+    }
+
     @Test
     public void testIsEnabled() {
-        String uri = "http://172.0.0.1";
-        PowerMockito.mockStatic(System.class);
-        PowerMockito.when(System.getenv(ECS_METADATA_KEY)).thenReturn(uri);
+        environmentVariables.set(ECS_METADATA_KEY, GOOD_URI);
 
         boolean enabled = plugin.isEnabled();
-
-        Assert.assertTrue(enabled);
+        assertThat(enabled).isTrue();
     }
 
     @Test
     public void testNotEnabled() {
-        String uri = "Not a URL";
-        PowerMockito.mockStatic(System.class);
-        PowerMockito.when(System.getenv(ECS_METADATA_KEY)).thenReturn(uri);
+        environmentVariables.set(ECS_METADATA_KEY, BAD_URI);
 
         boolean enabled = plugin.isEnabled();
-
-        Assert.assertFalse(enabled);
+        assertThat(enabled).isFalse();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/ECSPluginTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/ECSPluginTest.java
@@ -17,38 +17,32 @@ package com.amazonaws.xray.plugins;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 public class ECSPluginTest {
-    @Rule
-    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
     private static final String ECS_METADATA_KEY = "ECS_CONTAINER_METADATA_URI";
     private static final String GOOD_URI = "http://172.0.0.1";
     private static final String BAD_URI = "Not a URL";
 
     private final ECSPlugin plugin = new ECSPlugin();
 
-    @BeforeEach
-    public void setup() {
-        environmentVariables.set(ECS_METADATA_KEY, null);
-    }
-
     @Test
+    @SetEnvironmentVariable(key = ECS_METADATA_KEY, value = GOOD_URI)
     public void testIsEnabled() {
-        environmentVariables.set(ECS_METADATA_KEY, GOOD_URI);
-
         boolean enabled = plugin.isEnabled();
         assertThat(enabled).isTrue();
     }
 
     @Test
+    @SetEnvironmentVariable(key = ECS_METADATA_KEY, value = BAD_URI)
     public void testNotEnabled() {
-        environmentVariables.set(ECS_METADATA_KEY, BAD_URI);
+        boolean enabled = plugin.isEnabled();
+        assertThat(enabled).isFalse();
+    }
 
+    @Test
+    public void testNotEnabledWithoutEnvironmentVariable() {
         boolean enabled = plugin.isEnabled();
         assertThat(enabled).isFalse();
     }


### PR DESCRIPTION
*Description of changes:*
Removed unnecessary powermock from ECS plugin tests. I tried using the JUnit Pioneer `SetEnvironmentVariable` annotation but for some reason couldn't get it to actually set the environment variable in the tests. Specifically, I tried:

```java
@Test
@SetEnvironmentVariable(key = ECS_METADATA_KEY, value = GOOD_URI)
```

but the environment variable would still be `null`, so I just went with System Rules instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
