### PR TITLE
Improve emitter send data log

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/emitters/UDPEmitter.java
@@ -32,98 +32,96 @@ import org.apache.commons.logging.LogFactory;
  */
 @Deprecated
 public class UDPEmitter extends Emitter {
-    private static final Log logger = LogFactory.getLog(UDPEmitter.class);
+  private static final Log logger = LogFactory.getLog(UDPEmitter.class);
 
-    private DatagramSocket daemonSocket;
-    private DaemonConfiguration config;
-    private byte[] sendBuffer = new byte[DAEMON_BUF_RECEIVE_SIZE];
+  private final DatagramSocket daemonSocket;
+  private final DaemonConfiguration config;
+  private final byte[] sendBuffer = new byte[DAEMON_BUF_RECEIVE_SIZE];
 
-    /**
-     * Constructs a UDPEmitter. Sets the daemon address to the value of the {@code AWS_XRAY_DAEMON_ADDRESS} environment variable
-     * or {@code com.amazonaws.xray.emitters.daemonAddress} system property, if either are set to a non-empty value. Otherwise,
-     * points to {@code InetAddress.getLoopbackAddress()} at port {@code 2000}.
-     *
-     * @throws SocketException
-     *             if an error occurs while instantiating a {@code DatagramSocket}.
-     */
-    public UDPEmitter() throws SocketException {
-        this(new DaemonConfiguration());
+  /**
+   * Constructs a UDPEmitter. Sets the daemon address to the value of the {@code AWS_XRAY_DAEMON_ADDRESS} environment variable
+   * or {@code com.amazonaws.xray.emitters.daemonAddress} system property, if either are set to a non-empty value. Otherwise,
+   * points to {@code InetAddress.getLoopbackAddress()} at port {@code 2000}.
+   *
+   * @throws SocketException if an error occurs while instantiating a {@code DatagramSocket}.
+   */
+  public UDPEmitter() throws SocketException {
+    this(new DaemonConfiguration());
+  }
+
+  /**
+   * Constructs a UDPEmitter. This overload allows you to specify the configuration.
+   *
+   * @param config The {@link DaemonConfiguration} for the Emitter.
+   * @throws SocketException if an error occurs while instantiating a {@code DatagramSocket}.
+   */
+  public UDPEmitter(DaemonConfiguration config) throws SocketException {
+    this.config = config;
+    try {
+      daemonSocket = new DatagramSocket();
+    } catch (SocketException e) {
+      logger.error("Exception while instantiating daemon socket.", e);
+      throw e;
     }
+  }
 
-    /**
-     * Constructs a UDPEmitter. This overload allows you to specify the configuration.
-     *
-     * @param config The {@link DaemonConfiguration} for the Emitter.
-     * @throws SocketException
-     *             if an error occurs while instantiating a {@code DatagramSocket}.
-     */
-    public UDPEmitter(DaemonConfiguration config) throws SocketException {
-        this.config = config;
-        try {
-            daemonSocket = new DatagramSocket();
-        } catch (SocketException e) {
-            logger.error("Exception while instantiating daemon socket.", e);
-            throw e;
-        }
-    }
+  public String getUDPAddress() {
+    return config.getUDPAddress();
+  }
 
-    public String getUDPAddress() {
-        return config.getUDPAddress();
+  /**
+   * {@inheritDoc}
+   *
+   * @see Emitter#sendSegment(Segment)
+   */
+  @Override
+  public boolean sendSegment(Segment segment) {
+    if (logger.isDebugEnabled()) {
+      logger.debug(segment.prettySerialize());
     }
+    if (segment.compareAndSetEmitted(false, true)) {
+      return sendData((PROTOCOL_HEADER + PROTOCOL_DELIMITER + segment.serialize()).getBytes(StandardCharsets.UTF_8),
+          segment);
+    } else {
+      return false;
+    }
+  }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @see Emitter#sendSegment(Segment)
-     */
-    @Override
-    public boolean sendSegment(Segment segment) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(segment.prettySerialize());
-        }
-        if (segment.compareAndSetEmitted(false, true)) {
-            return sendData((PROTOCOL_HEADER + PROTOCOL_DELIMITER + segment.serialize()).getBytes(StandardCharsets.UTF_8),
-                            segment);
-        } else {
-            return false;
-        }
+  /**
+   * {@inheritDoc}
+   *
+   * @see Emitter#sendSubsegment(Subsegment)
+   */
+  @Override
+  public boolean sendSubsegment(Subsegment subsegment) {
+    if (logger.isDebugEnabled()) {
+      logger.debug(subsegment.prettyStreamSerialize());
     }
+    if (subsegment.compareAndSetEmitted(false, true)) {
+      return sendData(
+          (PROTOCOL_HEADER + PROTOCOL_DELIMITER + subsegment.streamSerialize()).getBytes(StandardCharsets.UTF_8),
+          subsegment);
+    } else {
+      return false;
+    }
+  }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @see Emitter#sendSubsegment(Subsegment)
-     */
-    @Override
-    public boolean sendSubsegment(Subsegment subsegment) {
-        if (logger.isDebugEnabled()) {
-            logger.debug(subsegment.prettyStreamSerialize());
-        }
-        if (subsegment.compareAndSetEmitted(false, true)) {
-            return sendData((PROTOCOL_HEADER + PROTOCOL_DELIMITER +
-                             subsegment.streamSerialize()).getBytes(StandardCharsets.UTF_8),
-                            subsegment);
-        } else {
-            return false;
-        }
+  private boolean sendData(byte[] data, Entity entity) {
+    try {
+      DatagramPacket packet = new DatagramPacket(sendBuffer, DAEMON_BUF_RECEIVE_SIZE, config.getAddressForEmitter());
+      packet.setData(data);
+      logger.debug("Sending UDP packet.");
+      daemonSocket.send(packet);
+    } catch (Exception e) {
+      String segmentName = Optional.ofNullable(entity.getParent()).map(this::nameAndId).orElse("[no parent segment]");
+      logger.error("Exception while sending segment (" + entity.getClass().getSimpleName() + ") over UDP for entity "
+          + nameAndId(entity) + " on segment " + segmentName + ". Bytes: " + data.length, e);
+      return false;
     }
+    return true;
+  }
 
-    private boolean sendData(byte[] data, Entity entity) {
-        try {
-            DatagramPacket packet = new DatagramPacket(sendBuffer, DAEMON_BUF_RECEIVE_SIZE, config.getAddressForEmitter());
-            packet.setData(data);
-            logger.debug("Sending UDP packet.");
-            daemonSocket.send(packet);
-        } catch (Exception e) {
-            String segmentName = Optional.ofNullable(entity.getParent()).map(this::nameAndId).orElse("[no parent segment]");
-            logger.error("Exception while sending segment over UDP for entity " +  nameAndId(entity) + " on segment "
-                         + segmentName, e);
-            return false;
-        }
-        return true;
-    }
-
-    private String nameAndId(Entity entity) {
-        return entity.getName() + " [" + entity.getId() + "]";
-    }
+  private String nameAndId(Entity entity) {
+    return entity.getName() + " [" + entity.getId() + "]";
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
#26 

*Description of changes:*
Improve the emitter sendData failure log message to include the number of bytes involved and the type of entity that failed to be published.

New log message has format:

```
Exception while sending segment (SegmentImpl) over UDP for entity CoreApi [1827010d1fe3a482] on segment [no parent segment]. Bytes: 77861
```


This code semi-frequently publishes a semi-meaningless stack trace `java.net.SocketException: Message too long` when the UDP packet to the daemon server is too large. 

```
Exception while sending segment over UDP for entity CoreApi [3c2c14f28ed556d9] on segment [no parent segment]
java.net.SocketException: Message too long
at sun.nio.ch.DatagramChannelImpl.send0(Native Method) ~[?:?]
...
at sun.nio.ch.DatagramSocketAdaptor.send(DatagramSocketAdaptor.java:218) ~[?:?]
at java.net.DatagramSocket.send(DatagramSocket.java:664) ~[?:?]
at com.amazonaws.xray.emitters.UDPEmitter.sendData(UDPEmitter.java:116) ~[aws-xray-recorder-sdk-core-2.11.2.jar:?]
at com.amazonaws.xray.emitters.UDPEmitter.sendSegment(UDPEmitter.java:85) ~[aws-xray-recorder-sdk-core-2.11.2.jar:?]
at com.amazonaws.xray.AWSXRayRecorder.sendSegment(AWSXRayRecorder.java:195) ~[aws-xray-recorder-sdk-core-2.11.2.jar:?]
at com.amazonaws.xray.AWSXRayRecorder.endSubsegment(AWSXRayRecorder.java:588) ~[aws-xray-recorder-sdk-core-2.11.2.jar:?]
at com.amazonaws.xray.AWSXRay.endSubsegment(AWSXRay.java:129)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
