### PR TITLE
Added log correlation to ECS plugin

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSMetadataFetcher.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSMetadataFetcher.java
@@ -34,6 +34,7 @@ class ECSMetadataFetcher {
     private static final String METADATA_SERVICE_NAME = "TMDE";
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
+    @Nullable
     private final URL containerUrl;
 
     // TODO: Record additional attributes in runtime context from Task Metadata Endpoint
@@ -62,7 +63,7 @@ class ECSMetadataFetcher {
             return Collections.emptyMap();
         }
 
-        String metadata = MetadataUtils.fetchString("GET", this.containerUrl, null, false, METADATA_SERVICE_NAME);
+        String metadata = MetadataUtils.fetchString("GET", this.containerUrl, "", false, METADATA_SERVICE_NAME);
 
         Map<ECSContainerMetadata, String> result = new HashMap<>();
         try (JsonParser parser = JSON_FACTORY.createParser(metadata)) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSMetadataFetcher.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSMetadataFetcher.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.plugins;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class ECSMetadataFetcher {
+    private static final Log logger = LogFactory.getLog(ECSMetadataFetcher.class);
+
+    private static final String METADATA_SERVICE_NAME = "TMDE";
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+    private final URL containerUrl;
+
+    // TODO: Record additional attributes in runtime context from Task Metadata Endpoint
+    enum ECSContainerMetadata {
+        LOG_DRIVER,
+        LOG_GROUP_REGION,
+        LOG_GROUP_NAME,
+        CONTAINER_ARN,
+    }
+
+    ECSMetadataFetcher(@Nullable String endpoint) {
+        if (endpoint == null) {
+            this.containerUrl = null;
+            return;
+        }
+
+        try {
+            this.containerUrl = new URL(endpoint);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Illegal endpoint: " + endpoint);
+        }
+    }
+
+    Map<ECSContainerMetadata, String> fetchContainer() {
+        if (this.containerUrl == null) {
+            return Collections.emptyMap();
+        }
+
+        String metadata = MetadataUtils.fetchString("GET", this.containerUrl, null, false, METADATA_SERVICE_NAME);
+
+        Map<ECSContainerMetadata, String> result = new HashMap<>();
+        try (JsonParser parser = JSON_FACTORY.createParser(metadata)) {
+            parser.nextToken();
+            parseContainerJson(parser, result);
+        } catch (IOException e) {
+            logger.warn("Could not parse container metadata.", e);
+            return Collections.emptyMap();
+        }
+
+        // This means the document didn't have all the metadata fields we wanted.
+        if (result.size() != ECSContainerMetadata.values().length) {
+            logger.debug("Container metadata response missing metadata: " + metadata);
+        }
+
+        return Collections.unmodifiableMap(result);
+    }
+
+    // Helper method to shallow-parse a JSON object, assuming the parser is located at the start of an object,
+    // and record the desired fields in the result map in-place
+    private void parseContainerJson(JsonParser parser, Map<ECSContainerMetadata, String> result) throws IOException {
+        if (!parser.isExpectedStartObjectToken()) {
+            logger.warn("Container metadata endpoint returned invalid JSON");
+            return;
+        }
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            String value = parser.nextTextValue();
+            switch (parser.getCurrentName()) {
+                case "LogDriver":
+                    result.put(ECSContainerMetadata.LOG_DRIVER, value);
+                    break;
+                case "ContainerARN":
+                    result.put(ECSContainerMetadata.CONTAINER_ARN, value);
+                    break;
+                case "awslogs-group":
+                    result.put(ECSContainerMetadata.LOG_GROUP_NAME, value);
+                    break;
+                case "awslogs-region":
+                    result.put(ECSContainerMetadata.LOG_GROUP_REGION, value);
+                    break;
+                case "LogOptions":
+                    parseContainerJson(parser, result);  // Parse the LogOptions object for log fields
+                    break;
+                default:
+                    parser.skipChildren();
+            }
+            if (result.size() == ECSContainerMetadata.values().length) {
+                return;
+            }
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/ECSPlugin.java
@@ -53,6 +53,7 @@ public class ECSPlugin implements Plugin {
     private final Set<AWSLogReference> logReferences;
     private final Map<ECSMetadataFetcher.ECSContainerMetadata, String> containerMetadata;
 
+    @SuppressWarnings("nullness:method.invocation.invalid")
     public ECSPlugin() {
         runtimeContext = new HashMap<>();
         dockerUtils = new DockerUtils();
@@ -120,16 +121,15 @@ public class ECSPlugin implements Plugin {
     // See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
     private void populateLogReferences() {
         String logGroup = containerMetadata.get(ECSMetadataFetcher.ECSContainerMetadata.LOG_GROUP_NAME);
-        String logRegion = containerMetadata.get(ECSMetadataFetcher.ECSContainerMetadata.LOG_GROUP_REGION);
-        String containerArn = containerMetadata.get(ECSMetadataFetcher.ECSContainerMetadata.CONTAINER_ARN);
-        String logAccount = containerArn == null ? null : containerArn.split(":")[4];
-
         if (logGroup == null) {
             return;
         }
-
         AWSLogReference logReference = new AWSLogReference();
         logReference.setLogGroup(logGroup);
+
+        String logRegion = containerMetadata.get(ECSMetadataFetcher.ECSContainerMetadata.LOG_GROUP_REGION);
+        String containerArn = containerMetadata.get(ECSMetadataFetcher.ECSContainerMetadata.CONTAINER_ARN);
+        String logAccount = containerArn != null ? containerArn.split(":")[4] : null;
 
         if (logRegion != null && logAccount != null) {
             logReference.setArn("arn:aws:logs:" + logRegion + ":" + logAccount + ":log-group:" + logGroup);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/MetadataUtils.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/MetadataUtils.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.plugins;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class MetadataUtils {
+    private static final Log logger = LogFactory.getLog(MetadataUtils.class);
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 100;
+    private static final int READ_TIMEOUT_MILLIS = 1000;
+
+    private MetadataUtils() {
+    }
+
+    static String fetchString(String httpMethod, URL url, String token, boolean includeTtl, String metadataService) {
+        final HttpURLConnection connection;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+        } catch (Exception e) {
+            logger.debug("Error connecting to " + metadataService, e);
+            return "";
+        }
+
+        try {
+            connection.setRequestMethod(httpMethod);
+        } catch (ProtocolException e) {
+            logger.warn("Unknown HTTP method, this is a programming bug.", e);
+            return "";
+        }
+
+        connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+        connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+
+        if (includeTtl) {
+            connection.setRequestProperty("X-aws-ec2-metadata-token-ttl-seconds", "60");
+        }
+        if (token != null && !token.isEmpty()) {
+            connection.setRequestProperty("X-aws-ec2-metadata-token", token);
+        }
+
+        final int responseCode;
+        try {
+            responseCode = connection.getResponseCode();
+        } catch (Exception e) {
+            if (e instanceof SocketTimeoutException) {
+                logger.debug("Timed out trying to connect to " + metadataService);
+            } else {
+                logger.debug("Error connecting to " + metadataService, e);
+            }
+            return "";
+        }
+
+        if (responseCode != 200) {
+            logger.warn("Error response from " + metadataService + ": code (" +
+                responseCode + ") text " + readResponseString(connection));
+        }
+
+        return MetadataUtils.readResponseString(connection).trim();
+    }
+
+    static String readResponseString(HttpURLConnection connection) {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (InputStream is = connection.getInputStream()) {
+            readTo(is, os);
+        } catch (IOException e) {
+            // Only best effort read if we can.
+        }
+        try (InputStream is = connection.getErrorStream()) {
+            readTo(is, os);
+        } catch (IOException e) {
+            // Only best effort read if we can.
+        }
+        try {
+            return os.toString(StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 not supported can't happen.");
+        }
+    }
+
+    static void readTo(@Nullable InputStream is, ByteArrayOutputStream os) throws IOException {
+        if (is == null) {
+            return;
+        }
+        int b;
+        while ((b = is.read()) != -1) {
+            os.write(b);
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/ECSMetadataFetcherTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/ECSMetadataFetcherTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.plugins;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ECSMetadataFetcherTest {
+    @ClassRule
+    public static WireMockClassRule server = new WireMockClassRule(wireMockConfig().dynamicPort());
+
+    private static final String CONTAINER_METADATA =
+        "{\n" +
+        "   \"DockerId\":\"efgh\",\n" +
+        "   \"Name\":\"main\",\n" +
+        "   \"DockerName\":\"ecs-helloworld-3-main-f69182c192af9cd71000\",\n" +
+        "   \"Image\":\"public.ecr.aws/my-image\",\n" +
+        "   \"ImageID\":\"sha256:937f680f89da88d36ddc3cff9ae5a70909fe149ca2d08b99208633730117ad67\",\n" +
+        "   \"Labels\":{\n" +
+        "      \"com.amazonaws.ecs.cluster\":\"myCluster\"\n" +
+        "   },\n" +
+        "   \"DesiredStatus\":\"RUNNING\",\n" +
+        "   \"KnownStatus\":\"RUNNING\",\n" +
+        "   \"Limits\":{\n" +
+        "      \"CPU\":256,\n" +
+        "      \"Memory\":0\n" +
+        "   },\n" +
+        "   \"CreatedAt\":\"2020-09-29T19:05:57.744432392Z\",\n" +
+        "   \"StartedAt\":\"2020-09-29T19:05:58.656886747Z\",\n" +
+        "   \"Type\":\"NORMAL\",\n" +
+        "   \"LogDriver\":\"awslogs\",\n" +
+        "   \"LogOptions\":{\n" +
+        "      \"awslogs-group\":\"my-group\",\n" +
+        "      \"awslogs-region\":\"ap-southeast-1\",\n" +
+        "      \"awslogs-stream\":\"logs/main/5678\"\n" +
+        "   },\n" +
+        "   \"ContainerARN\":\"arn:aws:ecs:ap-southeast-1:123456789012:container/567\",\n" +
+        "   \"Networks\":[\n" +
+        "      {\n" +
+        "         \"NetworkMode\":\"host\",\n" +
+        "         \"IPv4Addresses\":[\n" +
+        "            \"\"\n" +
+        "         ]\n" +
+        "      }\n" +
+        "   ]\n" +
+        "}";
+
+    private ECSMetadataFetcher fetcher;
+
+    @Before
+    public void setup() {
+        fetcher = new ECSMetadataFetcher("http://localhost:" + server.port());
+    }
+
+    @Test
+    public void testContainerMetadata() {
+        stubFor(any(urlPathEqualTo("/")).willReturn(okJson(CONTAINER_METADATA)));
+
+        Map<ECSMetadataFetcher.ECSContainerMetadata, String> metadata = this.fetcher.fetchContainer();
+
+        assertThat(metadata).containsOnly(
+            entry(ECSMetadataFetcher.ECSContainerMetadata.CONTAINER_ARN, "arn:aws:ecs:ap-southeast-1:123456789012:container/567"),
+            entry(ECSMetadataFetcher.ECSContainerMetadata.LOG_DRIVER, "awslogs"),
+            entry(ECSMetadataFetcher.ECSContainerMetadata.LOG_GROUP_REGION, "ap-southeast-1"),
+            entry(ECSMetadataFetcher.ECSContainerMetadata.LOG_GROUP_NAME, "my-group")
+        );
+
+        verify(getRequestedFor(urlEqualTo("/")));
+    }
+
+    @Test
+    public void testIncompleteResponse() {
+        stubFor(any(urlPathEqualTo("/")).willReturn(okJson("{\"DockerId\":\"efgh\"}")));
+
+        Map<ECSMetadataFetcher.ECSContainerMetadata, String> metadata = this.fetcher.fetchContainer();
+
+        assertThat(metadata).isEmpty();
+        verify(getRequestedFor(urlEqualTo("/")));
+    }
+
+    @Test
+    public void testErrorResponse() {
+        stubFor(any(urlPathEqualTo("/")).willReturn(okJson("bad json string")));
+
+        Map<ECSMetadataFetcher.ECSContainerMetadata, String> metadata = this.fetcher.fetchContainer();
+
+        assertThat(metadata).isEmpty();
+        verify(getRequestedFor(urlEqualTo("/")));
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Records Amazon CloudWatch Log Groups in traces for ECS customers. We accomplish this by querying the Task Metadata Endpoint (TMDE) Available in ECS containers. I refactored some of the EC2 metadata fetching code into a utility class for reuse to this end.

Tested on ECS Fargate agent version 1.4.0 and added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
