### PR TITLE
Remove retry count assertions from unit tests

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
@@ -405,8 +405,6 @@ public class TracingInterceptorTest {
             Assert.assertEquals("1111-2222-3333-4444", awsStats.get("request_id"));
             Assert.assertEquals("extended", awsStats.get("id_2"));
             Assert.assertEquals("us-west-42", awsStats.get("region"));
-            // throttled requests are retried
-            Assert.assertEquals(3, awsStats.get("retries"));
             Assert.assertEquals(2L, httpResponseStats.get("content_length"));
             Assert.assertEquals(429, httpResponseStats.get("status"));
             Assert.assertEquals(true, subsegment.isError());
@@ -456,8 +454,6 @@ public class TracingInterceptorTest {
             Assert.assertEquals("1111-2222-3333-4444", awsStats.get("request_id"));
             Assert.assertEquals("extended", awsStats.get("id_2"));
             Assert.assertEquals("us-west-42", awsStats.get("region"));
-            // throttled requests are retried
-            Assert.assertEquals(3, awsStats.get("retries"));
             Assert.assertEquals(2L, httpResponseStats.get("content_length"));
             Assert.assertEquals(429, httpResponseStats.get("status"));
             Assert.assertEquals(true, subsegment.isError());
@@ -508,8 +504,6 @@ public class TracingInterceptorTest {
             Assert.assertEquals("1111-2222-3333-4444", awsStats.get("request_id"));
             Assert.assertEquals("extended", awsStats.get("id_2"));
             Assert.assertEquals("us-west-42", awsStats.get("region"));
-            // 500 exceptions are retried
-            Assert.assertEquals(3, awsStats.get("retries"));
             Assert.assertEquals(2L, httpResponseStats.get("content_length"));
             Assert.assertEquals(500, httpResponseStats.get("status"));
             Assert.assertEquals(false, subsegment.isError());
@@ -559,8 +553,6 @@ public class TracingInterceptorTest {
             Assert.assertEquals("1111-2222-3333-4444", awsStats.get("request_id"));
             Assert.assertEquals("extended", awsStats.get("id_2"));
             Assert.assertEquals("us-west-42", awsStats.get("region"));
-            // 500 exceptions are retried
-            Assert.assertEquals(3, awsStats.get("retries"));
             Assert.assertEquals(2L, httpResponseStats.get("content_length"));
             Assert.assertEquals(500, httpResponseStats.get("status"));
             Assert.assertEquals(false, subsegment.isError());


### PR DESCRIPTION
The number of retries on a failed request is Lambda dependent in these test cases and may break the assertions if the retry counts are changed in the dependency. Since it is not in the scope of the code being tested, we can safely drop these assertions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
