### PR TITLE
Don't lock segment from subsegment

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -36,10 +36,10 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.logging.Log;
@@ -198,7 +198,7 @@ public abstract class EntityImpl implements Entity {
 
         this.creator = creator;
         this.name = name;
-        this.subsegments = new CopyOnWriteArrayList<>();
+        this.subsegments = Collections.synchronizedList(new ArrayList<>());
         this.subsegmentsLock = new ReentrantLock();
         this.cause = new Cause();
         this.http = new HashMap<>();

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/EntityImpl.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.logging.Log;
@@ -197,7 +198,7 @@ public abstract class EntityImpl implements Entity {
 
         this.creator = creator;
         this.name = name;
-        this.subsegments = new ArrayList<>();
+        this.subsegments = new CopyOnWriteArrayList<>();
         this.subsegmentsLock = new ReentrantLock();
         this.cause = new Cause();
         this.http = new HashMap<>();
@@ -531,25 +532,21 @@ public abstract class EntityImpl implements Entity {
 
     @Override
     public List<Subsegment> getSubsegments() {
-        synchronized (lock) {
-            return subsegments;
-        }
+        return subsegments;
     }
 
     @JsonIgnore
     @Override
     public List<Subsegment> getSubsegmentsCopy() {
-        synchronized (lock) {
-            return new ArrayList<>(subsegments);
-        }
+        return new ArrayList<>(subsegments);
     }
 
     @Override
     public void addSubsegment(Subsegment subsegment) {
         synchronized (lock) {
             checkAlreadyEmitted();
-            subsegments.add(subsegment);
         }
+        subsegments.add(subsegment);
     }
 
     @Override
@@ -675,8 +672,8 @@ public abstract class EntityImpl implements Entity {
         synchronized (lock) {
             checkAlreadyEmitted();
             referenceCount++;
-            totalSize.increment();
         }
+        totalSize.increment();
     }
 
     @Override
@@ -706,9 +703,7 @@ public abstract class EntityImpl implements Entity {
      */
     @Override
     public LongAdder getTotalSize() {
-        synchronized (lock) {
-            return totalSize;
-        }
+        return totalSize;
     }
 
     /**
@@ -770,10 +765,8 @@ public abstract class EntityImpl implements Entity {
 
     @Override
     public void removeSubsegment(Subsegment subsegment) {
-        synchronized (lock) {
-            subsegments.remove(subsegment);
-            getParentSegment().getTotalSize().decrement();
-        }
+        subsegments.remove(subsegment);
+        getParentSegment().getTotalSize().decrement();
     }
 
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SegmentImpl.java
@@ -34,8 +34,7 @@ public class SegmentImpl extends EntityImpl implements Segment {
     protected Map<String, Object> service;
 
     @JsonIgnore
-    @GuardedBy("lock")
-    private boolean sampled;
+    private volatile boolean sampled;
 
     @SuppressWarnings({ "unused", "nullness" })
     private SegmentImpl() {
@@ -88,17 +87,15 @@ public class SegmentImpl extends EntityImpl implements Segment {
 
     @Override
     public boolean isSampled() {
-        synchronized (lock) {
-            return sampled;
-        }
+        return sampled;
     }
 
     @Override
     public void setSampled(boolean sampled) {
         synchronized (lock) {
             checkAlreadyEmitted();
-            this.sampled = sampled;
         }
+        this.sampled = sampled;
     }
 
     @Override

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/DefaultStreamingStrategy.java
@@ -67,7 +67,7 @@ public class DefaultStreamingStrategy implements StreamingStrategy {
      */
     @Override
     public boolean requiresStreaming(Segment segment) {
-        if (segment.isSampled() && null != segment.getTotalSize()) {
+        if (segment.isSampled()) {
             return segment.getTotalSize().intValue() > maxSegmentSize;
         }
         return false;


### PR DESCRIPTION
*Issue #, if available:* #303

*Description of changes:*

High mutability and circular refrences between segments and subsegments create a prime landscape for thread issues. This tries to solve #303 by removing locking on the codepaths from `DefaultStreamingStrategy` - the streaming strategy is used when processing subsegments which may be on a different thread than the segment, which could then try to stream subsegments.

This should avoid deadlocks, I don't know if it's possible to be totally confident without removing streaming strategy completely - alway streaming, removing the circular references between segments / subsegments completely, would give confidence they can't deadlock. Probably best to shift to OTel instead though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
