### PR TITLE
Added JavaTimeModule for entity object mapper

### DIFF
--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -8,8 +8,8 @@ dependencies {
 
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     compileOnly("javax.servlet:javax.servlet-api:3.1.0")
-    compileOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0")
 
+    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0")
     testImplementation("com.github.stefanbirkner:system-rules:1.16.0")
     testImplementation("com.github.tomakehurst:wiremock-jre8")
     testImplementation("org.openjdk.jmh:jmh-core:1.19")

--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     compileOnly("javax.servlet:javax.servlet-api:3.1.0")
+    compileOnly("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0")
 
     testImplementation("com.github.stefanbirkner:system-rules:1.16.0")
     testImplementation("com.github.tomakehurst:wiremock-jre8")

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -58,7 +57,7 @@ public abstract class EntityImpl implements Entity {
     @SuppressWarnings("checkstyle:ConstantName")
     @Deprecated
     protected static final ObjectMapper mapper = new ObjectMapper()
-        .registerModule(new JavaTimeModule())
+        .findAndRegisterModules()
         .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
         .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -57,6 +58,7 @@ public abstract class EntityImpl implements Entity {
     @SuppressWarnings("checkstyle:ConstantName")
     @Deprecated
     protected static final ObjectMapper mapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
         .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
         .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
@@ -1,21 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
 package com.amazonaws.xray.entities;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.amazonaws.xray.AWSXRay;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class EntityTest {
 
+    @BeforeEach
+    void setup() {
+        AWSXRay.clearTraceEntity();
+    }
+
     @Test
-    void testTimeModuleSerialization() {
-        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(),"test");
-        Duration duration = Duration.ofSeconds(1);
-        seg.putMetadata("meta", duration);
+    void testDurationSerialization() {
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test");
+        seg.putMetadata("millisecond", Duration.ofMillis(3));
+        seg.putMetadata("second", Duration.ofSeconds(1));
+        seg.putMetadata("minute", Duration.ofMinutes(55));
         String serializedSeg = seg.serialize();
 
-        String expected = "{\"default\":{\"meta\":1.000000000}}}";
+        String expected = "{\"default\":{\"millisecond\":0.003000000,\"second\":1.000000000,\"minute\":3300.000000000}}";
+        assertThat(serializedSeg).contains(expected);
+    }
+
+    @Test
+    void testTimestampSerialization() {
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test");
+        seg.putMetadata("date", Date.from(Instant.ofEpochSecond(1616559298)));
+        String serializedSeg = seg.serialize();
+
+        String expected = "{\"default\":{\"date\":1616559298000}}";
         assertThat(serializedSeg).contains(expected);
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import com.amazonaws.xray.AWSXRay;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,10 +47,24 @@ class EntityTest {
     @Test
     void testTimestampSerialization() {
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test");
-        seg.putMetadata("date", Instant.ofEpochSecond(1616559298));
+        seg.putMetadata("instant", Instant.ofEpochSecond(1616559298));
         String serializedSeg = seg.serialize();
 
-        String expected = "{\"default\":{\"date\":1616559298.000000000}}";
+        String expected = "{\"default\":{\"instant\":1616559298.000000000}}";
+        assertThat(serializedSeg).contains(expected);
+    }
+
+    /**
+     * Dates are serialized into millisecond integers rather than second doubles because anything beyond millisecond
+     * accuracy is meaningless for Dates: https://docs.oracle.com/javase/8/docs/api/java/util/Date.html
+     */
+    @Test
+    void testDateSerialization() {
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test");
+        seg.putMetadata("date", Date.from(Instant.ofEpochSecond(1616559298)));
+        String serializedSeg = seg.serialize();
+
+        String expected = "{\"default\":{\"date\":1616559298000}}";
         assertThat(serializedSeg).contains(expected);
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import com.amazonaws.xray.AWSXRay;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,10 +46,10 @@ class EntityTest {
     @Test
     void testTimestampSerialization() {
         Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test");
-        seg.putMetadata("date", Date.from(Instant.ofEpochSecond(1616559298)));
+        seg.putMetadata("date", Instant.ofEpochSecond(1616559298));
         String serializedSeg = seg.serialize();
 
-        String expected = "{\"default\":{\"date\":1616559298000}}";
+        String expected = "{\"default\":{\"date\":1616559298.000000000}}";
         assertThat(serializedSeg).contains(expected);
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
@@ -1,0 +1,21 @@
+package com.amazonaws.xray.entities;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import com.amazonaws.xray.AWSXRay;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class EntityTest {
+
+    @Test
+    void testTimeModuleSerialization() {
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(),"test");
+        Duration duration = Duration.ofSeconds(1);
+        seg.putMetadata("meta", duration);
+        String serializedSeg = seg.serialize();
+
+        String expected = "{\"default\":{\"meta\":1.000000000}}}";
+        assertThat(serializedSeg).contains(expected);
+    }
+}

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -16,6 +16,11 @@ val DEPENDENCY_SETS = listOf(
                 listOf("error_prone_annotations")
         ),
         DependencySet(
+                "com.fasterxml.jackson.datatype",
+                "2.11.0",
+                listOf("jackson-datatype-jsr310")
+        ),
+        DependencySet(
                 "com.github.tomakehurst",
                 "2.26.3",
                 listOf("wiremock-jre8")


### PR DESCRIPTION
*Description of changes:*
Adds a `JavaTimeModule` to our ObjectMapper for serializing entities, so that we can support `Duration` and other Time-based attributes being added to Metadata. We had a customer feature request for this

@anuraaga I know the tests will fail for this with `ClassDefNotFoundError`s, I wasn't sure how to resolve this without just adding a test dependency in a bunch of modules on the new `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` dependency. 

I'm also curious to hear if you think this is even a fair expectation of the SDK, or if we should just require customers to cast their timestamps to primitives before adding it as metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
