### PR TITLE
Fix Sampling rules not being deleted

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifest.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifest.java
@@ -93,12 +93,23 @@ public class CentralizedManifest implements Manifest {
         boolean invalidate = false;
 
         Map<String, CentralizedRule> rules = this.rules;
+        List<String> inputNames = new ArrayList<>(inputs.size());
 
         for (SamplingRule i : inputs) {
             if (i.getRuleName().equals(CentralizedRule.DEFAULT_RULE_NAME)) {
                 putDefaultRule(i);
             } else {
+                inputNames.add(i.getRuleName());
                 invalidate = putCustomRule(rules, i);
+            }
+        }
+        // Check if any rule was removed
+        if (!invalidate) {
+            for (CentralizedRule rule : rules.values()) {
+                if (!inputNames.contains(rule.getName())) {
+                    invalidate = true;
+                    break;
+                }
             }
         }
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifestTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/strategy/sampling/manifest/CentralizedManifestTest.java
@@ -221,6 +221,23 @@ class CentralizedManifestTest {
     }
 
     @Test
+    void testRebuildOnRuleDeletion() {
+        CentralizedManifest manifest = new CentralizedManifest();
+
+        manifest.putRules(Arrays.asList(rule("r1"), rule("r2")), Instant.now());
+        Map<String, CentralizedRule> rules1 = Whitebox.getInternalState(manifest, "rules", CentralizedManifest.class);
+
+        manifest.putRules(Arrays.asList(rule("r2")), Instant.now());
+        Map<String, CentralizedRule> rules2 = Whitebox.getInternalState(manifest, "rules", CentralizedManifest.class);
+
+        // The map of rules should be rebuilt, resulting in a new object
+        Assertions.assertFalse(rules1 == rules2);
+
+        Assertions.assertEquals(2, rules1.size());
+        Assertions.assertEquals(1, rules2.size());
+    }
+
+    @Test
     void testManifestSizeWithDefaultRule() {
         CentralizedManifest m = new CentralizedManifest();
 


### PR DESCRIPTION
*Issue #, if available:*
#239 

*Description of changes:*
Review if any of the rules present in the manifest is not present in the payload to rebuild the manifest (I am not sure if removing just that rule is enough or we need to rebuild so I opted for rebuilding). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
