### PR TITLE
use jackson to snake case for better performance

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk-core/src/main/java/com/amazonaws/xray/utils/StringTransform.java
+++ b/aws-xray-recorder-sdk-aws-sdk-core/src/main/java/com/amazonaws/xray/utils/StringTransform.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 @Deprecated
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 public class StringTransform {
-    private static final Pattern REGEX = Pattern.compile("([a-z])([A-Z]+)");
+    private static final Pattern REGEX = Pattern.compile("([a-z])([A-Z])");
     private static final String REPLACE = "$1_$2";
 
     public static String toSnakeCase(String camelCase) {

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
@@ -71,7 +71,8 @@ public class TracingInterceptor implements ExecutionInterceptor {
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(JsonParser.Feature.ALLOW_COMMENTS, true);
 
-    private static final PropertyNamingStrategies.NamingBase SNAKE_CASE_NAMING_STRATEGY = (PropertyNamingStrategies.NamingBase) PropertyNamingStrategies.SNAKE_CASE;
+    private static final PropertyNamingStrategies.NamingBase
+            SNAKE_CASE_NAMING_STRATEGY = (PropertyNamingStrategies.NamingBase) PropertyNamingStrategies.SNAKE_CASE;
     
     private static final URL DEFAULT_OPERATION_PARAMETER_WHITELIST =
         TracingInterceptor.class.getResource("/com/amazonaws/xray/interceptors/DefaultOperationParameterWhitelist.json");

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
@@ -26,11 +26,10 @@ import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.handlers.config.AWSOperationHandler;
 import com.amazonaws.xray.handlers.config.AWSOperationHandlerManifest;
 import com.amazonaws.xray.handlers.config.AWSServiceHandlerManifest;
-import com.amazonaws.xray.utils.StringTransform;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
@@ -68,10 +67,12 @@ public class TracingInterceptor implements ExecutionInterceptor {
     private static final Log logger = LogFactory.getLog(TracingInterceptor.class);
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(JsonParser.Feature.ALLOW_COMMENTS, true);
 
+    private static final PropertyNamingStrategies.NamingBase SNAKE_CASE_NAMING_STRATEGY = (PropertyNamingStrategies.NamingBase) PropertyNamingStrategies.SNAKE_CASE;
+    
     private static final URL DEFAULT_OPERATION_PARAMETER_WHITELIST =
         TracingInterceptor.class.getResource("/com/amazonaws/xray/interceptors/DefaultOperationParameterWhitelist.json");
 
@@ -147,7 +148,7 @@ public class TracingInterceptor implements ExecutionInterceptor {
                 SdkRequest request = context.request();
                 Optional<Object> parameterValue = request.getValueForField(parameterName, Object.class);
                 if (parameterValue.isPresent()) {
-                    parameters.put(StringTransform.toSnakeCase(parameterName), parameterValue.get());
+                    parameters.put(SNAKE_CASE_NAMING_STRATEGY.translate(parameterName), parameterValue.get());
                 }
             });
         }
@@ -159,14 +160,14 @@ public class TracingInterceptor implements ExecutionInterceptor {
                     Optional<Map> parameterValue = request.getValueForField(key, Map.class);
                     if (parameterValue.isPresent()) {
                         String renameTo = descriptor.getRenameTo() != null ? descriptor.getRenameTo() : key;
-                        parameters.put(StringTransform.toSnakeCase(renameTo), parameterValue.get().keySet());
+                        parameters.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.get().keySet());
                     }
                 } else if (descriptor.isList() && descriptor.shouldGetCount()) {
                     SdkRequest request = context.request();
                     Optional<List> parameterValue = request.getValueForField(key, List.class);
                     if (parameterValue.isPresent()) {
                         String renameTo = descriptor.getRenameTo() != null ? descriptor.getRenameTo() : key;
-                        parameters.put(StringTransform.toSnakeCase(renameTo), parameterValue.get().size());
+                        parameters.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.get().size());
                     }
                 }
             });
@@ -189,7 +190,7 @@ public class TracingInterceptor implements ExecutionInterceptor {
                 SdkResponse response = context.response();
                 Optional<Object> parameterValue = response.getValueForField(parameterName, Object.class);
                 if (parameterValue.isPresent()) {
-                    parameters.put(StringTransform.toSnakeCase(parameterName), parameterValue.get());
+                    parameters.put(SNAKE_CASE_NAMING_STRATEGY.translate(parameterName), parameterValue.get());
                 }
             });
         }
