### PR TITLE
Avoid nanosecond-resolution time where not needed

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
@@ -17,7 +17,6 @@ package com.amazonaws.xray.entities;
 
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +61,7 @@ public class DummySegment implements Segment {
     }
 
     public DummySegment(AWSXRayRecorder creator, TraceID traceId) {
-        this.startTime = Instant.now().toEpochMilli() / 1000.0d;
+        this.startTime = System.currentTimeMillis() / 1000.0d;
         this.creator = creator;
         this.traceId = traceId;
     }
@@ -316,7 +315,7 @@ public class DummySegment implements Segment {
     @Override
     public boolean end() {
         if (getEndTime() < Double.MIN_NORMAL) {
-            setEndTime(Instant.now().toEpochMilli() / 1000.0d);
+            setEndTime(System.currentTimeMillis() / 1000.0d);
         }
 
         return false;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -175,7 +174,7 @@ public abstract class EntityImpl implements Entity {
         this.sql = new ConcurrentHashMap<>();
         this.annotations = new ConcurrentHashMap<>();
         this.metadata = new ConcurrentHashMap<>();
-        this.startTime = Instant.now().toEpochMilli() / 1000.0d;
+        this.startTime = System.currentTimeMillis() / 1000d;
         this.id = creator.getIdGenerator().newEntityId();
         this.inProgress = true;
         this.referenceCount = new LongAdder();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
@@ -17,7 +17,6 @@ package com.amazonaws.xray.entities;
 
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -63,7 +62,7 @@ public class SegmentImpl extends EntityImpl implements Segment {
     @Override
     public boolean end() {
         if (getEndTime() < Double.MIN_NORMAL) {
-            setEndTime(Instant.now().toEpochMilli() / 1000.0d);
+            setEndTime(System.currentTimeMillis() / 1000d);
         }
 
         setInProgress(false);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
@@ -18,7 +18,6 @@ package com.amazonaws.xray.entities;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.logging.Log;
@@ -55,7 +54,7 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
         }
 
         if (getEndTime() < Double.MIN_NORMAL) {
-            setEndTime(Instant.now().toEpochMilli() / 1000.0d);
+            setEndTime(System.currentTimeMillis() / 1000d);
         }
         setInProgress(false);
         boolean shouldEmit = parentSegment.decrementReferenceCount() && parentSegment.isSampled();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceID.java
@@ -20,8 +20,8 @@ import static com.amazonaws.xray.utils.ByteUtils.numberToBase16String;
 
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorder;
+import com.amazonaws.xray.internal.TimeUtils;
 import java.math.BigInteger;
-import java.time.Instant;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class TraceID {
@@ -39,7 +39,7 @@ public class TraceID {
      * @see #create(AWSXRayRecorder)
      */
     public static TraceID create() {
-        return new TraceID(Instant.now().getEpochSecond(), AWSXRay.getGlobalRecorder());
+        return new TraceID(TimeUtils.currentEpochSecond(), AWSXRay.getGlobalRecorder());
     }
 
     /**
@@ -48,7 +48,7 @@ public class TraceID {
      * that created it.
      */
     public static TraceID create(AWSXRayRecorder creator) {
-        return new TraceID(Instant.now().getEpochSecond(), creator);
+        return new TraceID(TimeUtils.currentEpochSecond(), creator);
     }
 
     /**
@@ -108,7 +108,7 @@ public class TraceID {
      */
     @Deprecated
     public TraceID() {
-        this(Instant.now().getEpochSecond());
+        this(TimeUtils.currentEpochSecond());
     }
 
     /**

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/TimeUtils.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/TimeUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.internal;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public final class TimeUtils {
+    /**
+     * @return the current epoch second
+     */
+    public static long currentEpochSecond() {
+        return MILLISECONDS.toSeconds(System.currentTimeMillis());
+    }
+
+    private TimeUtils() {
+        throw new AssertionError("no instances, please");
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/TimeUtils.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/internal/TimeUtils.java
@@ -26,6 +26,5 @@ public final class TimeUtils {
     }
 
     private TimeUtils() {
-        throw new AssertionError("no instances, please");
     }
 }


### PR DESCRIPTION
`Instant#now` returns an Instant with nanonsecond-level resolution. The
ns-level timer isn't cheap, and is always discarded in X-Ray's code. We
can avoid much of this cost by swapping out `Instant#now` with
`System#currentTimeMillis`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
