### PR TITLE
Add option to  always create trace ID 

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -135,6 +135,7 @@ public class AWSXRayRecorder {
 
     @MonotonicNonNull
     private String origin;
+    private boolean alwaysCreateTraceId;
 
     public AWSXRayRecorder() {
         samplingStrategy = new DefaultSamplingStrategy();
@@ -441,7 +442,7 @@ public class AWSXRayRecorder {
      * will be propagated downstream.
      */
     public Segment beginNoOpSegment() {
-        return beginSegment(Segment.noOp(TraceID.invalid(), this));
+        return beginSegment(Segment.noOp(this.alwaysCreateTraceId ? TraceID.create(this) : TraceID.invalid(), this));
     }
 
     /**
@@ -1081,5 +1082,13 @@ public class AWSXRayRecorder {
                                                   SegmentNotFoundException.class);
             return null;
         }
+    }
+
+    /**
+     * Configures this {@code AWSXRayRecorder} to add valid TraceId in all segments even NoOp ones that usually have
+     * a fixed value.
+     */
+    public void alwaysCreateTraceID(final boolean alwaysCreateTraceId) {
+        this.alwaysCreateTraceId = alwaysCreateTraceId;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -135,7 +135,7 @@ public class AWSXRayRecorder {
 
     @MonotonicNonNull
     private String origin;
-    private boolean alwaysCreateTraceId;
+    private boolean forcedTraceIdGeneration;
 
     public AWSXRayRecorder() {
         samplingStrategy = new DefaultSamplingStrategy();
@@ -442,7 +442,7 @@ public class AWSXRayRecorder {
      * will be propagated downstream.
      */
     public Segment beginNoOpSegment() {
-        return beginSegment(Segment.noOp(this.alwaysCreateTraceId ? TraceID.create(this) : TraceID.invalid(), this));
+        return beginSegment(Segment.noOp(this.forcedTraceIdGeneration ? TraceID.create(this) : TraceID.invalid(), this));
     }
 
     /**
@@ -1088,7 +1088,7 @@ public class AWSXRayRecorder {
      * Configures this {@code AWSXRayRecorder} to add valid TraceId in all segments even NoOp ones that usually have
      * a fixed value.
      */
-    public void alwaysCreateTraceID(final boolean alwaysCreateTraceId) {
-        this.alwaysCreateTraceId = alwaysCreateTraceId;
+    public void setForcedTraceIdGeneration(final boolean alwaysCreateTraceId) {
+        this.forcedTraceIdGeneration = alwaysCreateTraceId;
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
@@ -250,7 +250,7 @@ public class AWSXRayRecorderBuilder {
 
     /**
      * Prepares this builder to build an {@code AWSXRayRecorder} which creates Trace ID for all Segments
-     * even for NoOp segments that usually include include a static invalid TraceID.
+     * even for NoOpSegments or not sampled ones that usually include include a static invalid TraceID.
      * This could be useful for example in case the Trace ID is logged to be able to aggregate all logs from a
      * single request
      */

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
@@ -81,7 +81,7 @@ public class AWSXRayRecorderBuilder {
     private Emitter emitter;
 
     private boolean useFastIdGenerator = false;
-    private boolean alwaysCreateTraceId = false;
+    private boolean forcedTraceIdGeneration = false;
 
 
     private AWSXRayRecorderBuilder() {
@@ -254,8 +254,8 @@ public class AWSXRayRecorderBuilder {
      * This could be useful for example in case the Trace ID is logged to be able to aggregate all logs from a
      * single request
      */
-    public AWSXRayRecorderBuilder withAlwaysCreateTraceId() {
-        this.alwaysCreateTraceId = true;
+    public AWSXRayRecorderBuilder withForcedTraceIdGeneration() {
+        this.forcedTraceIdGeneration = true;
         return this;
     }
 
@@ -303,8 +303,8 @@ public class AWSXRayRecorderBuilder {
             client.useSecureIdGenerator();
         }
 
-        if (alwaysCreateTraceId) {
-            client.alwaysCreateTraceID(true);
+        if (forcedTraceIdGeneration) {
+            client.setForcedTraceIdGeneration(true);
         }
 
         plugins.stream().filter(Objects::nonNull).filter(p -> p.isEnabled()).forEach(plugin -> {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorderBuilder.java
@@ -81,6 +81,7 @@ public class AWSXRayRecorderBuilder {
     private Emitter emitter;
 
     private boolean useFastIdGenerator = false;
+    private boolean alwaysCreateTraceId = false;
 
 
     private AWSXRayRecorderBuilder() {
@@ -248,6 +249,17 @@ public class AWSXRayRecorderBuilder {
     }
 
     /**
+     * Prepares this builder to build an {@code AWSXRayRecorder} which creates Trace ID for all Segments
+     * even for NoOp segments that usually include include a static invalid TraceID.
+     * This could be useful for example in case the Trace ID is logged to be able to aggregate all logs from a
+     * single request
+     */
+    public AWSXRayRecorderBuilder withAlwaysCreateTraceId() {
+        this.alwaysCreateTraceId = true;
+        return this;
+    }
+
+    /**
      * Constructs and returns an AWSXRayRecorder with the provided configuration.
      *
      * @return a configured instance of AWSXRayRecorder
@@ -289,6 +301,10 @@ public class AWSXRayRecorderBuilder {
             client.useFastIdGenerator();
         } else {
             client.useSecureIdGenerator();
+        }
+
+        if (alwaysCreateTraceId) {
+            client.alwaysCreateTraceID(true);
         }
 
         plugins.stream().filter(Objects::nonNull).filter(p -> p.isEnabled()).forEach(plugin -> {

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -763,7 +763,7 @@ public class AWSXRayRecorderTest {
     @Test
     public void testNoOpSegmentWithForcedTraceId() {
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
-                                                         .withAlwaysCreateTraceId()
+                                                         .withForcedTraceIdGeneration()
                                                          .build();
         Segment segment = recorder.beginNoOpSegment();
         assertThat(segment.getTraceId()).isNotEqualTo(TraceID.invalid());
@@ -776,7 +776,7 @@ public class AWSXRayRecorderTest {
     @Test
     public void testAlwaysCreateTraceId() {
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
-                                                         .withAlwaysCreateTraceId()
+                                                         .withForcedTraceIdGeneration()
                                                          .withSamplingStrategy(new NoSamplingStrategy())
                                                          .build();
         Segment segment = recorder.beginSegmentWithSampling("test");

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -40,6 +40,7 @@ import com.amazonaws.xray.strategy.IgnoreErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.LogErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.RuntimeErrorContextMissingStrategy;
 import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
+import com.amazonaws.xray.strategy.sampling.NoSamplingStrategy;
 import com.amazonaws.xray.strategy.sampling.SamplingResponse;
 import com.amazonaws.xray.strategy.sampling.SamplingStrategy;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -757,6 +758,29 @@ public class AWSXRayRecorderTest {
         TraceID traceID = TraceID.create();
         Segment segment = AWSXRay.getGlobalRecorder().beginNoOpSegment(traceID);
         assertThat(segment.getTraceId()).isEqualTo(traceID);
+    }
+
+    @Test
+    public void testNoOpSegmentWithForcedTraceId() {
+        AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
+                                                         .withAlwaysCreateTraceId()
+                                                         .build();
+        Segment segment = recorder.beginNoOpSegment();
+        assertThat(segment.getTraceId()).isNotEqualTo(TraceID.invalid());
+        AWSXRayRecorder recorder2 = AWSXRayRecorderBuilder.standard()
+                                                         .build();
+        Segment segment2 = recorder2.beginNoOpSegment();
+        assertThat(segment2.getTraceId()).isEqualTo(TraceID.invalid());
+    }
+
+    @Test
+    public void testAlwaysCreateTraceId() {
+        AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
+                                                         .withAlwaysCreateTraceId()
+                                                         .withSamplingStrategy(new NoSamplingStrategy())
+                                                         .build();
+        Segment segment = recorder.beginSegmentWithSampling("test");
+        assertThat(segment.getTraceId()).isNotEqualTo(TraceID.invalid());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
Fixes #238 

*Description of changes:*
This PR adds a new method in the builder and in the recorder to force NoOpSegments to have a valid individual Trace ID.
I am not entirely happy with the variable name so suggestions are accepted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
