### PR TITLE
[aws-xray-recorder-sdk-apache-http] Don't return a null target to avoid possible NPE

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
+++ b/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
@@ -72,17 +72,11 @@ public class TracedHttpClient extends CloseableHttpClient {
     }
 
     public static HttpHost determineTarget(final HttpUriRequest request) throws ClientProtocolException {
-        // A null target may be acceptable if there is a default target.
-        // Otherwise, the null target is detected in the director.
-        HttpHost target = null;
-
         final URI requestUri = request.getURI();
-        if (requestUri.isAbsolute()) {
-            target = URIUtils.extractHost(requestUri);
-            if (target == null) {
-                throw new ClientProtocolException("URI does not specify a valid host name: "
-                        + requestUri);
-            }
+        HttpHost target = URIUtils.extractHost(requestUri);
+        if (target == null) {
+            throw new ClientProtocolException("URI does not specify a valid host name: "
+                    + requestUri);
         }
         return target;
     }


### PR DESCRIPTION
*Issue*: 
The Apache HTTP instrumentation is prone to throwing a `NullPointerException` by returning a `null` from the [`determineTarget`](https://github.com/aws/aws-xray-sdk-java/blob/9b09ed52a53c445904fc52b31aec1cfb1e11fef4/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java#L74-L88) method. Since a user is not expected to handle NPE, it will break the application.

*Description of changes:*
The method doesn't need to check for URL absoluteness and bail out early if it is not. The `URIUtils.extractHost(requestUri)` method does this check implicitly and we handle it's `null` return value by throwing a `ClientProtocolException` which a user will handle in their code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
