### PR TITLE
Remove subsegments lock

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
@@ -242,6 +242,11 @@ public class DummySegment implements Segment {
     }
 
     @Override
+    public List<Subsegment> getSubsegmentsCopy() {
+        return new ArrayList<>(list);
+    }
+
+    @Override
     public void addSubsegment(Subsegment subsegment) {
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
@@ -224,6 +224,11 @@ public class DummySubsegment implements Subsegment {
     }
 
     @Override
+    public List<Subsegment> getSubsegmentsCopy() {
+        return new ArrayList<>(list);
+    }
+
+    @Override
     public void addSubsegment(Subsegment subsegment) {
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
@@ -368,10 +368,16 @@ public interface Entity extends AutoCloseable {
     /**
      * @return the subsegments
      *
-     * @deprecated Use {@link #addSubsegment(Subsegment)} to add subsegments.
+     * @deprecated Use {@link #getSubsegmentsCopy()}.
      */
     @Deprecated
     List<Subsegment> getSubsegments();
+
+    /**
+     * Returns a copy of the currently added subsegments. Updates to the returned {@link List} will not be reflected in the
+     * {@link Entity}.
+     */
+    List<Subsegment> getSubsegmentsCopy();
 
     /**
      * Adds a subsegment.

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
@@ -158,7 +158,7 @@ public interface Entity extends AutoCloseable {
     void setNamespace(String namespace);
 
     /**
-     * @return the subsegmentsLock
+     * @return an unused {@link ReentrantLock}
      *
      * @deprecated This is for internal use of the SDK and will be made private.
      */

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
@@ -367,7 +367,10 @@ public interface Entity extends AutoCloseable {
 
     /**
      * @return the subsegments
+     *
+     * @deprecated Use {@link #addSubsegment(Subsegment)} to add subsegments.
      */
+    @Deprecated
     List<Subsegment> getSubsegments();
 
     /**

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -531,6 +531,13 @@ public abstract class EntityImpl implements Entity {
     }
 
     @Override
+    public List<Subsegment> getSubsegmentsCopy() {
+        synchronized (lock) {
+            return new ArrayList<>(subsegments);
+        }
+    }
+
+    @Override
     public void addSubsegment(Subsegment subsegment) {
         synchronized (lock) {
             checkAlreadyEmitted();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -534,12 +534,7 @@ public abstract class EntityImpl implements Entity {
     public void addSubsegment(Subsegment subsegment) {
         synchronized (lock) {
             checkAlreadyEmitted();
-            getSubsegmentsLock().lock();
-            try {
-                subsegments.add(subsegment);
-            } finally {
-                getSubsegmentsLock().unlock();
-            }
+            subsegments.add(subsegment);
         }
     }
 
@@ -548,13 +543,8 @@ public abstract class EntityImpl implements Entity {
         synchronized (lock) {
             checkAlreadyEmitted();
             setFault(true);
-            getSubsegmentsLock().lock();
-            try {
-                cause.addExceptions(creator.getThrowableSerializationStrategy()
-                                           .describeInContext(this, exception, subsegments));
-            } finally {
-                getSubsegmentsLock().unlock();
-            }
+            cause.addExceptions(creator.getThrowableSerializationStrategy()
+                                       .describeInContext(this, exception, subsegments));
         }
     }
 
@@ -756,12 +746,7 @@ public abstract class EntityImpl implements Entity {
     @Override
     public void removeSubsegment(Subsegment subsegment) {
         synchronized (lock) {
-            getSubsegmentsLock().lock();
-            try {
-                subsegments.remove(subsegment);
-            } finally {
-                getSubsegmentsLock().unlock();
-            }
+            subsegments.remove(subsegment);
             getParentSegment().getTotalSize().decrement();
         }
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -530,6 +530,7 @@ public abstract class EntityImpl implements Entity {
         }
     }
 
+    @JsonIgnore
     @Override
     public List<Subsegment> getSubsegmentsCopy() {
         synchronized (lock) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
@@ -283,6 +283,11 @@ class NoOpSegment implements Segment {
     }
 
     @Override
+    public List<Subsegment> getSubsegmentsCopy() {
+        return NoOpList.get();
+    }
+
+    @Override
     public void addSubsegment(Subsegment subsegment) {
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
@@ -226,6 +226,11 @@ class NoOpSubSegment implements Subsegment {
     }
 
     @Override
+    public List<Subsegment> getSubsegmentsCopy() {
+        return NoOpList.get();
+    }
+
+    @Override
     public void addSubsegment(Subsegment subsegment) {
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
@@ -82,13 +82,7 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
      */
     @Override
     public void streamSome(Entity entity, Emitter emitter) {
-        if (entity.getSubsegmentsLock().tryLock()) {
-            try {
-                stream(entity, emitter);
-            } finally {
-                entity.getSubsegmentsLock().unlock();
-            }
-        }
+        stream(entity, emitter);
     }
 
     private boolean stream(Entity entity, Emitter emitter) {
@@ -98,14 +92,8 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
         //Gather children and in the condition they are ready to stream, add them to the streamable list.
         if (children.size() > 0) {
             for (Subsegment child : children) {
-                if (child.getSubsegmentsLock().tryLock()) {
-                    try {
-                        if (stream(child, emitter)) {
-                            streamable.add(child);
-                        }
-                    } finally {
-                        child.getSubsegmentsLock().unlock();
-                    }
+                if (stream(child, emitter)) {
+                    streamable.add(child);
                 }
             }
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
@@ -20,6 +20,7 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import java.util.ArrayList;
+import java.util.List;
 
 public class DefaultStreamingStrategy implements StreamingStrategy {
 
@@ -86,8 +87,8 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
     }
 
     private boolean stream(Entity entity, Emitter emitter) {
-        ArrayList<Subsegment> children = new ArrayList<>(entity.getSubsegments());
-        ArrayList<Subsegment> streamable = new ArrayList<>();
+        List<Subsegment> children = entity.getSubsegmentsCopy();
+        List<Subsegment> streamable = new ArrayList<>();
 
         //Gather children and in the condition they are ready to stream, add them to the streamable list.
         if (children.size() > 0) {


### PR DESCRIPTION
*Issue #, if available:* Fixes #276

*Description of changes:*
Since we lock all access to the segment now, the subsegments lock is mostly not necessary. The only pattern it was needed for is user code doing something like

```java
getSubsegmentsLock().lock()
getSubsegments().add(segment) // Not addSubsegment
unlock()
```

But it's basically impossible to make code deadlock-free when returning locks to unknown code and is basically a forbidden practice in Java. I think it's best we just hope no one is doing this, and if someone is and tells us, we recommend the unfortunate code change of switching to `addSubsegment`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
