### PR TITLE
Apply publish-plugin to automatically close sonatype repository on re…

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -81,7 +81,7 @@ jobs:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: Execute Gradle publish
-        run: ./gradlew snapshot --stacktrace
+        run: ./gradlew snapshot --stacktrace --info
         shell: bash
         env:
           CI: true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,8 +27,8 @@ jobs:
         run: ./gradlew build -Prelease.version=${{ github.event.inputs.version }} --stacktrace
         env:
           CI: true
-      - name: Publish to staging repo
-        run: ./gradlew final -Prelease.version=${{ github.event.inputs.version }} --stacktrace
+      - name: Build and publish to sonatype
+        run: ./gradlew final closeAndReleaseSonatypeStagingRepository -Prelease.version=${{ github.event.inputs.version }} --stacktrace
         env:
           CI: true
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
         id("com.github.hierynomus.license") version "0.15.0"
         id("nebula.release") version "15.1.0"
         id("io.freefair.aggregate-javadoc-jar") version "5.3.0"
+        id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
         id("net.ltgt.errorprone") version "1.2.1"
         id("org.ajoberstar.grgit") version "4.0.2"
         id("org.checkerframework") version "0.5.4"


### PR DESCRIPTION
…lease.

Off chance that it will fix the mysterious missing snapshot builds (they work fine for the similarly configured `aws-otel-java-instrumentation`). But add `--info` to CI build to debug in case the problem persists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
