### PR TITLE
Bumping grgit version

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ pluginManagement {
         id("io.freefair.aggregate-javadoc-jar") version "5.3.0"
         id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
         id("net.ltgt.errorprone") version "1.2.1"
-        id("org.ajoberstar.grgit") version "5.2.0"
+        id("org.ajoberstar.grgit") version "4.1.1"
         id("org.checkerframework") version "0.5.4"
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ pluginManagement {
         id("io.freefair.aggregate-javadoc-jar") version "5.3.0"
         id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
         id("net.ltgt.errorprone") version "1.2.1"
-        id("org.ajoberstar.grgit") version "4.0.2"
+        id("org.ajoberstar.grgit") version "5.2.0"
         id("org.checkerframework") version "0.5.4"
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-java/actions/runs/5358250724/jobs/9720271919
https://repo1.maven.org/maven2/org/ajoberstar/grgit/grgit-core/
Version 4.0.2 has been deleted from maven for grgit.

*Description of changes:*
Bumping grgit version to 4.1.1.
I tried version 5.2.0, but it required a minimum Java version of 11 and we compile for 1.8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
