### PR TITLE
Add javadoc to Subsegment.close() method.

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/Subsegment.java
@@ -87,7 +87,7 @@ public interface Subsegment extends Entity {
     /**
      * Serializes the subsegment as a standalone String with enough information for the subsegment to be streamed on its own.
      * @return
-     *  the string representation of the subsegment with enouogh information for it to be streamed
+     *  the string representation of the subsegment with enough information for it to be streamed
      */
     String streamSerialize();
 
@@ -96,10 +96,16 @@ public interface Subsegment extends Entity {
      * own. Only used for debugging.
      *
      * @return
-     *  the pretty string representation of the subsegment with enouogh information for it to be streamed
+     *  the pretty string representation of the subsegment with enough information for it to be streamed
      */
     String prettyStreamSerialize();
 
+    /**
+     * Implements the {@link AutoCloseable} interface.
+     *
+     * Warning. This method is intended to be private to the xray library and should not be used externally. Instead, use
+     * {@link com.amazonaws.xray.AWSXRay#endSubsegment(Subsegment)}.
+     */
     @Override
     void close();
 }


### PR DESCRIPTION
*Issue #, if available:*
#318

*Description of changes:*
Add javadoc to Subsegment.close() method.
This method should not be used to end subsegments for segments using multiple threads as this can result in a deadlock. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
