### PR TITLE
Fix sqs/sns case for aws sdk v2 parameter allowlist lookups (#373)

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
     testImplementation("software.amazon.awssdk:dynamodb:2.15.20")
     testImplementation("software.amazon.awssdk:lambda:2.15.20")
+    testImplementation("software.amazon.awssdk:sqs:2.15.20")
+    testImplementation("software.amazon.awssdk:sns:2.15.20")
 }
 
 tasks.jar {

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/resources/com/amazonaws/xray/interceptors/DefaultOperationParameterWhitelist.json
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/resources/com/amazonaws/xray/interceptors/DefaultOperationParameterWhitelist.json
@@ -1,6 +1,6 @@
 {
   "services": {
-    "SNS": {
+    "Sns": {
       "operations": {
         "Publish": {
           "request_parameters": [
@@ -152,7 +152,7 @@
         }
       }
     },
-    "SQS": {
+    "Sqs": {
       "operations": {
         "AddPermission": {
           "request_parameters": [

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
@@ -127,7 +127,15 @@ public class TracingInterceptorTest {
 
     @Test
     public void testSqsSendMessageSubsegmentContainsQueueUrl() throws Exception {
-        SdkHttpClient mockClient = mockClientWithSuccessResponse("<SendMessageResponse><SendMessageResult><MD5OfMessageBody>b10a8db164e0754105b7a99be72e3fe5</MD5OfMessageBody><MessageId>abc-def-ghi</MessageId></SendMessageResult><ResponseMetadata><RequestId>123-456-789</RequestId></ResponseMetadata></SendMessageResponse>");
+        SdkHttpClient mockClient = mockClientWithSuccessResponse(
+                "<SendMessageResponse>" +
+                    "<SendMessageResult>" +
+                        "<MD5OfMessageBody>b10a8db164e0754105b7a99be72e3fe5</MD5OfMessageBody>" +
+                        "<MessageId>abc-def-ghi</MessageId>" +
+                    "</SendMessageResult>" +
+                    "<ResponseMetadata><RequestId>123-456-789</RequestId></ResponseMetadata>" +
+                "</SendMessageResponse>"
+        );
         SqsClient client = sqsClient(mockClient);
 
         Segment segment = AWSXRay.getCurrentSegment();
@@ -152,7 +160,12 @@ public class TracingInterceptorTest {
 
     @Test
     public void testSnsPublishSubsegmentContainsTopicArn() throws Exception {
-        SdkHttpClient mockClient = mockClientWithSuccessResponse("<PublishResponse><PublishResult><MessageId>abc-def-ghi</MessageId></PublishResult><ResponseMetadata><RequestId>123-456-789</RequestId></ResponseMetadata></PublishResponse>");
+        SdkHttpClient mockClient = mockClientWithSuccessResponse(
+                "<PublishResponse>" +
+                    "<PublishResult><MessageId>abc-def-ghi</MessageId></PublishResult>" +
+                    "<ResponseMetadata><RequestId>123-456-789</RequestId></ResponseMetadata>" +
+                "</PublishResponse>"
+        );
         SnsClient client = snsClient(mockClient);
 
         Segment segment = AWSXRay.getCurrentSegment();


### PR DESCRIPTION
*Issue #, if available:* #373

*Description of changes:*
- Fix sqs/sns case `SQS` -> `Sqs`, `SNS` -> `Sns`
- Refactor `TracingInterceptorTest` to
  - Make `@Test` cases come first
  - Move private utility methods to the end of the class
  - Extract utility methods to setup the clients for tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