@@ -201,14 +202,14 @@ public class TracingInterceptor implements ExecutionInterceptor {
                     Optional<Map> parameterValue = response.getValueForField(key, Map.class);
                     if (parameterValue.isPresent()) {
                         String renameTo = descriptor.getRenameTo() != null ? descriptor.getRenameTo() : key;
-                        parameters.put(StringTransform.toSnakeCase(renameTo), parameterValue.get().keySet());
+                        parameters.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.get().keySet());
                     }
                 } else if (descriptor.isList() && descriptor.shouldGetCount()) {
                     SdkResponse response = context.response();
                     Optional<List> parameterValue = response.getValueForField(key, List.class);
                     if (parameterValue.isPresent()) {
                         String renameTo = descriptor.getRenameTo() != null ? descriptor.getRenameTo() : key;
-                        parameters.put(StringTransform.toSnakeCase(renameTo), parameterValue.get().size());
+                        parameters.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.get().size());
                     }
                 }
             });

--- a/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
@@ -40,7 +40,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
@@ -83,7 +82,8 @@ public class TracingHandler extends RequestHandler2 {
     private static final HandlerContextKey<Entity> ENTITY_KEY = new HandlerContextKey<>("AWS X-Ray Entity");
     private static final HandlerContextKey<Long> EXECUTING_THREAD_KEY = new HandlerContextKey<>("AWS X-Ray Executing Thread ID");
     
-    private static final PropertyNamingStrategies.NamingBase SNAKE_CASE_NAMING_STRATEGY = (PropertyNamingStrategies.NamingBase) PropertyNamingStrategies.SNAKE_CASE;
+    private static final PropertyNamingStrategies.NamingBase
+            SNAKE_CASE_NAMING_STRATEGY = (PropertyNamingStrategies.NamingBase) PropertyNamingStrategies.SNAKE_CASE;
 
     private final String accountId;
 

--- a/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
@@ -36,11 +36,11 @@ import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.handlers.config.AWSOperationHandler;
 import com.amazonaws.xray.handlers.config.AWSOperationHandlerManifest;
 import com.amazonaws.xray.handlers.config.AWSServiceHandlerManifest;
-import com.amazonaws.xray.utils.StringTransform;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
@@ -61,7 +61,7 @@ public class TracingHandler extends RequestHandler2 {
     private static final Log logger = LogFactory.getLog(TracingHandler.class);
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
-        .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+        .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         .configure(JsonParser.Feature.ALLOW_COMMENTS, true);
 
@@ -82,6 +82,8 @@ public class TracingHandler extends RequestHandler2 {
 
     private static final HandlerContextKey<Entity> ENTITY_KEY = new HandlerContextKey<>("AWS X-Ray Entity");
     private static final HandlerContextKey<Long> EXECUTING_THREAD_KEY = new HandlerContextKey<>("AWS X-Ray Executing Thread ID");
+    
+    private static final PropertyNamingStrategies.NamingBase SNAKE_CASE_NAMING_STRATEGY = (PropertyNamingStrategies.NamingBase) PropertyNamingStrategies.SNAKE_CASE;
 
     private final String accountId;
 
@@ -229,7 +231,7 @@ public class TracingHandler extends RequestHandler2 {
                     Object parameterValue = originalRequest
                         .getClass().getMethod(GETTER_METHOD_NAME_PREFIX + parameterName).invoke(originalRequest);
                     if (null != parameterValue) {
-                        ret.put(StringTransform.toSnakeCase(parameterName), parameterValue);
+                        ret.put(SNAKE_CASE_NAMING_STRATEGY.translate(parameterName), parameterValue);
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                     logger.error("Error getting request parameter: " + parameterName, e);
@@ -249,7 +251,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != requestDescriptor.getRenameTo() ? requestDescriptor.getRenameTo() : requestKeyName;
-                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.keySet());
+                            ret.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.keySet());
                         }
                     } else if (requestDescriptor.isList() && requestDescriptor.shouldGetCount()) {
                         @SuppressWarnings("unchecked")
@@ -259,7 +261,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != requestDescriptor.getRenameTo() ? requestDescriptor.getRenameTo() : requestKeyName;
-                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.size());
+                            ret.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.size());
                         }
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassCastException e) {
@@ -294,7 +296,7 @@ public class TracingHandler extends RequestHandler2 {
                     Object parameterValue = response
                         .getClass().getMethod(GETTER_METHOD_NAME_PREFIX + parameterName).invoke(response);
                     if (null != parameterValue) {
-                        ret.put(StringTransform.toSnakeCase(parameterName), parameterValue);
+                        ret.put(SNAKE_CASE_NAMING_STRATEGY.translate(parameterName), parameterValue);
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                     logger.error("Error getting response parameter: " + parameterName, e);
@@ -313,7 +315,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != responseDescriptor.getRenameTo() ? responseDescriptor.getRenameTo() : responseKeyName;
-                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.keySet());
+                            ret.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.keySet());
                         }
                     } else if (responseDescriptor.isList() && responseDescriptor.shouldGetCount()) {
                         @SuppressWarnings("unchecked")
@@ -323,7 +325,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != responseDescriptor.getRenameTo() ? responseDescriptor.getRenameTo() : responseKeyName;
-                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.size());
+                            ret.put(SNAKE_CASE_NAMING_STRATEGY.translate(renameTo), parameterValue.size());
                         }
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassCastException e) {

--- a/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
@@ -36,6 +36,7 @@ import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.handlers.config.AWSOperationHandler;
 import com.amazonaws.xray.handlers.config.AWSOperationHandlerManifest;
 import com.amazonaws.xray.handlers.config.AWSServiceHandlerManifest;
+import com.amazonaws.xray.utils.StringTransform;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -81,9 +82,6 @@ public class TracingHandler extends RequestHandler2 {
 
     private static final HandlerContextKey<Entity> ENTITY_KEY = new HandlerContextKey<>("AWS X-Ray Entity");
     private static final HandlerContextKey<Long> EXECUTING_THREAD_KEY = new HandlerContextKey<>("AWS X-Ray Executing Thread ID");
-
-    private static final String TO_SNAKE_CASE_REGEX = "([a-z])([A-Z]+)";
-    private static final String TO_SNAKE_CASE_REPLACE = "$1_$2";
 
     private final String accountId;
 
@@ -206,10 +204,6 @@ public class TracingHandler extends RequestHandler2 {
         return ret;
     }
 
-    private static String toSnakeCase(String camelCase) {
-        return camelCase.replaceAll(TO_SNAKE_CASE_REGEX, TO_SNAKE_CASE_REPLACE).toLowerCase();
-    }
-
     private HashMap<String, Object> extractRequestParameters(Request<?> request) {
         HashMap<String, Object> ret = new HashMap<>();
         if (null == awsServiceHandlerManifest) {
@@ -235,7 +229,7 @@ public class TracingHandler extends RequestHandler2 {
                     Object parameterValue = originalRequest
                         .getClass().getMethod(GETTER_METHOD_NAME_PREFIX + parameterName).invoke(originalRequest);
                     if (null != parameterValue) {
-                        ret.put(TracingHandler.toSnakeCase(parameterName), parameterValue);
+                        ret.put(StringTransform.toSnakeCase(parameterName), parameterValue);
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                     logger.error("Error getting request parameter: " + parameterName, e);
@@ -255,7 +249,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != requestDescriptor.getRenameTo() ? requestDescriptor.getRenameTo() : requestKeyName;
-                            ret.put(TracingHandler.toSnakeCase(renameTo), parameterValue.keySet());
+                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.keySet());
                         }
                     } else if (requestDescriptor.isList() && requestDescriptor.shouldGetCount()) {
                         @SuppressWarnings("unchecked")
@@ -265,7 +259,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != requestDescriptor.getRenameTo() ? requestDescriptor.getRenameTo() : requestKeyName;
-                            ret.put(TracingHandler.toSnakeCase(renameTo), parameterValue.size());
+                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.size());
                         }
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassCastException e) {
@@ -300,7 +294,7 @@ public class TracingHandler extends RequestHandler2 {
                     Object parameterValue = response
                         .getClass().getMethod(GETTER_METHOD_NAME_PREFIX + parameterName).invoke(response);
                     if (null != parameterValue) {
-                        ret.put(TracingHandler.toSnakeCase(parameterName), parameterValue);
+                        ret.put(StringTransform.toSnakeCase(parameterName), parameterValue);
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                     logger.error("Error getting response parameter: " + parameterName, e);
@@ -319,7 +313,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != responseDescriptor.getRenameTo() ? responseDescriptor.getRenameTo() : responseKeyName;
-                            ret.put(TracingHandler.toSnakeCase(renameTo), parameterValue.keySet());
+                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.keySet());
                         }
                     } else if (responseDescriptor.isList() && responseDescriptor.shouldGetCount()) {
                         @SuppressWarnings("unchecked")
@@ -329,7 +323,7 @@ public class TracingHandler extends RequestHandler2 {
                         if (null != parameterValue) {
                             String renameTo =
                                 null != responseDescriptor.getRenameTo() ? responseDescriptor.getRenameTo() : responseKeyName;
-                            ret.put(TracingHandler.toSnakeCase(renameTo), parameterValue.size());
+                            ret.put(StringTransform.toSnakeCase(renameTo), parameterValue.size());
                         }
                     }
                 } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassCastException e) {


### PR DESCRIPTION
*Description of changes:*

Hello, I am big fan of making things faster and originally was trying to avoid some String.replaceAll calls in TracingHandler, but found that you already have a better StringTransform implementation but not using it there, 

after looking more deeply I found that using the SnakeCaseStrategy from PropertyNamingStrategies that is already highly optimized was the best route. 

Thanks. 

ps. I checked the performance using this branch https://github.com/rudygt/aws-xray-sdk-java/tree/benchmark, I dont think merging that test is needed.  this is the output I get on my system.

```
Benchmark                                                           Mode      Cnt     Score      Error   Units
SnakeCaseBenchmark.jacksonSnakeCase                                thrpt        5    27.105 �    0.527  ops/us
SnakeCaseBenchmark.jacksonSnakeCase:�gc.alloc.rate                 thrpt        5  7155.905 �   96.815  MB/sec
SnakeCaseBenchmark.jacksonSnakeCase:�gc.alloc.rate.norm            thrpt        5   416.000 �    0.001    B/op
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Eden_Space        thrpt        5  7087.917 � 1873.788  MB/sec
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Eden_Space.norm   thrpt        5   411.981 �  104.107    B/op
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Old_Gen           thrpt        5     0.003 �    0.004  MB/sec
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Old_Gen.norm      thrpt        5    ? 10??               B/op
SnakeCaseBenchmark.jacksonSnakeCase:�gc.count                      thrpt        5    38.000             counts
SnakeCaseBenchmark.jacksonSnakeCase:�gc.time                       thrpt        5    30.000                 ms
SnakeCaseBenchmark.ownSnakeCase                                    thrpt        5     4.139 �    0.131  ops/us
SnakeCaseBenchmark.ownSnakeCase:�gc.alloc.rate                     thrpt        5  5303.713 �  174.552  MB/sec
SnakeCaseBenchmark.ownSnakeCase:�gc.alloc.rate.norm                thrpt        5  2024.002 �    0.001    B/op
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Eden_Space            thrpt        5  5294.799 � 1334.128  MB/sec
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Eden_Space.norm       thrpt        5  2019.998 �  456.831    B/op
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Old_Gen               thrpt        5     0.003 �    0.006  MB/sec
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Old_Gen.norm          thrpt        5     0.001 �    0.002    B/op
SnakeCaseBenchmark.ownSnakeCase:�gc.count                          thrpt        5    42.000             counts
SnakeCaseBenchmark.ownSnakeCase:�gc.time                           thrpt        5    29.000                 ms
SnakeCaseBenchmark.jacksonSnakeCase                               sample  2103354     0.650 �    0.012   us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p0.00        sample              0.400              us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p0.50        sample              0.500              us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p0.90        sample              0.900              us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p0.95        sample              0.900              us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p0.99        sample              0.900              us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p0.999       sample              3.700              us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p0.9999      sample             34.048              us/op
SnakeCaseBenchmark.jacksonSnakeCase:jacksonSnakeCase�p1.00        sample           1634.304              us/op
SnakeCaseBenchmark.jacksonSnakeCase:�gc.alloc.rate                sample        5  7028.249 �  184.340  MB/sec
SnakeCaseBenchmark.jacksonSnakeCase:�gc.alloc.rate.norm           sample        5   416.135 �    0.013    B/op
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Eden_Space       sample        5  7031.250 � 1664.497  MB/sec
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Eden_Space.norm  sample        5   416.249 �   92.975    B/op
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Old_Gen          sample        5     0.002 �    0.009  MB/sec
SnakeCaseBenchmark.jacksonSnakeCase:�gc.churn.G1_Old_Gen.norm     sample        5    ? 10??               B/op
SnakeCaseBenchmark.jacksonSnakeCase:�gc.count                     sample        5    43.000             counts
SnakeCaseBenchmark.jacksonSnakeCase:�gc.time                      sample        5    34.000                 ms
SnakeCaseBenchmark.ownSnakeCase                                   sample  2674887     3.737 �    0.024   us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p0.00                sample              2.500              us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p0.50                sample              2.900              us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p0.90                sample              4.696              us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p0.95                sample              4.800              us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p0.99                sample              5.000              us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p0.999               sample             16.576              us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p0.9999              sample            100.668              us/op
SnakeCaseBenchmark.ownSnakeCase:ownSnakeCase�p1.00                sample           1898.496              us/op
SnakeCaseBenchmark.ownSnakeCase:�gc.alloc.rate                    sample        5  5664.450 �  574.098  MB/sec
SnakeCaseBenchmark.ownSnakeCase:�gc.alloc.rate.norm               sample        5  2024.767 �    0.167    B/op
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Eden_Space           sample        5  5763.147 � 1199.824  MB/sec
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Eden_Space.norm      sample        5  2060.170 �  379.310    B/op
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Old_Gen              sample        5     0.007 �    0.022  MB/sec
SnakeCaseBenchmark.ownSnakeCase:�gc.churn.G1_Old_Gen.norm         sample        5     0.003 �    0.008    B/op
SnakeCaseBenchmark.ownSnakeCase:�gc.count                         sample        5    41.000             counts
SnakeCaseBenchmark.ownSnakeCase:�gc.time                          sample        5    36.000                 ms
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
