### PR TITLE
Add Automatic-Module-Name to jar manifest. Fixes #292.

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/build.gradle.kts
+++ b/aws-xray-recorder-sdk-apache-http/build.gradle.kts
@@ -11,4 +11,10 @@ dependencies {
     testImplementation("com.github.tomakehurst:wiremock-jre8")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.apache-http")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - Apache HTTP Client Proxy"

--- a/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
@@ -9,4 +9,10 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core:jackson-databind")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-core")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK Core"

--- a/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
@@ -7,4 +7,10 @@ dependencies {
     implementation(project(":aws-xray-recorder-sdk-aws-sdk"))
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-instrumentor")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK Instrumentor"

--- a/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
@@ -7,4 +7,10 @@ dependencies {
     implementation(project(":aws-xray-recorder-sdk-aws-sdk-v2"))
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-v2-instrumentor")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK V2 Instrumentor"

--- a/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
@@ -15,4 +15,10 @@ dependencies {
     testImplementation("software.amazon.awssdk:lambda:2.15.20")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-v2")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK V2"

--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -15,4 +15,10 @@ dependencies {
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK Handler"

--- a/aws-xray-recorder-sdk-benchmark/build.gradle.kts
+++ b/aws-xray-recorder-sdk-benchmark/build.gradle.kts
@@ -22,6 +22,12 @@ dependencies {
     add("jmhRuntimeClasspath", platform(project(":dependencyManagement")))
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.benchmark")
+    }
+}
+
 jmh {
     fork = 1
     // Required when also including annotation processor.

--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -18,4 +18,10 @@ dependencies {
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sdk-core")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - Core"

--- a/aws-xray-recorder-sdk-log4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-log4j/build.gradle.kts
@@ -11,4 +11,10 @@ dependencies {
     testImplementation("org.apache.logging.log4j:log4j-api:2.13.3")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.log4j")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java – Log4J Trace ID Injection"

--- a/aws-xray-recorder-sdk-metrics/build.gradle.kts
+++ b/aws-xray-recorder-sdk-metrics/build.gradle.kts
@@ -13,4 +13,10 @@ dependencies {
     testImplementation("org.powermock:powermock-api-mockito2:2.0.2")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.metrics")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - Segment Metrics"

--- a/aws-xray-recorder-sdk-slf4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-slf4j/build.gradle.kts
@@ -11,4 +11,10 @@ dependencies {
     testImplementation("ch.qos.logback:logback-classic:1.3.0-alpha5")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.slf4j")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - SLF4J Trace ID Injection"

--- a/aws-xray-recorder-sdk-spring/build.gradle.kts
+++ b/aws-xray-recorder-sdk-spring/build.gradle.kts
@@ -16,4 +16,10 @@ dependencies {
     compileOnly("org.springframework.data:spring-data-commons:2.0.0.RELEASE")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.spring")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - Spring Framework Interceptors"

--- a/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
@@ -9,4 +9,9 @@ dependencies {
     compileOnly("org.apache.tomcat:tomcat-jdbc:8.0.36")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql-mysql")
+    }
+}
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK MySQL Interceptor"

--- a/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
@@ -9,4 +9,9 @@ dependencies {
     compileOnly("org.apache.tomcat:tomcat-jdbc:8.0.36")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql-postgres")
+    }
+}
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK PostgreSQL Interceptor"

--- a/aws-xray-recorder-sdk-sql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql/build.gradle.kts
@@ -8,4 +8,16 @@ dependencies {
     implementation("com.blogspot.mydailyjava:weak-lock-free:0.18")
 }
 
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql")
+    }
+}
+
+tasks.jar {
+    manifest {
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql")
+    }
+}
+
 description = "AWS X-Ray Recorder SDK for Java - SQL Interceptor"

--- a/aws-xray-recorder-sdk-sql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql/build.gradle.kts
@@ -14,10 +14,4 @@ tasks.jar {
     }
 }
 
-tasks.jar {
-    manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql")
-    }
-}
-
 description = "AWS X-Ray Recorder SDK for Java - SQL Interceptor"


### PR DESCRIPTION
*Issue #, if available:*
#292 

*Description of changes:*

Configures the gradle JAR plugin to add an `Automatic-Module-Name` entry to the manifest for each project. This allows for using aws-xray-sdk-java in a modular Java project.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
