### PR TITLE
Adds enhanced metadata parsing for Oracle DBs

### DIFF
--- a/aws-xray-recorder-sdk-sql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(":aws-xray-recorder-sdk-core"))
+    implementation("com.blogspot.mydailyjava:weak-lock-free:0.18")
 }
 
 description = "AWS X-Ray Recorder SDK for Java - SQL Interceptor"

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.sql;
+
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class ConnectionInfo {
+    @Nullable
+    private final String sanitizedUrl;
+    @Nullable
+    private final String user;
+    @Nullable
+    private final String host;
+    @Nullable
+    private final String dbName;
+
+    private ConnectionInfo(@Nullable String sanitizedUrl,
+                           @Nullable String user,
+                           @Nullable String host,
+                           @Nullable String dbName) {
+        this.sanitizedUrl = sanitizedUrl;
+        this.user = user;
+        this.host = host;
+        this.dbName = dbName;
+    }
+
+    String getSanitizedUrl() {
+        return sanitizedUrl;
+    }
+
+    String getUser() {
+        return user;
+    }
+
+    String getHost() {
+        return host;
+    }
+
+    String getDbName() {
+        return dbName;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionInfo{" +
+            "sanitizedUrl='" + sanitizedUrl + '\'' +
+            ", user='" + user + '\'' +
+            ", host='" + host + '\'' +
+            ", dbName='" + dbName + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionInfo that = (ConnectionInfo) o;
+        return Objects.equals(sanitizedUrl, that.sanitizedUrl) &&
+            Objects.equals(user, that.user) &&
+            Objects.equals(host, that.host) &&
+            Objects.equals(dbName, that.dbName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sanitizedUrl, user, host, dbName);
+    }
+
+    static class Builder {
+        private String sanitizedUrl;
+        private String user;
+        private String host;
+        private String dbName;
+
+        Builder sanitizedUrl(String sanitizedUrl) {
+            this.sanitizedUrl = sanitizedUrl;
+            return this;
+        }
+
+        Builder user(String user) {
+            this.user = user;
+            return this;
+        }
+
+        Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        Builder dbName(String dbName) {
+            this.dbName = dbName;
+            return this;
+        }
+
+        ConnectionInfo build() {
+            return new ConnectionInfo(sanitizedUrl, user, host, dbName);
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
@@ -55,16 +55,6 @@ final class ConnectionInfo {
     }
 
     @Override
-    public String toString() {
-        return "ConnectionInfo{" +
-            "sanitizedUrl='" + sanitizedUrl + '\'' +
-            ", user='" + user + '\'' +
-            ", host='" + host + '\'' +
-            ", dbName='" + dbName + '\'' +
-            '}';
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
@@ -71,7 +71,7 @@ final class ConnectionInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sanitizedUrl, user, host, dbName);
+        return Objects.hashCode(sanitizedUrl);
     }
 
     static class Builder {

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/ConnectionInfo.java
@@ -71,7 +71,11 @@ final class ConnectionInfo {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(sanitizedUrl);
+        int result = sanitizedUrl != null ? sanitizedUrl.hashCode() : 0;
+        result = 31 * result + (user != null ? user.hashCode() : 0);
+        result = 31 * result + (host != null ? host.hashCode() : 0);
+        result = 31 * result + (dbName != null ? dbName.hashCode() : 0);
+        return result;
     }
 
     static class Builder {

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/OracleConnectionUrlParser.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/OracleConnectionUrlParser.java
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.amazonaws.xray.sql;
 
 import java.util.regex.Matcher;

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/OracleConnectionUrlParser.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/OracleConnectionUrlParser.java
@@ -30,8 +30,8 @@ import org.apache.commons.logging.LogFactory;
 final class OracleConnectionUrlParser {
     private static final Log log = LogFactory.getLog(OracleConnectionUrlParser.class);
 
-    private static final Pattern hostPattern = Pattern.compile("\\(\\s*host\\s*=\\s*([^ )]+)\\s*\\)");
-    private static final Pattern instancePattern = Pattern.compile("\\(\\s*service_name\\s*=\\s*([^ )]+)\\s*\\)");
+    private static final Pattern HOST_PATTERN = Pattern.compile("\\(\\s*host\\s*=\\s*([^ )]+)\\s*\\)");
+    private static final Pattern INSTANCE_PATTERN = Pattern.compile("\\(\\s*service_name\\s*=\\s*([^ )]+)\\s*\\)");
 
 
     static ConnectionInfo parseUrl(String jdbcUrl, ConnectionInfo.Builder builder) {
@@ -150,12 +150,12 @@ final class OracleConnectionUrlParser {
             builder.user(atSplit[0].substring(0, userInfoLoc));
         }
 
-        Matcher hostMatcher = hostPattern.matcher(atSplit[1]);
+        Matcher hostMatcher = HOST_PATTERN.matcher(atSplit[1]);
         if (hostMatcher.find()) {
             builder.host(hostMatcher.group(1));
         }
 
-        Matcher instanceMatcher = instancePattern.matcher(atSplit[1]);
+        Matcher instanceMatcher = INSTANCE_PATTERN.matcher(atSplit[1]);
         if (instanceMatcher.find()) {
             builder.dbName(instanceMatcher.group(1));
         }

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/OracleConnectionUrlParser.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/OracleConnectionUrlParser.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.sql;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Class for parsing Oracle database connection URLs and extracting useful metadata.
+ * Adapted from the OpenTelemetry JdbcConnectionUrlParser class under the Apache 2.0 license.
+ *
+ * Original source: https://bit.ly/2OZB5jR
+ * Oracle URL documentation: https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
+ */
+final class OracleConnectionUrlParser {
+    private static final Log log = LogFactory.getLog(OracleConnectionUrlParser.class);
+
+    private static final Pattern hostPattern = Pattern.compile("\\(\\s*host\\s*=\\s*([^ )]+)\\s*\\)");
+    private static final Pattern instancePattern = Pattern.compile("\\(\\s*service_name\\s*=\\s*([^ )]+)\\s*\\)");
+
+
+    static ConnectionInfo parseUrl(String jdbcUrl, ConnectionInfo.Builder builder) {
+        jdbcUrl = jdbcUrl.toLowerCase();
+        recordSanitizedUrl(jdbcUrl, builder);
+        int subtypeEndIndex = jdbcUrl.indexOf(":", "jdbc:oracle:".length());
+        if (subtypeEndIndex < 0) {
+            return builder.build();
+        }
+
+        // Strip the constant prefix for simplicity
+        jdbcUrl = jdbcUrl.substring(subtypeEndIndex + 1);
+
+        if (jdbcUrl.contains("@")) {
+            return parseUrlWithAt(jdbcUrl, builder).build();
+        } else {
+            return parseOracleConnectInfo(jdbcUrl, builder).build();
+        }
+    }
+
+    private static ConnectionInfo.Builder recordSanitizedUrl(String jdbcUrl, ConnectionInfo.Builder builder) {
+        int atLoc = jdbcUrl.indexOf("@");
+        int userEndLoc = jdbcUrl.indexOf("/");
+        if (userEndLoc != -1 && userEndLoc < atLoc) {
+            builder.sanitizedUrl(jdbcUrl.substring(0, userEndLoc) + jdbcUrl.substring(atLoc));
+        } else {
+            builder.sanitizedUrl(jdbcUrl);
+        }
+
+        return builder;
+    }
+
+    private static ConnectionInfo.Builder parseOracleConnectInfo(String jdbcUrl, ConnectionInfo.Builder builder) {
+        String host;
+        String instance;
+
+        int hostEnd = jdbcUrl.indexOf(":");
+        int instanceLoc = jdbcUrl.indexOf("/");
+        if (hostEnd > 0) {
+            host = jdbcUrl.substring(0, hostEnd);
+            int afterHostEnd = jdbcUrl.indexOf(":", hostEnd + 1);
+            if (afterHostEnd > 0) {
+                instance = jdbcUrl.substring(afterHostEnd + 1);
+            } else {
+                if (instanceLoc > 0) {
+                    instance = jdbcUrl.substring(instanceLoc + 1);
+                } else {
+                    String portOrInstance = jdbcUrl.substring(hostEnd + 1);
+                    Integer parsedPort = null;
+                    try {
+                        parsedPort = Integer.parseInt(portOrInstance);
+                    } catch (NumberFormatException e) {
+                        log.debug(e.getMessage(), e);
+                    }
+                    if (parsedPort == null) {
+                        instance = portOrInstance;
+                    } else {
+                        instance = null;
+                    }
+                }
+            }
+        } else {
+            if (instanceLoc > 0) {
+                host = jdbcUrl.substring(0, instanceLoc);
+                instance = jdbcUrl.substring(instanceLoc + 1);
+            } else {
+                if (jdbcUrl.isEmpty()) {
+                    return builder;
+                } else {
+                    host = null;
+                    instance = jdbcUrl;
+                }
+            }
+        }
+        if (host != null) {
+            builder.host(host);
+        }
+        return builder.dbName(instance);
+    }
+
+    private static ConnectionInfo.Builder parseUrlWithAt(String jdbcUrl, ConnectionInfo.Builder builder) {
+        if (jdbcUrl.contains("@(description")) {
+            return parseDescription(jdbcUrl, builder);
+        }
+        String user;
+
+        String[] atSplit = jdbcUrl.split("@", 2);
+
+        int userInfoLoc = atSplit[0].indexOf("/");
+        if (userInfoLoc > 0) {
+            user = atSplit[0].substring(0, userInfoLoc);
+        } else {
+            user = null;
+        }
+
+        String connectInfo = atSplit[1];
+        int hostStart;
+        if (connectInfo.startsWith("//")) {
+            hostStart = "//".length();
+        } else if (connectInfo.startsWith("ldap://")) {
+            hostStart = "ldap://".length();
+        } else {
+            hostStart = 0;
+        }
+        if (user != null) {
+            builder.user(user);
+        }
+        return parseOracleConnectInfo(connectInfo.substring(hostStart), builder);
+    }
+
+    private static ConnectionInfo.Builder parseDescription(String jdbcUrl, ConnectionInfo.Builder builder) {
+        String[] atSplit = jdbcUrl.split("@", 2);
+
+        int userInfoLoc = atSplit[0].indexOf("/");
+        if (userInfoLoc > 0) {
+            builder.user(atSplit[0].substring(0, userInfoLoc));
+        }
+
+        Matcher hostMatcher = hostPattern.matcher(atSplit[1]);
+        if (hostMatcher.find()) {
+            builder.host(hostMatcher.group(1));
+        }
+
+        Matcher instanceMatcher = instancePattern.matcher(atSplit[1]);
+        if (instanceMatcher.find()) {
+            builder.dbName(instanceMatcher.group(1));
+        }
+
+        return builder;
+    }
+
+
+    private OracleConnectionUrlParser() {
+    }
+}

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
@@ -19,14 +19,13 @@ import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Subsegment;
 
+import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
-import java.util.Map;
-import java.util.WeakHashMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -38,7 +37,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class SqlSubsegments {
     private static final Log logger = LogFactory.getLog(SqlSubsegments.class);
 
-    private static Map<Connection, ConnectionInfo> connMap = new WeakHashMap<>();
+    private static WeakConcurrentMap<Connection, ConnectionInfo> connMap = new WeakConcurrentMap.WithInlinedExpunction<>();
 
     /**
      * The URL of the database this query is made on
@@ -163,7 +162,7 @@ public final class SqlSubsegments {
     }
 
     // Visible for testing
-    static void setConnMap(Map connMap) {
+    static void setConnMap(WeakConcurrentMap<Connection, ConnectionInfo> connMap) {
         SqlSubsegments.connMap = connMap;
     }
 

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
@@ -88,7 +88,6 @@ public final class SqlSubsegments {
      * @return the created {@link Subsegment}.
      */
     public static Subsegment forQuery(Connection connection, @Nullable String query) {
-        logger.info("In forQuery with connection: " + connection + " and query: " + query);
         DatabaseMetaData metadata;
         ConnectionInfo connectionInfo = connMap.get(connection);
         String subsegmentName = DEFAULT_DATABASE_NAME;
@@ -96,10 +95,6 @@ public final class SqlSubsegments {
         try {
             metadata = connection.getMetaData();
             String connUrl = metadata.getURL();
-            logger.info("Got connUrl: " + connUrl);
-            if (connectionInfo != null) {
-                logger.info("cache hit!!\n" + connectionInfo.toString());
-            }
 
             // Parse URL if Oracle
             if (connectionInfo == null && connUrl != null && connUrl.contains("oracle")) {
@@ -119,22 +114,18 @@ public final class SqlSubsegments {
                 database = DEFAULT_DATABASE_NAME;
             }
 
-            logger.info("determined database name: " + database);
-
             // Get database host if available; otherwise omit host
             String host = null;
             if (connectionInfo.getHost() != null) {
                 host = connectionInfo.getHost();
-            } else {
+            } else if (connUrl != null) {
                 try {
-                    host = new URI(new URI(metadata.getURL()).getSchemeSpecificPart()).getHost();
+                    host = new URI(new URI(connUrl).getSchemeSpecificPart()).getHost();
                 } catch (URISyntaxException e) {
                     logger.debug("Unable to parse database URI. Falling back to default '" + DEFAULT_DATABASE_NAME
                         + "' for subsegment name.", e);
                 }
             }
-
-            logger.info("determined host: " + host);
 
             // Fully formed subsegment name is of form "dbName@host"
             subsegmentName = database + (host != null ? "@" + host : "");

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/OracleConnectionUrlParserTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/OracleConnectionUrlParserTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class OracleConnectionUrlParserTest {
+
+    // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
+    // https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm
+    // https://docs.oracle.com/cd/B28359_01/java.111/b31224/instclnt.htm
+    private String[] ORACLE_URLS = {
+        "jdbc:oracle:thin:orcluser/PW@localhost:55:orclsn",
+        "jdbc:oracle:thin:orcluser/PW@//orcl.host:55/orclsn",
+        "jdbc:oracle:thin:orcluser/PW@127.0.0.1:orclsn",
+        "jdbc:oracle:thin:orcluser/PW@//orcl.host/orclsn",
+        "jdbc:oracle:thin:@//orcl.host:55/orclsn",
+        "jdbc:oracle:thin:@ldap://orcl.host:55/some,cn=OracleContext,dc=com",
+        "jdbc:oracle:thin:127.0.0.1:orclsn",
+        "jdbc:oracle:thin:orcl.host:orclsn",
+        "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST= 127.0.0.1 )(POR T= 666))" +
+            "(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=orclsn)))",
+        "jdbc:oracle:drivertype:orcluser/PW@orcl.host:55/orclsn",
+        "jdbc:oracle:oci8:@",
+        "jdbc:oracle:oci8:@orclsn",
+        "jdbc:oracle:oci:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)( HOST =  orcl.host )" +
+            "( PORT = 55  ))(CONNECT_DATA=(SERVICE_NAME =orclsn  )))"
+    };
+
+    private ConnectionInfo[] EXPECTED_INFO = {
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:orcluser@localhost:55:orclsn").user("orcluser")
+            .host("localhost").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:orcluser@//orcl.host:55/orclsn").user("orcluser")
+            .host("orcl.host").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:orcluser@127.0.0.1:orclsn").user("orcluser")
+            .host("127.0.0.1").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:orcluser@//orcl.host/orclsn").user("orcluser")
+            .host("orcl.host").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:@//orcl.host:55/orclsn")
+            .host("orcl.host").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:@ldap://orcl.host:55/some,cn=oraclecontext,dc=com")
+            .host("orcl.host").dbName("some,cn=oraclecontext,dc=com").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:127.0.0.1:orclsn")
+            .host("127.0.0.1").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:orcl.host:orclsn")
+            .host("orcl.host").dbName("orclsn").build(),
+        new ConnectionInfo.Builder()
+            .sanitizedUrl("jdbc:oracle:thin:@(description=(address=(protocol=tcp)(host= 127.0.0.1 )(por t= 666))" +
+            "(connect_data=(server=dedicated)(service_name=orclsn)))").host("127.0.0.1").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:drivertype:orcluser@orcl.host:55/orclsn").user("orcluser")
+            .host("orcl.host").dbName("orclsn").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:oci8:@").build(),
+        new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:oci8:@orclsn").dbName("orclsn").build(),
+        new ConnectionInfo.Builder()
+            .sanitizedUrl("jdbc:oracle:oci:@(description=(address=(protocol=tcp)( host =  orcl.host )( port = 55  ))" +
+            "(connect_data=(service_name =orclsn  )))").host("orcl.host").dbName("orclsn").build()
+    };
+
+    @Test
+    void testUrlParsing() {
+        assertThat(ORACLE_URLS.length).isEqualTo(EXPECTED_INFO.length);
+        for (int i = 0; i < ORACLE_URLS.length; i++) {
+            ConnectionInfo.Builder builder = new ConnectionInfo.Builder();
+            ConnectionInfo parsed = OracleConnectionUrlParser.parseUrl(ORACLE_URLS[i], builder);
+            assertThat(parsed).isEqualTo(EXPECTED_INFO[i]);
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/OracleConnectionUrlParserTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/OracleConnectionUrlParserTest.java
@@ -13,12 +13,23 @@
  * permissions and limitations under the License.
  */
 
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.amazonaws.xray.sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Test class for parsing a bunch of acceptable Oracle URLs. The test cases are taken from the
+ * OpenTelemetry JdbcConnectionUrlParser test class.
+ *
+ * Original source: https://bit.ly/3mhFCud
+ */
 class OracleConnectionUrlParserTest {
 
     // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/OracleConnectionUrlParserTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/OracleConnectionUrlParserTest.java
@@ -24,7 +24,7 @@ class OracleConnectionUrlParserTest {
     // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm
     // https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm
     // https://docs.oracle.com/cd/B28359_01/java.111/b31224/instclnt.htm
-    private String[] ORACLE_URLS = {
+    private static final String[] ORACLE_URLS = {
         "jdbc:oracle:thin:orcluser/PW@localhost:55:orclsn",
         "jdbc:oracle:thin:orcluser/PW@//orcl.host:55/orclsn",
         "jdbc:oracle:thin:orcluser/PW@127.0.0.1:orclsn",
@@ -42,7 +42,7 @@ class OracleConnectionUrlParserTest {
             "( PORT = 55  ))(CONNECT_DATA=(SERVICE_NAME =orclsn  )))"
     };
 
-    private ConnectionInfo[] EXPECTED_INFO = {
+    private static final ConnectionInfo[] EXPECTED_INFO = {
         new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:orcluser@localhost:55:orclsn").user("orcluser")
             .host("localhost").dbName("orclsn").build(),
         new ConnectionInfo.Builder().sanitizedUrl("jdbc:oracle:thin:orcluser@//orcl.host:55/orclsn").user("orcluser")

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
@@ -136,7 +136,7 @@ class SqlSubsegmentsTest {
 
     @Test
     void testHostIsNotNull() throws SQLException {
-        when(metaData.getURL()).thenReturn(null);
+        when(metaData.getURL()).thenReturn("some invalid URL");
 
         Subsegment sub = SqlSubsegments.forQuery(connection, SQL);
 

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
@@ -16,6 +16,10 @@
 package com.amazonaws.xray.sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.xray.AWSXRay;
@@ -28,13 +32,15 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.WeakHashMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
-public class SqlSubsegmentsTest {
+class SqlSubsegmentsTest {
     private static final String URL = "http://www.foo.com";
     private static final String HOST = "www.foo.com";
     private static final String USER = "user";
@@ -51,6 +57,9 @@ public class SqlSubsegmentsTest {
     @Mock
     DatabaseMetaData metaData;
 
+    @Spy
+    Map<Connection, ConnectionInfo> mapSpy = new WeakHashMap<>();
+
     @BeforeEach
     void setup() throws SQLException {
         MockitoAnnotations.initMocks(this);
@@ -63,6 +72,7 @@ public class SqlSubsegmentsTest {
         when(metaData.getDatabaseProductVersion()).thenReturn(DB_VERSION);
 
         AWSXRay.beginSegment("test");
+        SqlSubsegments.setConnMap(new WeakHashMap());
     }
 
     @AfterEach
@@ -113,5 +123,59 @@ public class SqlSubsegmentsTest {
         assertThat(sub.getName()).isEqualTo(SqlSubsegments.DEFAULT_DATABASE_NAME);
         assertThat(sub.isInProgress()).isTrue();
         assertThat(sub.getParentSegment().getSubsegments()).contains(sub);
+    }
+
+    @Test
+    void testDbNameIsNotNull() throws SQLException {
+        when(connection.getCatalog()).thenReturn(null);
+
+        Subsegment sub = SqlSubsegments.forQuery(connection, SQL);
+
+        assertThat(sub.getName()).isEqualTo(SqlSubsegments.DEFAULT_DATABASE_NAME + "@" + HOST);
+    }
+
+    @Test
+    void testHostIsNotNull() throws SQLException {
+        when(metaData.getURL()).thenReturn(null);
+
+        Subsegment sub = SqlSubsegments.forQuery(connection, SQL);
+
+        assertThat(sub.getName()).isEqualTo(CATALOG);
+    }
+
+    @Test
+    void testPrefersSubsegmentNameFromUrl() {
+        Map<Connection, ConnectionInfo> map = new HashMap<>();
+        map.put(connection, new ConnectionInfo.Builder().dbName("newDb").host("another").build());
+        SqlSubsegments.setConnMap(map);
+    }
+
+    @Test
+    void testPrefersMetaDataFromUrl() {
+        Map<Connection, ConnectionInfo> map = new HashMap<>();
+        map.put(connection, new ConnectionInfo.Builder()
+            .sanitizedUrl("jdbc:oracle:rds.us-west-2.com").user("another").dbName("newDb").host("rds.us-west-2.com").build());
+        SqlSubsegments.setConnMap(map);
+
+        Subsegment sub = SqlSubsegments.forQuery(connection, SQL);
+
+        assertThat(sub.getName()).isEqualTo("newDb@rds.us-west-2.com");
+        assertThat(sub.getSql()).containsEntry("url", "jdbc:oracle:rds.us-west-2.com");
+        assertThat(sub.getSql()).containsEntry("user", "another");
+    }
+
+    @Test
+    void testCacheInsertionOnNewConnection() throws SQLException {
+        when(metaData.getURL()).thenReturn("jdbc:oracle:thin@rds.us-west-2.com");
+        SqlSubsegments.setConnMap(mapSpy);
+
+        SqlSubsegments.forQuery(connection, "query 1");
+        SqlSubsegments.forQuery(connection, "query 2");
+
+        assertThat(mapSpy).hasSize(1);
+        assertThat(mapSpy).containsKey(connection);
+
+        verify(mapSpy, times(1)).put(eq(connection), any());
+        verify(mapSpy, times(2)).get(connection);
     }
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -368,14 +368,12 @@
         -->
 
         <!-- Checks that we don't use Objects.hash. Objects.hashCode is preferred-->
-        <!--
         <module name="Regexp">
             <property name="format" value="\bObjects.hash\b"/>
             <property name="illegalPattern" value="true"/>
             <property name="message" value="Don't use Objects.hash, use Objects.hashCode instead"/>
             <property name="ignoreComments" value="true"/>
         </module>
-        -->
 
         <!-- Checks for redundant public modifier on interfaces and other redundant modifiers -->
         <module name="RedundantModifier" />

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -368,12 +368,14 @@
         -->
 
         <!-- Checks that we don't use Objects.hash. Objects.hashCode is preferred-->
+        <!--
         <module name="Regexp">
             <property name="format" value="\bObjects.hash\b"/>
             <property name="illegalPattern" value="true"/>
             <property name="message" value="Don't use Objects.hash, use Objects.hashCode instead"/>
             <property name="ignoreComments" value="true"/>
         </module>
+        -->
 
         <!-- Checks for redundant public modifier on interfaces and other redundant modifiers -->
         <module name="RedundantModifier" />


### PR DESCRIPTION
*Description of changes:*
This change enables users of the X-Ray SDK and agent who query Oracle DBs to have more accurate metadata by directly parsing the DB connection URL. Much of the parsing logic is adapted from [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/28b1aa386bde65647a95d9e7d435a0894d52cfa1/instrumentation/jdbc/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/jdbc/JdbcConnectionUrlParser.java), and attributed as such. 

Since we are likely not going to add this advanced support for other DB providers, I mostly special-cased the Oracle logic as opposed to the more generic approach that OTel takes for simplicity. I always preferred the info from parsing over the info from `DatabaseMetaData` where applicable.

This also fixes a more general issue with DB subsegment naming where we didn't do sufficient null-checking.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
