### PR TITLE
Lock all accesses to entities.

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/FacadeSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/FacadeSegment.java
@@ -26,12 +26,6 @@ public class FacadeSegment extends EntityImpl implements Segment {
     private static final String MUTATION_UNSUPPORTED_MESSAGE = "FacadeSegments cannot be mutated.";
     private static final String INFORMATION_UNAVAILABLE_MESSAGE = "This information is unavailable.";
 
-    protected String resourceArn;
-    protected String user;
-    protected String origin;
-
-    protected Map<String, Object> service;
-
     private final boolean sampled;
 
     // TODO(anuraaga): Refactor the entity relationship. There isn't a great reason to use a type hierarchy for data classes and

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,6 +121,8 @@ allprojects {
             add("testImplementation", "org.mockito:mockito-core")
             add("testImplementation", "org.mockito:mockito-junit-jupiter")
 
+            add("compileOnly", "com.google.errorprone:error_prone_annotations")
+
             add("compileOnly", "org.checkerframework:checker-qual:3.4.1")
             add("testImplementation", "org.checkerframework:checker-qual:3.4.1")
             add("checkerFramework", "org.checkerframework:checker:3.4.1")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -11,6 +11,11 @@ val DEPENDENCY_BOMS = listOf(
 
 val DEPENDENCY_SETS = listOf(
         DependencySet(
+                "com.google.errorprone",
+                "2.5.1",
+                listOf("error_prone_annotations")
+        ),
+        DependencySet(
                 "com.github.tomakehurst",
                 "2.26.3",
                 listOf("wiremock-jre8")


### PR DESCRIPTION
*Issue #, if available:* #108

*Description of changes:*
Almost none of the entity accesses are currently safe since there are many mutations of non-volatile fields. While making fields volatile is one way to help, modern CPUs have fast enough performance for non-contended locks (just atomic CAS) that it's common to just use locks (Golang makes it very hard to use volatile for this reason). This is the implementation OTel uses

https://github.com/open-telemetry/opentelemetry-java/blob/master/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/RecordEventsReadableSpan.java

OTel doesn't have setters for every single thing so doesn't need as much locking, but as we don't expect much contention here it should be fine. 

I haven't quite reasoned through whether this fixes the subsegment issues, but it's an important change regardless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
