### PR TITLE
Improvements to no-op subsegment behavior

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
+++ b/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
@@ -110,10 +110,12 @@ public class TracedHttpClient extends CloseableHttpClient {
         subsegment.setNamespace(Namespace.REMOTE.toString());
         Segment parentSegment = subsegment.getParentSegment();
 
-        TraceHeader header = new TraceHeader(parentSegment.getTraceId(),
-                                parentSegment.isSampled() ? subsegment.getId() : null,
-                                parentSegment.isSampled() ? SampleDecision.SAMPLED : SampleDecision.NOT_SAMPLED);
-        request.addHeader(TraceHeader.HEADER_KEY, header.toString());
+        if (subsegment.shouldPropagate()) {
+            TraceHeader header = new TraceHeader(parentSegment.getTraceId(),
+                parentSegment.isSampled() ? subsegment.getId() : null,
+                parentSegment.isSampled() ? SampleDecision.SAMPLED : SampleDecision.NOT_SAMPLED);
+            request.addHeader(TraceHeader.HEADER_KEY, header.toString());
+        }
 
         Map<String, Object> requestInformation = new HashMap<>();
 

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
@@ -245,7 +245,7 @@ public class TracingInterceptor implements ExecutionInterceptor {
         SdkHttpRequest httpRequest = context.httpRequest();
 
         Subsegment subsegment = executionAttributes.getAttribute(entityKey);
-        if (subsegment == null) {
+        if (!subsegment.shouldPropagate()) {
             return httpRequest;
         }
 

--- a/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
@@ -191,7 +191,7 @@ public class TracingHandler extends RequestHandler2 {
         }
         currentSubsegment.setNamespace(Namespace.AWS.toString());
 
-        if (recorder.getCurrentSegment() != null) {
+        if (recorder.getCurrentSegment() != null && recorder.getCurrentSubsegment().shouldPropagate()) {
             TraceHeader header =
                 new TraceHeader(recorder.getCurrentSegment().getTraceId(),
                                 recorder.getCurrentSegment().isSampled() ? currentSubsegment.getId() : null,

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -609,7 +609,9 @@ public class AWSXRayRecorder {
         if (context == null) {
             // No context available, we return a no-op subsegment so user code does not have to work around this. Based on
             // ContextMissingStrategy they will still know about the issue unless they explicitly opt-ed out.
-            return Subsegment.noOp(this);
+            // This no-op subsegment is different from unsampled no-op subsegments only in that it should not cause trace
+            // context to be propagated downstream
+            return Subsegment.noOp(this, false);
         }
         return context.beginSubsegment(this, name);
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -107,7 +107,11 @@ public class LambdaSegmentContext implements SegmentContext {
         Entity current = getTraceEntity();
         if (current instanceof Subsegment) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Ending subsegment named: " + current.getName());
+                if (current.getName().isEmpty() && !current.getParentSegment().isSampled()) {
+                    logger.debug("Ending no-op subsegment");
+                } else {
+                    logger.debug("Ending subsegment named: " + current.getName());
+                }
             }
             Subsegment currentSubsegment = (Subsegment) current;
 
@@ -139,7 +143,8 @@ public class LambdaSegmentContext implements SegmentContext {
             }
 
         } else {
-            throw new SubsegmentNotFoundException("Failed to end a subsegment: subsegment cannot be found.");
+            recorder.getContextMissingStrategy().contextMissing("Failed to end subsegment: subsegment cannot be found.",
+                SubsegmentNotFoundException.class);
         }
     }
 }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ThreadLocalSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/ThreadLocalSegmentContext.java
@@ -39,7 +39,7 @@ public class ThreadLocalSegmentContext implements SegmentContext {
         if (current == null) {
             recorder.getContextMissingStrategy().contextMissing("Failed to begin subsegment named '" + name
                                                                 + "': segment cannot be found.", SegmentNotFoundException.class);
-            return Subsegment.noOp(recorder);
+            return Subsegment.noOp(recorder, false);
         }
         if (logger.isDebugEnabled()) {
             logger.debug("Beginning subsegment named: " + name);
@@ -65,7 +65,11 @@ public class ThreadLocalSegmentContext implements SegmentContext {
         Entity current = getTraceEntity();
         if (current instanceof Subsegment) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Ending subsegment named: " + current.getName());
+                if (current.getName().isEmpty() && !current.getParentSegment().isSampled()) {
+                    logger.debug("Ending no-op subsegment");
+                } else {
+                    logger.debug("Ending subsegment named: " + current.getName());
+                }
             }
             Subsegment currentSubsegment = (Subsegment) current;
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * @deprecated Use {@link Subsegment#noOp(AWSXRayRecorder)}.
+ * @deprecated Use {@link Subsegment#noOp(AWSXRayRecorder, boolean)}.
  */
 @Deprecated
 public class DummySubsegment implements Subsegment {
@@ -338,6 +338,15 @@ public class DummySubsegment implements Subsegment {
 
     @Override
     public void addPrecursorId(String precursorId) {
+    }
+
+    @Override
+    public boolean shouldPropagate() {
+        return false;
+    }
+
+    @Override
+    public void setShouldPropagate(boolean shouldPropagate) {
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/DummySubsegment.java
@@ -346,10 +346,6 @@ public class DummySubsegment implements Subsegment {
     }
 
     @Override
-    public void setShouldPropagate(boolean shouldPropagate) {
-    }
-
-    @Override
     public String streamSerialize() {
         return "";
     }

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
@@ -28,11 +28,17 @@ class NoOpSubSegment implements Subsegment {
     private final Segment parentSegment;
     private final AWSXRayRecorder creator;
 
+    private boolean shouldPropagate;
     private volatile Entity parent;
 
     NoOpSubSegment(Segment parentSegment, AWSXRayRecorder creator) {
+        this(parentSegment, creator, true);
+    }
+
+    NoOpSubSegment(Segment parentSegment, AWSXRayRecorder creator, boolean shouldPropagate) {
         this.parentSegment = parentSegment;
         this.creator = creator;
+        this.shouldPropagate = shouldPropagate;
         parent = parentSegment;
     }
 
@@ -345,6 +351,16 @@ class NoOpSubSegment implements Subsegment {
 
     @Override
     public void addPrecursorId(String precursorId) {
+    }
+
+    @Override
+    public boolean shouldPropagate() {
+        return this.shouldPropagate;
+    }
+
+    @Override
+    public void setShouldPropagate(boolean shouldPropagate) {
+        this.shouldPropagate = shouldPropagate;
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
@@ -27,8 +27,8 @@ class NoOpSubSegment implements Subsegment {
 
     private final Segment parentSegment;
     private final AWSXRayRecorder creator;
+    private final boolean shouldPropagate;
 
-    private boolean shouldPropagate;
     private volatile Entity parent;
 
     NoOpSubSegment(Segment parentSegment, AWSXRayRecorder creator) {
@@ -356,11 +356,6 @@ class NoOpSubSegment implements Subsegment {
     @Override
     public boolean shouldPropagate() {
         return this.shouldPropagate;
-    }
-
-    @Override
-    public void setShouldPropagate(boolean shouldPropagate) {
-        this.shouldPropagate = shouldPropagate;
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
@@ -85,12 +85,6 @@ public interface Subsegment extends Entity {
     boolean shouldPropagate();
 
     /**
-     * Determines if this subsegment should propagate its trace context downstream
-     * @param shouldPropagate
-     */
-    void setShouldPropagate(boolean shouldPropagate);
-
-    /**
      * Serializes the subsegment as a standalone String with enough information for the subsegment to be streamed on its own.
      * @return
      *  the string representation of the subsegment with enouogh information for it to be streamed

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
@@ -21,8 +21,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Subsegment extends Entity {
 
-    static Subsegment noOp(AWSXRayRecorder recorder) {
-        return new NoOpSubSegment(Segment.noOp(TraceID.invalid(), recorder), recorder);
+    static Subsegment noOp(AWSXRayRecorder recorder, boolean shouldPropagate) {
+        return new NoOpSubSegment(Segment.noOp(TraceID.invalid(), recorder), recorder, shouldPropagate);
     }
 
     static Subsegment noOp(Segment parent, AWSXRayRecorder recorder) {
@@ -77,6 +77,18 @@ public interface Subsegment extends Entity {
      * @param precursorId the precursor ID to add to the set
      */
     void addPrecursorId(String precursorId);
+
+    /**
+     * Determines if this subsegment should propagate its trace context downstream
+     * @return true if its trace context should be propagated downstream, false otherwise
+     */
+    boolean shouldPropagate();
+
+    /**
+     * Determines if this subsegment should propagate its trace context downstream
+     * @param shouldPropagate
+     */
+    void setShouldPropagate(boolean shouldPropagate);
 
     /**
      * Serializes the subsegment as a standalone String with enough information for the subsegment to be streamed on its own.

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
@@ -136,14 +136,6 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
         }
     }
 
-    @Override
-    public void setShouldPropagate(boolean shouldPropagate) {
-        synchronized (lock) {
-            checkAlreadyEmitted();
-            this.shouldPropagate = shouldPropagate;
-        }
-    }
-
     private ObjectNode getStreamSerializeObjectNode() {
         synchronized (lock) {
             ObjectNode obj = (ObjectNode) mapper.valueToTree(this);

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
@@ -38,6 +38,9 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
     @GuardedBy("lock")
     private Set<String> precursorIds;
 
+    @GuardedBy("lock")
+    private boolean shouldPropagate;
+
     @SuppressWarnings("nullness")
     private SubsegmentImpl() {
         super();
@@ -48,6 +51,7 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
         this.parentSegment = parentSegment;
         parentSegment.incrementReferenceCount();
         this.precursorIds = new HashSet<>();
+        this.shouldPropagate = true;
     }
 
     @Override
@@ -122,6 +126,21 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
         synchronized (lock) {
             checkAlreadyEmitted();
             this.precursorIds = precursorIds;
+        }
+    }
+
+    @Override
+    public boolean shouldPropagate() {
+        synchronized (lock) {
+            return shouldPropagate;
+        }
+    }
+
+    @Override
+    public void setShouldPropagate(boolean shouldPropagate) {
+        synchronized (lock) {
+            checkAlreadyEmitted();
+            this.shouldPropagate = shouldPropagate;
         }
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletAsyncListener.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/javax/servlet/AWSXRayServletAsyncListener.java
@@ -15,7 +15,6 @@
 
 package com.amazonaws.xray.javax.servlet;
 
-import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Entity;
 import java.io.IOException;
@@ -39,15 +38,7 @@ class AWSXRayServletAsyncListener implements AsyncListener {
         this.recorder = recorder;
     }
 
-    private AWSXRayRecorder getRecorder() {
-        if (recorder == null) {
-            recorder = AWSXRay.getGlobalRecorder();
-        }
-        return recorder;
-    }
-
     private void processEvent(AsyncEvent event) throws IOException {
-        AWSXRayRecorder recorder = getRecorder();
         Entity entity = (Entity) event.getSuppliedRequest().getAttribute(ENTITY_ATTRIBUTE_KEY);
         entity.run(() -> {
             if (event.getThrowable() != null) {


### PR DESCRIPTION
*Description of changes:*
This PR includes a few changes involving no-op subsegment behavior to correct regressions:
1. Add a new `shouldPropagate` field to subsegments, so that we can distinguish between no-op subsegments that are unsampled and no-op subsegments which are created from context missing exceptions.
2. In LambdaSegmentContext, fixed the `endSubsegment` behavior to use the context missing strategy instead of always throwing an exception.
3. Changed the logging logic for ending no-op subsegments to make debug logs more clear

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
