### PR TITLE
Fix Automatic-Module-Names to use underscores instead of dashes (not …

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/build.gradle.kts
+++ b/aws-xray-recorder-sdk-apache-http/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.apache-http")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.apache_http")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-core")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws_sdk_core")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-instrumentor/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-instrumentor")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws_sdk_instrumentor")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2-instrumentor/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-v2-instrumentor")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws_sdk_v2_instrumentor")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk-v2")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws_sdk_v2")
     }
 }
 

--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws-sdk")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.aws_sdk")
     }
 }
 

--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sdk-core")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sdk_core")
     }
 }
 

--- a/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-mysql/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql-mysql")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql_mysql")
     }
 }
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK MySQL Interceptor"

--- a/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
+++ b/aws-xray-recorder-sdk-sql-postgres/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 tasks.jar {
     manifest {
-        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql-postgres")
+        attributes("Automatic-Module-Name" to "com.amazonaws.xray.sql_postgres")
     }
 }
 description = "AWS X-Ray Recorder SDK for Java - AWS SDK PostgreSQL Interceptor"


### PR DESCRIPTION
…allowed by JPMS).

*Issue #, if available:*

*Description of changes:*
I made a mistake in #295 - dashes are not allowed in module names. This PR uses underscores instead. I also opened #296 which uses dots - I'll leave the choice up to the maintainers :).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
