### PR TITLE
Keep track of emitted in emitter.

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -81,7 +81,12 @@ public class UDPEmitter extends Emitter {
         if (logger.isDebugEnabled()) {
             logger.debug(segment.prettySerialize());
         }
-        return sendData((PROTOCOL_HEADER + PROTOCOL_DELIMITER + segment.serialize()).getBytes(StandardCharsets.UTF_8), segment);
+        if (segment.compareAndSetEmitted(false, true)) {
+            return sendData((PROTOCOL_HEADER + PROTOCOL_DELIMITER + segment.serialize()).getBytes(StandardCharsets.UTF_8),
+                            segment);
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -94,8 +99,13 @@ public class UDPEmitter extends Emitter {
         if (logger.isDebugEnabled()) {
             logger.debug(subsegment.prettyStreamSerialize());
         }
-        return sendData((PROTOCOL_HEADER + PROTOCOL_DELIMITER + subsegment.streamSerialize()).getBytes(StandardCharsets.UTF_8),
-                        subsegment);
+        if (subsegment.compareAndSetEmitted(false, true)) {
+            return sendData((PROTOCOL_HEADER + PROTOCOL_DELIMITER +
+                             subsegment.streamSerialize()).getBytes(StandardCharsets.UTF_8),
+                            subsegment);
+        } else {
+            return false;
+        }
     }
 
     private boolean sendData(byte[] data, Entity entity) {

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySegment.java
@@ -303,6 +303,11 @@ public class DummySegment implements Segment {
     }
 
     @Override
+    public boolean compareAndSetEmitted(boolean current, boolean next) {
+        return false;
+    }
+
+    @Override
     public String serialize() {
         return "";
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
@@ -285,6 +285,11 @@ public class DummySubsegment implements Subsegment {
     }
 
     @Override
+    public boolean compareAndSetEmitted(boolean current, boolean next) {
+        return false;
+    }
+
+    @Override
     public String serialize() {
         return "";
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Entity.java
@@ -591,7 +591,17 @@ public interface Entity extends AutoCloseable {
 
     boolean isEmitted();
 
+    /**
+     * @deprecated Use {@link #compareAndSetEmitted(boolean, boolean)}
+     */
+    @Deprecated
     void setEmitted(boolean emitted);
+
+    /**
+     * Checks whether this {@link Entity} currently has emitted state of {@code current} and if so, set emitted state to
+     * {@code next}. Returns {@code true} if the state was updated, or {@code false} otherwise.
+     */
+    boolean compareAndSetEmitted(boolean current, boolean next);
 
     String serialize();
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -142,6 +142,10 @@ public abstract class EntityImpl implements Entity {
     @GuardedBy("lock")
     private boolean emitted = false;
 
+    @JsonIgnore
+    @GuardedBy("lock")
+    protected boolean ended = false;
+
     static {
         /*
          * Inject the CauseSerializer and StackTraceElementSerializer classes into the local mapper such that they will serialize
@@ -207,7 +211,7 @@ public abstract class EntityImpl implements Entity {
     }
 
     /**
-     * Checks if the entity has already been emitted to the X-Ray daemon.
+     * Checks if the entity has already been ended.
      *
      * @throws AlreadyEmittedException
      *             if the entity has already been emitted to the X-Ray daemon and the ContextMissingStrategy of the
@@ -216,7 +220,7 @@ public abstract class EntityImpl implements Entity {
      */
     protected void checkAlreadyEmitted() {
         synchronized (lock) {
-            if (emitted) {
+            if (ended || emitted) {
                 getCreator().getContextMissingStrategy().contextMissing("Segment " + getName() + " has already been emitted.",
                                                                         AlreadyEmittedException.class);
             }
@@ -726,6 +730,17 @@ public abstract class EntityImpl implements Entity {
         synchronized (lock) {
             checkAlreadyEmitted();
             this.emitted = emitted;
+        }
+    }
+
+    @Override
+    public boolean compareAndSetEmitted(boolean current, boolean next) {
+        synchronized (lock) {
+            if (emitted == current) {
+                emitted = next;
+                return true;
+            }
+            return false;
         }
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
@@ -368,6 +368,11 @@ class NoOpSegment implements Segment {
     }
 
     @Override
+    public boolean compareAndSetEmitted(boolean current, boolean next) {
+        return false;
+    }
+
+    @Override
     public String serialize() {
         return "";
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
@@ -311,6 +311,11 @@ class NoOpSubSegment implements Subsegment {
     }
 
     @Override
+    public boolean compareAndSetEmitted(boolean current, boolean next) {
+        return false;
+    }
+
+    @Override
     public String serialize() {
         return "";
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
@@ -75,7 +75,7 @@ public class SegmentImpl extends EntityImpl implements Segment {
             boolean shouldEmit = referenceCount <= 0;
             if (shouldEmit) {
                 checkAlreadyEmitted();
-                setEmitted(true);
+                ended = true;
             }
             return shouldEmit;
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
@@ -65,7 +65,7 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
             boolean shouldEmit = parentSegment.decrementReferenceCount() && parentSegment.isSampled();
             if (shouldEmit) {
                 checkAlreadyEmitted();
-                setEmitted(true);
+                ended = true;
             }
             return shouldEmit;
         }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
@@ -118,7 +118,6 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
         //Stream the subtrees that are ready.
         for (Subsegment child : streamable) {
             emitter.sendSubsegment(child);
-            child.setEmitted(true);
             entity.removeSubsegment(child);
         }
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -749,6 +749,7 @@ public class AWSXRayRecorderTest {
         assertThat(segment.getReferenceCount()).isZero();
         segment.removeSubsegment(Subsegment.noOp(AWSXRay.getGlobalRecorder()));
         segment.setEmitted(true);
+        segment.compareAndSetEmitted(false, true);
         assertThat(segment.isEmitted()).isFalse();
         assertThat(segment.serialize()).isEmpty();
         assertThat(segment.prettySerialize()).isEmpty();
@@ -866,6 +867,7 @@ public class AWSXRayRecorderTest {
         assertThat(subsegment.getReferenceCount()).isZero();
         subsegment.removeSubsegment(Subsegment.noOp(AWSXRay.getGlobalRecorder()));
         subsegment.setEmitted(true);
+        subsegment.compareAndSetEmitted(false, true);
         assertThat(subsegment.isEmitted()).isFalse();
         assertThat(subsegment.serialize()).isEmpty();
         assertThat(subsegment.prettySerialize()).isEmpty();


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:*
In #278, we try to avoid having a long-standing lock around all emissions in a subtree. It causes a race where subsegments may be emitted multiple times. This is because the current `emitted` isn't being kept track of by the emitter actually, it's set by the caller. This PR splits into `emitted`, which is intended to prevent double-emission, and `ended`, which is intended to prevent mutation of an ended entity in most cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
