### PR TITLE
Generate and upload code coverage report on PRs

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -17,28 +17,48 @@ jobs:
         java:
           - 8
           - 11
+        include:
+          - os: ubuntu-latest
+            java: 11
+            coverage: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1
+
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - name: Cache Gradle Modules
         uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
           key: gradle-caches-${{ hashFiles('**/*.gradle.kts') }}
+
       - name: Cache Gradle Wrapper
         uses: actions/cache@v1
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
       - name: Execute Gradle build
-        run: ./gradlew build --stacktrace
+        run: ./gradlew build ${{ matrix.coverage && 'codeCoverageReport' || '' }} --stacktrace
         shell: bash
         env:
           CI: true
+
+      - uses: codecov/codecov-action@v1
+        if: ${{ matrix.coverage }}
+        with:
+          files: ./jacoco/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.coverage }}
+        with:
+          name: coverage-report
+          path: jacoco/build/reports/jacoco/codeCoverageReport/html
+
   publish:
     name: Publish snapshots
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,6 +17,10 @@ jobs:
         java:
           - 8
           - 11
+        include:
+          - os: ubuntu-latest
+            java: 11
+            coverage: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1
@@ -35,7 +39,14 @@ jobs:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: Execute Gradle build
-        run: ./gradlew build --stacktrace
+        run: ./gradlew build ${{ matrix.coverage && 'codeCoverageReport' || '' }} --stacktrace
         shell: bash
         env:
           CI: true
+      - uses: codecov/codecov-action@v1
+        if: ${{ matrix.coverage }}
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.coverage }}
+        with:
+          name: coverage-report
+          path: jacoco/build/reports/jacoco/codeCoverageReport/html

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,27 +24,35 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1
+
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+
       - name: Cache Gradle Modules
         uses: actions/cache@v1
         with:
           path: ~/.gradle/caches
           key: gradle-caches-${{ hashFiles('**/*.gradle.kts') }}
+
       - name: Cache Gradle Wrapper
         uses: actions/cache@v1
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
       - name: Execute Gradle build
         run: ./gradlew build ${{ matrix.coverage && 'codeCoverageReport' || '' }} --stacktrace
         shell: bash
         env:
           CI: true
+
       - uses: codecov/codecov-action@v1
         if: ${{ matrix.coverage }}
+        with:
+          files: ./jacoco/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+
       - uses: actions/upload-artifact@v2
         if: ${{ matrix.coverage }}
         with:

--- a/jacoco/build.gradle.kts
+++ b/jacoco/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 description = "AWS X-Ray SDK Code Coverage"
 
-
 dependencies {
     rootProject.subprojects.forEach { subproject ->
         // Generate aggregate coverage report for published modules that enable jacoco.

--- a/jacoco/build.gradle.kts
+++ b/jacoco/build.gradle.kts
@@ -1,0 +1,61 @@
+plugins {
+    `java-library`
+}
+
+description = "AWS X-Ray SDK Code Coverage"
+
+
+dependencies {
+    rootProject.subprojects.forEach { subproject ->
+        // Generate aggregate coverage report for published modules that enable jacoco.
+        subproject.plugins.withId("jacoco") {
+            subproject.plugins.withId("maven-publish") {
+                implementation(project(subproject.path)) {
+                    isTransitive = false
+                }
+            }
+        }
+    }
+}
+
+val sourcesPath by configurations.creating {
+    isVisible = false
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    extendsFrom(configurations.implementation.get())
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
+    }
+}
+
+val coverageDataPath by configurations.creating {
+    isVisible = false
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    extendsFrom(configurations.implementation.get())
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
+    }
+}
+
+// Task to gather code coverage from multiple subprojects
+val codeCoverageReport by tasks.registering(JacocoReport::class) {
+    additionalClassDirs(configurations.runtimeClasspath.get())
+    additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
+    executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
+
+    reports {
+        // xml is usually used to integrate code coverage with
+        // other tools like SonarQube, Coveralls or Codecov
+        xml.isEnabled = true
+
+        // HTML reports can be used to see code coverage
+        // without any external tools
+        html.isEnabled = true
+    }
+}
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,3 +28,5 @@ include(":aws-xray-recorder-sdk-metrics")
 
 // Internal project for applying dependency management.
 include(":dependencyManagement")
+// Project for generating aggregated Jacoco code coverage report.
+include(":jacoco")


### PR DESCRIPTION
Using the Jacoco plugin for gradle, generating an aggregated code coverage report. The report will be generated in the `jacoco` project and the `pr-build` workflow will upload the report to codecov.io.
Since we need only one report to be generated, I'm doing so in the build for Java 11.

For this to work completely, we need two more things:
1. The administrator needs to login/sign-up on codecov.io and add the this repo to the list of repositories so that the codecov/codecov-action can upload the coverage report
2. Add the codecov bot to the repo so that it can post the coverage diff as a comment on pull requests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
