### PR TITLE
added aggregate javadoc plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
     id("nebula.release")
     id("org.ajoberstar.grgit")
-    id("io.freefair.aggregate-javadoc")
+    id("io.freefair.aggregate-javadoc-jar")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
 
     id("nebula.release")
     id("org.ajoberstar.grgit")
+    id("io.freefair.aggregate-javadoc")
 }
 
 tasks {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ pluginManagement {
     plugins {
         id("com.github.hierynomus.license") version "0.15.0"
         id("nebula.release") version "15.1.0"
+        id("io.freefair.aggregate-javadoc") version "5.3.0"
         id("net.ltgt.errorprone") version "1.2.1"
         id("org.ajoberstar.grgit") version "4.0.2"
         id("org.checkerframework") version "0.5.4"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ pluginManagement {
     plugins {
         id("com.github.hierynomus.license") version "0.15.0"
         id("nebula.release") version "15.1.0"
-        id("io.freefair.aggregate-javadoc") version "5.3.0"
+        id("io.freefair.aggregate-javadoc-jar") version "5.3.0"
         id("net.ltgt.errorprone") version "1.2.1"
         id("org.ajoberstar.grgit") version "4.0.2"
         id("org.checkerframework") version "0.5.4"


### PR DESCRIPTION
*Description of changes:*
We need to aggregate all javadocs at the top-level to publish them publicly. This tool generates them with:

```
./gradlew aggregateJavadoc
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
