### PR TITLE
Add gradle wrapper cache to continuous monitoring workflow

### DIFF
--- a/.github/workflows/continuous-monitoring.yml
+++ b/.github/workflows/continuous-monitoring.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           java-version: 11
           
+      - name: Cache Gradle Wrapper
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          
       - name: Run smoke tests
         id: distribution-availability
         run: ./gradlew :smoke-tests:check -PtestDistributionChannel=true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Attempt to fix transient monitoring workflow failures like https://github.com/aws/aws-xray-sdk-java/actions/runs/941160994 which timeout in downloading the Gradle binary. I do not believe believe that caching the gradle binary will have any impact on the accuracy of this for smoke testing the SDK's availability/functionality, but please confirm this understanding @anuraaga.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
