### PR TITLE
Fix Automatic-Module-Names to use dots instead of dashes (not allowed…

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/build.gradle.kts
+++ b/aws-xray-recorder-sdk-apache-http/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.apache-http")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.apache.http")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-core")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws.sdk.core")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-instrumentor")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws.sdk.instrumentor")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-v2-instrumentor")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws.sdk.v2.instrumentor")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-v2")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws.sdk.v2")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws.sdk")
     }
 }
 

--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sdk-core")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sdk.core")
     }
 }
 

--- a/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql-mysql")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql.mysql")
     }
 }
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK MySQL Interceptor"

--- a/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql-postgres")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql.postgres")
     }
 }
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK PostgreSQL Interceptor"


### PR DESCRIPTION
… by JPMS).

*Issue #, if available:*

*Description of changes:*
I made a mistake in #295 - dashes are not allowed in module names. This PR uses dots instead. I also opened #297 which uses underscores - I'll leave the choice up to the maintainers :).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
