### PR TITLE
added context-free endSubsegment method to AWSXRay class

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -105,7 +105,7 @@ public class AWSXRay {
     }
 
     /**
-     * @deprecated Use {@code AWSXray.getGlobalRecorder().beginNoOpSegment() }.
+     * @deprecated Use {@code AWSXRay.getGlobalRecorder().beginNoOpSegment() }.
      */
     @Deprecated
     public static Segment beginDummySegment() {
@@ -122,6 +122,10 @@ public class AWSXRay {
 
     public static void endSubsegment() {
         globalRecorder.endSubsegment();
+    }
+
+    public static void endSubsegment(@Nullable Subsegment subsegment) {
+        globalRecorder.endSubsegment(subsegment);
     }
 
     @Nullable

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -554,12 +554,13 @@ public class AWSXRayRecorder {
     }
 
     /**
-     * Ends the provided subsegment. This method doesn't touch context storage.
+     * Ends the provided subsegment. This method doesn't touch context storage and should be used when ending custom subsegments
+     * in asynchronous methods or other threads.
      *
      * @param subsegment
      *          the subsegment to close.
      */
-    public void endSubsegment(Subsegment subsegment) {
+    public void endSubsegment(@Nullable Subsegment subsegment) {
         if (subsegment == null) {
             logger.debug("No input subsegment to end. No-op.");
             return;


### PR DESCRIPTION
*Issue #, if available:*
#227 

*Description of changes:*
This change is important because we should make this API as visible as possible to assist our customers using asynchronous or multi-threaded programming. I will also update the docs to emphasize this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
