### PR TITLE
Add smoke test of distribution channel.

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -1,5 +1,6 @@
 name: Continuous monitoring of distribution channels
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 */6 * * *'
 

--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -1,0 +1,18 @@
+name: Continuous monitoring of distribution channels
+on:
+  schedule:
+    - cron:  '0 */6 * * *'
+
+jobs:
+  smoke-tests:
+    name: Run smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Run smoke tests
+        run: ./gradlew :smoke-tests:check -PtestDistributionChannel=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,5 @@ include(":aws-xray-recorder-sdk-metrics")
 include(":dependencyManagement")
 // Project for generating aggregated Jacoco code coverage report.
 include(":jacoco")
+// Internal project for smoke tests
+include(":smoke-tests")

--- a/smoke-tests/build.gradle.kts
+++ b/smoke-tests/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation(project(":aws-xray-recorder-sdk-core"))
+}
+
+if (rootProject.findProperty("testDistributionChannel") == "true") {
+    configurations.all {
+        resolutionStrategy {
+            dependencySubstitution {
+                substitute(project(":aws-xray-recorder-sdk-core")).with(module("com.amazonaws:aws-xray-recorder-sdk-core:+"))
+            }
+        }
+    }
+}

--- a/smoke-tests/src/test/java/com/amazonaws/xray/smoketests/SimpleSmokeTest.java
+++ b/smoke-tests/src/test/java/com/amazonaws/xray/smoketests/SimpleSmokeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.smoketests;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.amazonaws.xray.AWSXRayRecorder;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
+import com.amazonaws.xray.emitters.Emitter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SimpleSmokeTest {
+
+    @Mock
+    private Emitter emitter;
+
+    @Test
+    void emits() {
+        AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
+                                                         .withEmitter(emitter)
+                                                         .build();
+
+        recorder.beginSegment("test");
+        recorder.endSegment();
+
+        verify(emitter, times(1)).sendSegment(any());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds smoke test that periodically runs by building against Maven Central's artifact. Doesn't publish metrics yet we can add easily later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
