### PR TITLE
Prevent crashes on serializing empty beans

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -58,6 +59,7 @@ public abstract class EntityImpl implements Entity {
     @Deprecated
     protected static final ObjectMapper mapper = new ObjectMapper()
         .findAndRegisterModules()
+        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
         .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
         .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
@@ -67,4 +67,16 @@ class EntityTest {
         String expected = "{\"default\":{\"date\":1616559298000}}";
         assertThat(serializedSeg).contains(expected);
     }
+
+    @Test
+    void testUnknownClassSerialization() {
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test");
+        seg.putAws("coolService", new EmptyBean());
+        seg.end();
+        seg.serialize();  // Verify we don't crash here
+    }
+
+    static class EmptyBean {
+        String otherField = "cerealization";
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#259

*Description of changes:*
Sometimes when serializing AWS SDK-defined classes we get a Jackson serialization error for empty beans. The long term fix is to build a proper serializer for these classes, but at the very least for now we shouldn't crash when encountering them.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
