### PR TITLE
Thread safety

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/SubsegmentImpl.java
@@ -20,8 +20,9 @@ import com.amazonaws.xray.internal.SamplingStrategyOverride;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -64,7 +65,7 @@ public class SubsegmentImpl extends EntityImpl implements Subsegment {
         super(creator, name);
         this.parentSegment = parentSegment;
         parentSegment.incrementReferenceCount();
-        this.precursorIds = new HashSet<>();
+        this.precursorIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
         this.shouldPropagate = true;
 
         this.isSampled = samplingStrategyOverride == SamplingStrategyOverride.DISABLED ?

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/ConcurrencyTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/ConcurrencyTest.java
@@ -20,10 +20,8 @@ import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.SegmentImpl;
 import com.amazonaws.xray.entities.SubsegmentImpl;
 import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
-
 import java.util.Iterator;
 import java.util.Random;
-import java.util.Vector;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/entities/EntityTest.java
@@ -76,6 +76,18 @@ class EntityTest {
         seg.serialize();  // Verify we don't crash here
     }
 
+    @Test
+    void testPrecursorIds() {
+        Segment seg = new SegmentImpl(AWSXRay.getGlobalRecorder(), "test");
+        SubsegmentImpl subseg = new SubsegmentImpl(AWSXRay.getGlobalRecorder(), "test", seg);
+        subseg.addPrecursorId("myId1");
+        subseg.addPrecursorId("myId2");
+        String serializedSubSeg = subseg.serialize();
+
+        String expected = "\"precursor_ids\":[\"myId1\",\"myId2\"]";
+        assertThat(serializedSubSeg).contains(expected);
+    }
+
     static class EmptyBean {
         String otherField = "cerealization";
     }

--- a/aws-xray-recorder-sdk-log4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-log4j/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 dependencies {
     api(project(":aws-xray-recorder-sdk-core"))
 
-    compileOnly("org.apache.logging.log4j:log4j-api:2.17.0")
+    compileOnly("org.apache.logging.log4j:log4j-api:2.17.1")
 
-    testImplementation("org.apache.logging.log4j:log4j-api:2.17.0")
+    testImplementation("org.apache.logging.log4j:log4j-api:2.17.1")
 }
 
 tasks.jar {

--- a/aws-xray-recorder-sdk-log4j/build.gradle.kts
+++ b/aws-xray-recorder-sdk-log4j/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 dependencies {
     api(project(":aws-xray-recorder-sdk-core"))
 
-    compileOnly("org.apache.logging.log4j:log4j-api:2.17.1")
+    compileOnly("org.apache.logging.log4j:log4j-api:2.17.0")
 
-    testImplementation("org.apache.logging.log4j:log4j-api:2.17.1")
+    testImplementation("org.apache.logging.log4j:log4j-api:2.17.0")
 }
 
 tasks.jar {


### PR DESCRIPTION
*Issue #, if available:*
It is possible to get a concurrent modification exception from adding PrecursorIds in two separate threads at the same time.

*Description of changes:*
Make the data structure for PrecursorIds thread safe.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
