### PR TITLE
Add @Nullable to AWSXray.setTraceEntity() parameter

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRay.java
@@ -192,7 +192,7 @@ public class AWSXRay {
      * the trace entity so it can be restored correctly.
      */
     @Deprecated
-    public static void setTraceEntity(Entity entity) {
+    public static void setTraceEntity(@Nullable Entity entity) {
         globalRecorder.setTraceEntity(entity);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add @Nullable to AWSXray.setTraceEntity() parameter as the delegate method in AWSXrayRecorder accepts nulls when clearing the TraceEntity state. 

This will resolve a 'null check' warning in IntelliJ `Argument 'original' might be null`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
