### PR TITLE
Upgrade AWS Java SDK to 1.12.228

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.11.0")
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations")
 
     testImplementation("com.fasterxml.jackson.core:jackson-databind")
 }

--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -8,9 +8,11 @@ dependencies {
 
     implementation(project(":aws-xray-recorder-sdk-aws-sdk-core"))
 
-    api("com.amazonaws:aws-java-sdk-core:1.11.1000")
+    api("com.amazonaws:aws-java-sdk-core")
 
-    testImplementation("com.amazonaws:aws-java-sdk:1.11.1000")
+    testImplementation("com.amazonaws:aws-java-sdk-lambda")
+    testImplementation("com.amazonaws:aws-java-sdk-s3")
+    testImplementation("com.amazonaws:aws-java-sdk-sns")
     testImplementation("org.powermock:powermock-reflect:2.0.2")
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
 }

--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -4,12 +4,12 @@ plugins {
 }
 
 dependencies {
-    api("com.amazonaws:aws-java-sdk-xray:1.11.903")
+    api("com.amazonaws:aws-java-sdk-xray")
 
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     compileOnly("javax.servlet:javax.servlet-api:3.1.0")
 
-    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.0")
+    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     testImplementation("com.github.stefanbirkner:system-rules:1.16.0")
     testImplementation("com.github.tomakehurst:wiremock-jre8")
     testImplementation("org.openjdk.jmh:jmh-core:1.19")

--- a/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
+++ b/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/SqlSubsegments.java
@@ -18,14 +18,12 @@ package com.amazonaws.xray.sql;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Subsegment;
-
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
+++ b/aws-xray-recorder-sdk-sql/src/test/java/com/amazonaws/xray/sql/SqlSubsegmentsTest.java
@@ -25,14 +25,12 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Subsegment;
-
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -5,8 +5,9 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-        "com.fasterxml.jackson:jackson-bom:2.11.0",
-        "org.junit:junit-bom:5.6.2"
+        "com.amazonaws:aws-java-sdk-bom:1.12.228",
+        "com.fasterxml.jackson:jackson-bom:2.12.0",
+        "org.junit:junit-bom:5.8.2"
 )
 
 val DEPENDENCY_SETS = listOf(
@@ -17,7 +18,7 @@ val DEPENDENCY_SETS = listOf(
         ),
         DependencySet(
                 "com.fasterxml.jackson.datatype",
-                "2.11.0",
+                "2.12.0",
                 listOf("jackson-datatype-jsr310")
         ),
         DependencySet(
@@ -42,7 +43,7 @@ val DEPENDENCY_SETS = listOf(
         ),
         DependencySet(
                 "junit",
-                "4.12",
+                "4.13.1",
                 listOf("junit")
         ),
         DependencySet(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id("com.github.hierynomus.license") version "0.15.0"
+        id("com.github.hierynomus.license") version "0.16.1"
         id("nebula.release") version "15.1.0"
         id("io.freefair.aggregate-javadoc-jar") version "5.3.0"
         id("io.github.gradle-nexus.publish-plugin") version "1.0.0"


### PR DESCRIPTION
*Issue #, if available:* #333

*Description of changes:*

Upgrade AWS SDK for Java to version `1.12.228`. This was inspired by the same changes we made in https://github.com/aws/aws-xray-sdk-java/pull/256.

We fixed several issues along the way:
* All of a sudden when we updated to AWS SDK version `1.12.228`, many dependencies could not be resolved even though they were definitely there. Worked with a colleague to find out that [this is a Gradle 6 issue](https://github.com/gradle/gradle/issues/8489#issuecomment-646346668). Updating gralde with `./gradlew wrapper --gradle-version=7.4.2
` fixed the issue 🥳
  * This was the error we were seeing which we were able to Google:
    ```
     What went wrong:
     Execution failed for task ':aws-xray-recorder-sdk-core:dependencies'.
     > Could not resolve all dependencies for configuration ':aws-xray-recorder-sdk-core:testCompileClasspath'.
     > Problems reading data from Binary store in /private/var/folders/5s/kz556x054vz8l7204yh4j9krq6bwmm/T/gradle9062832512095609875.bin offset 29727 exists? true
    ```
  * The reason is:
     > it's an issue with the binary serialization that occurs when the dependency graphs are resolved, and our project triggered one of them when we upgrade to AWS Java SDK 1.12.x for some reason.
* We had to update the `junit-bom` to version `5.8.2` because its dependencies [do not support `junit` version `1.12`](https://stackoverflow.com/a/67566548/7460739) which is another package we pull in
* Once we upgrade Gradle to version 7, a package that checks our license version started failing due to missing annotations. This [was fixed in version `0.16.1` of that package](https://github.com/hierynomus/license-gradle-plugin/issues/191) so we updated it here.

Cool thing I learned:

Your first instinct should be to check if all dependencies resolved when working with gradle.

i.e. `/gradlew :a-x-r-s-c:dependencies`

`a-x-r-s-c` is short for `aws-xray-recorder-sdk-core`.

and then google whatever failure comes out 🙂

Fixes #333

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
