### PR TITLE
Depend on aws-java-sdk-core instead of the full bundle from the instr…

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -8,8 +8,9 @@ dependencies {
 
     implementation(project(":aws-xray-recorder-sdk-aws-sdk-core"))
 
-    api("com.amazonaws:aws-java-sdk:1.11.398")
+    api("com.amazonaws:aws-java-sdk-core:1.11.398")
 
+    testImplementation("com.amazonaws:aws-java-sdk:1.11.398")
     testImplementation("org.powermock:powermock-reflect:2.0.2")
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
 }


### PR DESCRIPTION
…umenter.

*Issue #, if available:* Fixes #247

*Description of changes:*

Fixes dependency on aws sdk.

Thanks @tjoris for the callout on this bug!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
