### PR TITLE
added DockerPlugin for log correlation

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/AWSLogReference.java
@@ -16,6 +16,7 @@
 package com.amazonaws.xray.entities;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -34,6 +35,7 @@ public class AWSLogReference {
     /**
      * Returns the log group name associated with the segment.
      */
+    @JsonProperty("awslogs-group")
     @Nullable
     public String getLogGroup() {
         return logGroup;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/DockerPlugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/DockerPlugin.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.plugins;
+
+import com.amazonaws.xray.entities.AWSLogReference;
+import com.amazonaws.xray.entities.StringValidator;
+import com.amazonaws.xray.utils.DockerUtils;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A plugin, for use with the {@link com.amazonaws.xray.AWSXRayRecorderBuilder}, to record log references for dockerized
+ * applications using the awslogs driver.
+ */
+public class DockerPlugin implements Plugin {
+    private static final String LINUX_DOCKER_PATH = "/etc/docker/daemon.json";
+
+    private final FileSystem fs;
+    private final Set<AWSLogReference> logReferences;
+
+    public DockerPlugin() {
+        this(FileSystems.getDefault());
+    }
+
+    public DockerPlugin(FileSystem fs) {
+        this.fs = fs;
+        this.logReferences = new HashSet<>();
+    }
+
+    /**
+     * @return {@code null} because there is no allow-listed Docker origin for X-Ray segments
+     */
+    @Override
+    @Nullable
+    public String getOrigin() {
+        return null;
+    }
+
+    /**
+     * @return name of service for this plugin
+     */
+    @Override
+    public String getServiceName() {
+        return "docker";
+    }
+
+    /**
+     * Determines if the docker metadata can be recorded in X-Ray segments
+     * @return true if the Docker daemon config file is present at default location
+     */
+    @Override
+    public boolean isEnabled() {
+        return this.fs.getPath(LINUX_DOCKER_PATH).toFile().exists();
+    }
+
+    /**
+     * @return empty map because this plugin only collects log references.
+     */
+    @Override
+    public Map<String, @Nullable Object> getRuntimeContext() {
+        return new HashMap<>();
+    }
+
+    /**
+     * Parses the docker daemon config file for an AWS Log Group if the awslogs driver is in use
+     * @return a set containing the discovered log group if present, otherwise an empty set
+     */
+    @Override
+    public Set<AWSLogReference> getLogReferences() {
+        if (this.logReferences.isEmpty()) {
+            populateLogReferences();
+        }
+        return this.logReferences;
+    }
+
+    private void populateLogReferences() {
+        AWSLogReference reference = DockerUtils.getAwsLogReference(LINUX_DOCKER_PATH, this.fs);
+        if (reference != null && StringValidator.isNotNullOrBlank(reference.getLogGroup())) {
+            this.logReferences.add(reference);
+        }
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/Plugin.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/plugins/Plugin.java
@@ -27,8 +27,9 @@ public interface Plugin {
      * Returns the name of the origin associated with this plugin.
      * The {@link com.amazonaws.xray.AWSXRayRecorder} contains a prioritized list of origins from least to most specific.
      *
-     * @return the name of the origin associated with this plugin.
+     * @return the name of the origin associated with this plugin, or {@code null} if the plugin has no allow-listed origin
      */
+    @Nullable
     String getOrigin();
 
     String getServiceName();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/FSUtils.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/utils/FSUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.utils;
+
+import com.amazonaws.xray.entities.StringValidator;
+import java.nio.file.FileSystem;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class FSUtils {
+    private static final String WINDOWS_PROGRAM_DATA = "ProgramData";
+
+    @Nullable
+    public static String getOsSpecificFilePath(FileSystem fs, String linuxPath, String windowsPath) {
+        if (fs.getSeparator() == null) {
+            return null;
+        }
+
+        if (fs.getSeparator().equals("/")) {
+            return linuxPath;
+        } else if (fs.getSeparator().equals("\\")) {
+            String programData = System.getenv(WINDOWS_PROGRAM_DATA);
+            if (StringValidator.isNotNullOrBlank(programData)) {
+                return programData + windowsPath;
+            }
+        }
+
+        return null;
+    }
+
+    private FSUtils() {
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/DockerPluginTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/plugins/DockerPluginTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.xray.plugins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.xray.entities.AWSLogReference;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.Paths;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DockerPluginTest {
+    private DockerPlugin dockerPlugin;
+
+    @Mock
+    FileSystem fakeFs;
+
+    @BeforeEach
+    void setup() {
+        dockerPlugin = new DockerPlugin(fakeFs);
+    }
+
+    @Test
+    void testPluginEnabled() throws URISyntaxException {
+        String path = "/com/amazonaws/xray/utils/easyDockerConfig.json";
+        when(fakeFs.getPath(anyString())).thenReturn(Paths.get(DockerPluginTest.class.getResource(path).toURI()));
+
+        assertThat(dockerPlugin.isEnabled()).isTrue();
+    }
+
+    @Test
+    void testPluginDisabled() {
+        when(fakeFs.getPath(anyString())).thenReturn(Paths.get("/some/definitely/nonexistent/path"));
+
+        assertThat(dockerPlugin.isEnabled()).isFalse();
+    }
+
+    @Test
+    void testDockerLogGroupDiscovery() throws URISyntaxException {
+        String path = "/com/amazonaws/xray/utils/easyDockerConfig.json";
+        when(fakeFs.getPath(anyString())).thenReturn(Paths.get(DockerPluginTest.class.getResource(path).toURI()));
+        AWSLogReference expected = new AWSLogReference();
+        expected.setLogGroup("docker-group");
+
+        Set<AWSLogReference> logReferences = dockerPlugin.getLogReferences();
+        assertThat(logReferences).hasSize(1);
+        assertThat(logReferences).contains(expected);
+    }
+
+    @Test
+    void testNoLogGroupsDiscovered() throws URISyntaxException {
+        String path = "/com/amazonaws/xray/utils/noGroupDockerConfig.json";
+        when(fakeFs.getPath(anyString())).thenReturn(Paths.get(DockerPluginTest.class.getResource(path).toURI()));
+
+        Set<AWSLogReference> logReferences = dockerPlugin.getLogReferences();
+        assertThat(logReferences).isEmpty();
+    }
+}

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/DockerUtilsTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/utils/DockerUtilsTest.java
@@ -15,32 +15,46 @@
 
 package com.amazonaws.xray.utils;
 
-import java.io.IOException;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
+import com.amazonaws.xray.entities.AWSLogReference;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 class DockerUtilsTest {
     private static final String DOCKER_ID = "79311de543c2b01bdbb7ccaf355e71a02b0726366a1427ecfceb5e1f5be81644";
+
+    @Mock
+    private FileSystem mockFs;
 
     @Test
     void testEmptyCgroupFile() throws IOException {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource("/com/amazonaws/xray/utils/emptyCgroup"));
         String id = dockerUtils.getContainerId();
-        Assertions.assertNull(id);
+        assertThat(id).isNull();
     }
 
     @Test
     void testInvalidCgroupFile() throws IOException {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource("/com/amazonaws/xray/utils/invalidCgroup"));
         String id = dockerUtils.getContainerId();
-        Assertions.assertNull(id);
+        assertThat(id).isNull();
     }
 
     @Test
     void testValidFirstLineCgroupFile() throws IOException {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource("/com/amazonaws/xray/utils/validCgroup"));
         String id = dockerUtils.getContainerId();
-        Assertions.assertEquals(DOCKER_ID, id);
+        assertThat(id).isEqualTo(DOCKER_ID);
     }
 
     @Test
@@ -48,6 +62,43 @@ class DockerUtilsTest {
         DockerUtils dockerUtils = new DockerUtils(DockerUtilsTest.class.getResource(
             "/com/amazonaws/xray/utils/validSecondCgroup"));
         String id = dockerUtils.getContainerId();
-        Assertions.assertEquals(DOCKER_ID, id);
+        assertThat(id).isEqualTo(DOCKER_ID);
+    }
+
+    @Test
+    void testParseBasicDockerConfig() throws URISyntaxException {
+        String classPath = "/com/amazonaws/xray/utils/easyDockerConfig.json";
+        when(mockFs.getPath(anyString())).thenReturn(Paths.get(DockerUtilsTest.class.getResource(classPath).toURI()));
+        AWSLogReference expected = new AWSLogReference();
+        expected.setLogGroup("docker-group");
+
+        AWSLogReference logReference = DockerUtils.getAwsLogReference("", mockFs);
+        assertThat(logReference).isEqualTo(expected);
+    }
+
+    @Test
+    void testParseNonAwsConfig() throws URISyntaxException {
+        String classPath = "/com/amazonaws/xray/utils/otherDriverDockerConfig.json";
+        when(mockFs.getPath(anyString())).thenReturn(Paths.get(DockerUtilsTest.class.getResource(classPath).toURI()));
+
+        AWSLogReference logReference = DockerUtils.getAwsLogReference("", mockFs);
+        assertThat(logReference).isNull();
+    }
+
+    @Test
+    void testParseDockerConfigWithoutGroup() throws URISyntaxException {
+        String classPath = "/com/amazonaws/xray/utils/noGroupDockerConfig.json";
+        when(mockFs.getPath(anyString())).thenReturn(Paths.get(DockerUtilsTest.class.getResource(classPath).toURI()));
+        AWSLogReference expected = new AWSLogReference();
+
+        AWSLogReference logReference = DockerUtils.getAwsLogReference("", mockFs);
+        assertThat(logReference).isEqualTo(expected);
+    }
+
+    @Test
+    void testNonExistentDockerConfig() {
+        when(mockFs.getPath(anyString())).thenReturn(Paths.get("/some/definitely/fake/path"));
+        AWSLogReference logReference = DockerUtils.getAwsLogReference("", mockFs);
+        assertThat(logReference).isNull();
     }
 }

--- a/aws-xray-recorder-sdk-core/src/test/resources/com/amazonaws/xray/utils/easyDockerConfig.json
+++ b/aws-xray-recorder-sdk-core/src/test/resources/com/amazonaws/xray/utils/easyDockerConfig.json
@@ -1,0 +1,10 @@
+{
+  "data-root": "",
+  "dns": [],
+  "log-driver": "awslogs",
+  "log-opts": {
+    "labels": "somelabel",
+    "awslogs-region": "us-east-1",
+    "awslogs-group": "docker-group"
+  }
+}

--- a/aws-xray-recorder-sdk-core/src/test/resources/com/amazonaws/xray/utils/noGroupDockerConfig.json
+++ b/aws-xray-recorder-sdk-core/src/test/resources/com/amazonaws/xray/utils/noGroupDockerConfig.json
@@ -1,0 +1,9 @@
+{
+  "data-root": "",
+  "dns": [],
+  "log-driver": "awslogs",
+  "log-opts": {
+    "labels": "somelabel",
+    "awslogs-region": "us-east-1"
+  }
+}

--- a/aws-xray-recorder-sdk-core/src/test/resources/com/amazonaws/xray/utils/otherDriverDockerConfig.json
+++ b/aws-xray-recorder-sdk-core/src/test/resources/com/amazonaws/xray/utils/otherDriverDockerConfig.json
@@ -1,0 +1,10 @@
+{
+  "data-root": "",
+  "dns": [],
+  "log-driver": "other",
+  "log-opts": {
+    "labels": "somelabel",
+    "config": "foo",
+    "awslogs-group": "should-not-matter"
+  }
+}


### PR DESCRIPTION
*Description of changes:*
Adds a new plugin for Dockerized applications that parses log groups from the Docker daemon config file to record them in traces. Unfortunately, this parsing still requires manual action from the customer: they need to copy over the config file into their application container so it's readable by the plugin. This is because the docker daemon runs on the host, so its config file is also located on the host, which means it can't be read by containers unless the volume containing the file is bound to the container.

Also refactored some of the EC2Plugin logic to be cleaner.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
