### PR TITLE
Optimize default resolver chain construction

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
@@ -73,17 +73,17 @@ public class TracingHandlerLambdaTest {
     public void testSamplingOverrideTrueInLambda() {
         Emitter mockedEmitted = Mockito.mock(DefaultEmitter.class);
 
+        PowerMockito.stub(PowerMockito.method(
+                LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
+        PowerMockito.stub(PowerMockito.method(
+                LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
+
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
                 .withSamplingStrategy(new NoSamplingStrategy())
                 .withEmitter(mockedEmitted)
                 .build();
 
         TraceHeader header = TraceHeader.fromString(TRACE_HEADER);
-
-        PowerMockito.stub(PowerMockito.method(
-                LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
-        PowerMockito.stub(PowerMockito.method(
-                LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
 
         Mockito.doAnswer(invocation -> { return true; }).when(mockedEmitted).sendSubsegment(any());
 
@@ -95,17 +95,17 @@ public class TracingHandlerLambdaTest {
     public void testSamplingOverrideMixedInLambda() {
         Emitter mockedEmitted = Mockito.mock(DefaultEmitter.class);
 
+        PowerMockito.stub(PowerMockito.method(
+                LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
+        PowerMockito.stub(PowerMockito.method(
+                LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
+
         AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
                 .withSamplingStrategy(new NoSamplingStrategy())
                 .withEmitter(mockedEmitted)
                 .build();
 
         TraceHeader header = TraceHeader.fromString(TRACE_HEADER);
-
-        PowerMockito.stub(PowerMockito.method(
-                LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
-        PowerMockito.stub(PowerMockito.method(
-                LambdaSegmentContextResolver.class, "getLambdaTaskRoot")).toReturn("/var/task");
 
         Mockito.doAnswer(invocation -> { return true; }).when(mockedEmitted).sendSubsegment(any());
 

--- a/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
@@ -73,6 +73,8 @@ public class TracingHandlerLambdaTest {
     public void testSamplingOverrideTrueInLambda() {
         Emitter mockedEmitted = Mockito.mock(DefaultEmitter.class);
 
+        TraceHeader header = TraceHeader.fromString(TRACE_HEADER);
+
         PowerMockito.stub(PowerMockito.method(
                 LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
         PowerMockito.stub(PowerMockito.method(
@@ -82,8 +84,6 @@ public class TracingHandlerLambdaTest {
                 .withSamplingStrategy(new NoSamplingStrategy())
                 .withEmitter(mockedEmitted)
                 .build();
-
-        TraceHeader header = TraceHeader.fromString(TRACE_HEADER);
 
         Mockito.doAnswer(invocation -> { return true; }).when(mockedEmitted).sendSubsegment(any());
 
@@ -95,6 +95,8 @@ public class TracingHandlerLambdaTest {
     public void testSamplingOverrideMixedInLambda() {
         Emitter mockedEmitted = Mockito.mock(DefaultEmitter.class);
 
+        TraceHeader header = TraceHeader.fromString(TRACE_HEADER);
+
         PowerMockito.stub(PowerMockito.method(
                 LambdaSegmentContext.class, "getTraceHeaderFromEnvironment")).toReturn(header);
         PowerMockito.stub(PowerMockito.method(
@@ -104,8 +106,6 @@ public class TracingHandlerLambdaTest {
                 .withSamplingStrategy(new NoSamplingStrategy())
                 .withEmitter(mockedEmitted)
                 .build();
-
-        TraceHeader header = TraceHeader.fromString(TRACE_HEADER);
 
         Mockito.doAnswer(invocation -> { return true; }).when(mockedEmitted).sendSubsegment(any());
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -164,8 +164,12 @@ public class AWSXRayRecorder {
         }
 
         segmentContextResolverChain = new SegmentContextResolverChain();
-        segmentContextResolverChain.addResolver(new LambdaSegmentContextResolver());
-        segmentContextResolverChain.addResolver(new ThreadLocalSegmentContextResolver());
+        LambdaSegmentContextResolver lambdaSegmentContextResolver = new LambdaSegmentContextResolver();
+        if (lambdaSegmentContextResolver.resolve() != null) {
+            segmentContextResolverChain.addResolver(lambdaSegmentContextResolver);
+        } else {
+            segmentContextResolverChain.addResolver(new ThreadLocalSegmentContextResolver());
+        }
 
         segmentListeners = new ArrayList<>();
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -167,9 +167,9 @@ public class AWSXRayRecorder {
         LambdaSegmentContextResolver lambdaSegmentContextResolver = new LambdaSegmentContextResolver();
         if (lambdaSegmentContextResolver.resolve() != null) {
             segmentContextResolverChain.addResolver(lambdaSegmentContextResolver);
-        } else {
-            segmentContextResolverChain.addResolver(new ThreadLocalSegmentContextResolver());
         }
+        
+        segmentContextResolverChain.addResolver(new ThreadLocalSegmentContextResolver());
 
         segmentListeners = new ArrayList<>();
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java
@@ -167,10 +167,10 @@ public class AWSXRayRecorder {
         LambdaSegmentContextResolver lambdaSegmentContextResolver = new LambdaSegmentContextResolver();
         if (lambdaSegmentContextResolver.resolve() != null) {
             segmentContextResolverChain.addResolver(lambdaSegmentContextResolver);
+        } else {
+            segmentContextResolverChain.addResolver(new ThreadLocalSegmentContextResolver());
         }
         
-        segmentContextResolverChain.addResolver(new ThreadLocalSegmentContextResolver());
-
         segmentListeners = new ArrayList<>();
 
         awsRuntimeContext = new ConcurrentHashMap<>();

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -967,10 +967,6 @@ public class AWSXRayRecorderTest {
 
     @Test
     public void testMalformedTraceId() {
-        AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
-            .withSamplingStrategy(new NoSamplingStrategy())
-            .build();
-
         TraceHeader malformedHeader = TraceHeader.fromString("malformedTraceID");
 
         PowerMockito.stub(PowerMockito.method(
@@ -980,6 +976,10 @@ public class AWSXRayRecorderTest {
         PowerMockito.stub(PowerMockito.method(
                 LambdaSegmentContextResolver.class, "getLambdaTaskRoot"))
                 .toReturn("/var/task");
+
+        AWSXRayRecorder recorder = AWSXRayRecorderBuilder.standard()
+            .withSamplingStrategy(new NoSamplingStrategy())
+            .build();
 
         recorder.beginSubsegment("Test");
 


### PR DESCRIPTION
We can figure out the right SegmentContextResolver at init time since it should remain static throughout the lifetime of an application (we're either running within Lambda or we're not - it should never change). Trying to resolve through the resolver chain at runtime seems unnecessary. 

While typically it should not be very expensive to resolve both resolvers at runtime, I've noticed some performance overhead in environments where JSM (Java Security Manager) is enabled since the System.getenv() call that the LambdaSegmentContextResolver makes internally requires a permissions check (https://github.com/openjdk/jdk/blob/jdk-11%2B28/src/java.base/share/classes/java/lang/System.java#L991-L994) 

*Issue #, if available:*
N/A

*Description of changes:*
See above

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
