### PR TITLE
Revert from bom deps. Set duplicatesStrategy for benchmark project

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -8,6 +8,11 @@ dependencies {
 
     implementation(project(":aws-xray-recorder-sdk-aws-sdk-core"))
 
+    // TODO: Try and find a way to declare aws-java-sdk dependencies
+    //  via a bom in the dependencyManagement project and make it available
+    //  for resolution not only in the SDK projects but also in projects
+    //  like benchmark.
+    //  See PR for more details: https://github.com/aws/aws-xray-sdk-java/pull/336
     api("com.amazonaws:aws-java-sdk-core:1.12.228")
 
     testImplementation("com.amazonaws:aws-java-sdk-lambda:1.12.228")

--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -8,11 +8,11 @@ dependencies {
 
     implementation(project(":aws-xray-recorder-sdk-aws-sdk-core"))
 
-    api("com.amazonaws:aws-java-sdk-core")
+    api("com.amazonaws:aws-java-sdk-core:1.12.228")
 
-    testImplementation("com.amazonaws:aws-java-sdk-lambda")
-    testImplementation("com.amazonaws:aws-java-sdk-s3")
-    testImplementation("com.amazonaws:aws-java-sdk-sns")
+    testImplementation("com.amazonaws:aws-java-sdk-lambda:1.12.228")
+    testImplementation("com.amazonaws:aws-java-sdk-s3:1.12.228")
+    testImplementation("com.amazonaws:aws-java-sdk-sns:1.12.228")
     testImplementation("org.powermock:powermock-reflect:2.0.2")
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
 }

--- a/aws-xray-recorder-sdk-benchmark/build.gradle.kts
+++ b/aws-xray-recorder-sdk-benchmark/build.gradle.kts
@@ -28,6 +28,11 @@ tasks.jar {
     }
 }
 
+tasks.jmhJar {
+    // Gradle 7 requires duplicatesStrategy to be specified.
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 jmh {
     fork = 1
     // Required when also including annotation processor.

--- a/aws-xray-recorder-sdk-benchmark/build.gradle.kts
+++ b/aws-xray-recorder-sdk-benchmark/build.gradle.kts
@@ -30,6 +30,8 @@ tasks.jar {
 
 tasks.jmhJar {
     // Gradle 7 requires duplicatesStrategy to be specified.
+    //
+    // See more: https://github.com/gradle/gradle/issues/17236
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 

--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api("com.amazonaws:aws-java-sdk-xray")
+    api("com.amazonaws:aws-java-sdk-xray:1.12.228")
 
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     compileOnly("javax.servlet:javax.servlet-api:3.1.0")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 data class DependencySet(val group: String, val version: String, val modules: List<String>)
 
 val DEPENDENCY_BOMS = listOf(
-        "com.amazonaws:aws-java-sdk-bom:1.12.228",
         "com.fasterxml.jackson:jackson-bom:2.12.0",
         "org.junit:junit-bom:5.8.2"
 )


### PR DESCRIPTION
*Issue:*
#334 introduced aws-java-sdk dependencies version to be specified using `aws-java-sdk-bom` in the dependencyManagement which would then resolve any AWS JAVA SDK dependency across all projects in the repo.
The `./gradlew build` builds successfully from the root, however, `./gradle jmh` (used for running benchmarks) fails to resolve dependency with the following message:
``` shell
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':aws-xray-recorder-sdk-benchmark:jmhJar'.
> Could not resolve all files for configuration ':aws-xray-recorder-sdk-benchmark:jmhRuntime'.
   > Could not find com.amazonaws:aws-java-sdk-xray:.
     Required by:
         project :aws-xray-recorder-sdk-benchmark > project :aws-xray-recorder-sdk-core
```

*Description of changes:*
- Partially reverting the changes in #334 to specify version 1.12.228 for each of the aws-java-sdk dependencies and remove the declaration of aws-java-sdk-bom. 
This is a temporary measure to not have a broken project and in the future we should try and find a way to define the dependency version through bom in a single place.

- From Gradle 7, it is required to specify a `duplicatesStrategy`. No doing so will result in this error when running `./gradlew jmh`:
  ``` shell
  > Task :aws-xray-recorder-sdk-benchmark:jmhJar FAILED

  FAILURE: Build failed with an exception.

  * What went wrong:
  Execution failed for task ':aws-xray-recorder-sdk-benchmark:jmhJar'.
  > Entry LICENSE is a duplicate but no duplicate handling strategy has been set. Please refer to 
  https://docs.gradle.org/7.4.2/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
  ```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
