### PR TITLE
Read _X_AMZN_TRACE_ID from environment & system properties

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -36,6 +36,7 @@ public class LambdaSegmentContext implements SegmentContext {
 
     private static final String LAMBDA_TRACE_HEADER_KEY = "_X_AMZN_TRACE_ID";
     
+    // See: https://github.com/aws/aws-xray-sdk-java/issues/251
     private static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
 
     private static TraceHeader getTraceHeaderFromEnvironment() {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -35,9 +35,14 @@ public class LambdaSegmentContext implements SegmentContext {
     private static final Log logger = LogFactory.getLog(LambdaSegmentContext.class);
 
     private static final String LAMBDA_TRACE_HEADER_KEY = "_X_AMZN_TRACE_ID";
+    
+    private static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
 
     private static TraceHeader getTraceHeaderFromEnvironment() {
-        return TraceHeader.fromString(System.getenv(LAMBDA_TRACE_HEADER_KEY));
+        String lambdaTraceHeaderKey = System.getenv(LAMBDA_TRACE_HEADER_KEY);
+        return TraceHeader.fromString(lambdaTraceHeaderKey != null && lambdaTraceHeaderKey.length() > 0 
+            ? lambdaTraceHeaderKey 
+            : System.getProperty(LAMBDA_TRACE_HEADER_PROP));
     }
 
     private static boolean isInitializing(TraceHeader traceHeader) {

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -116,6 +117,14 @@ class LambdaSegmentContextTest {
             Subsegment secondInvocation = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
             assertThat(secondInvocation).isNotNull();
             assertThat(secondInvocation.getParent()).isInstanceOf(FacadeSegment.class);
+        }
+
+        @Test
+        @SetSystemProperty(key = "com.amazonaws.xray.traceHeader", value = TRACE_HEADER)
+        void oneInvocationGeneratesSegmentUsingSystemProperty() {
+            Subsegment firstInvocation = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
+            assertThat(firstInvocation).isNotNull();
+            assertThat(firstInvocation.getParent()).isInstanceOf(FacadeSegment.class);
         }
     }
 


### PR DESCRIPTION

*Issue #251 

*Description of changes:*
For custom runtimes that use this library, IE: graalvm. It's not possible to set the _X_AMZN_TRACE_ID as a environment property. By checking the system properties for _X_AMZN_TRACE_ID, if the environment property does not exist, this will allow the X-Ray to be able to be used by custom runtimes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
