### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/aws-xray-recorder-sdk-log4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-log4j/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 dependencies {
     api(project(":aws-xray-recorder-sdk-core"))
 
-    compileOnly("org.apache.logging.log4j:log4j-api:2.15.0")
+    compileOnly("org.apache.logging.log4j:log4j-api:2.17.0")
 
-    testImplementation("org.apache.logging.log4j:log4j-api:2.15.0")
+    testImplementation("org.apache.logging.log4j:log4j-api:2.17.0")
 }
 
 tasks.jar {


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105