### PR TITLE
Reduce log level of sampling error logging

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
@@ -71,7 +71,7 @@ public class RulePoller {
             try {
                 pollRule();
             } catch (Throwable t) {
-                logger.warn("Encountered error polling GetSamplingRules: ", t);
+                logger.info("Encountered error polling GetSamplingRules: ", t);
                 // Propagate if Error so executor stops executing.
                 // TODO(anuraaga): Many Errors aren't fatal, this should probably be more restricted, e.g.
                 // https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/Throwables.java

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/RulePoller.java
@@ -71,7 +71,7 @@ public class RulePoller {
             try {
                 pollRule();
             } catch (Throwable t) {
-                logger.error("Encountered error polling GetSamplingRules: ", t);
+                logger.warn("Encountered error polling GetSamplingRules: ", t);
                 // Propagate if Error so executor stops executing.
                 // TODO(anuraaga): Many Errors aren't fatal, this should probably be more restricted, e.g.
                 // https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/Throwables.java

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
@@ -66,7 +66,7 @@ public class TargetPoller {
             try {
                 pollManifest();
             } catch (Throwable t) {
-                logger.warn("Encountered error polling GetSamplingTargets: ", t);
+                logger.info("Encountered error polling GetSamplingTargets: ", t);
                 // Propagate if Error so executor stops executing.
                 // TODO(anuraaga): Many Errors aren't fatal, this should probably be more restricted, e.g.
                 // https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/Throwables.java

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/strategy/sampling/pollers/TargetPoller.java
@@ -66,7 +66,7 @@ public class TargetPoller {
             try {
                 pollManifest();
             } catch (Throwable t) {
-                logger.error("Encountered error polling GetSamplingTargets: ", t);
+                logger.warn("Encountered error polling GetSamplingTargets: ", t);
                 // Propagate if Error so executor stops executing.
                 // TODO(anuraaga): Many Errors aren't fatal, this should probably be more restricted, e.g.
                 // https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/internal/Throwables.java


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-java-agent/issues/65

*Description of changes:*
Given that errors retrieving sampling rules/targets are non-impacting to the fundamental functionality of tracing, we shouldn't be logging them at error level, especially since they are typically the result of transient network blips. Customers have complained about the verbose, scary looking error message in their logs.

@anuraaga would appreciate if you took a look.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
