### PR TITLE
Update build.gradle.kts

### DIFF
--- a/aws-xray-recorder-sdk-log4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-log4j/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 dependencies {
     api(project(":aws-xray-recorder-sdk-core"))
 
-    compileOnly("org.apache.logging.log4j:log4j-api:2.17.0")
+    compileOnly("org.apache.logging.log4j:log4j-api:2.17.1")
 
-    testImplementation("org.apache.logging.log4j:log4j-api:2.17.0")
+    testImplementation("org.apache.logging.log4j:log4j-api:2.17.1")
 }
 
 tasks.jar {


### PR DESCRIPTION
*Issue #, if available:*
There is a vulnerability found in 2.17.0 for log4j.
https://logging.apache.org/log4j/2.x/security.html

*Description of changes:*
Updated log4j to 2.17.1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
