### PR TITLE
TracingInterceptor should take effect only one time

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
@@ -65,7 +65,8 @@ public class TracingInterceptor implements ExecutionInterceptor {
     public static final ExecutionAttribute<Subsegment> entityKey = new ExecutionAttribute("AWS X-Ray Entity");
 
     // Make sure only one xray interceptor takes effect.
-    private static final ExecutionAttribute<TracingInterceptor> XRAY_INTERCEPTOR_KEY = new ExecutionAttribute("AWS X-Ray Interceptor");
+    private static final ExecutionAttribute<TracingInterceptor> XRAY_INTERCEPTOR_KEY =
+            new ExecutionAttribute("AWS X-Ray Interceptor");
 
     private static final Log logger = LogFactory.getLog(TracingInterceptor.class);
 

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
@@ -17,6 +17,7 @@ package com.amazonaws.xray.interceptors;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -96,6 +97,44 @@ public class TracingInterceptorTest {
     @After
     public void teardown() {
         AWSXRay.endSegment();
+    }
+
+    @Test
+    public void testDuplicateInterceptor() throws Exception {
+        SdkHttpClient mockClient = mockSdkHttpClient(generateLambdaInvokeResponse(400));
+        LambdaClient client = lambdaClientDupInterceptor(mockClient);
+
+        Segment segment = AWSXRay.getCurrentSegment();
+        try {
+            client.invoke(InvokeRequest.builder()
+                    .functionName("testFunctionName")
+                    .build()
+            );
+        } catch (Exception e) {
+            // ignore SDK errors
+        } finally {
+            Assert.assertEquals(1, segment.getSubsegments().size());
+            Subsegment subsegment = segment.getSubsegments().get(0);
+            Map<String, Object> awsStats = subsegment.getAws();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> httpResponseStats = (Map<String, Object>) subsegment.getHttp().get("response");
+            Cause cause = subsegment.getCause();
+
+            Assert.assertEquals("Invoke", awsStats.get("operation"));
+            Assert.assertEquals("testFunctionName", awsStats.get("function_name"));
+            Assert.assertEquals("1111-2222-3333-4444", awsStats.get("request_id"));
+            Assert.assertEquals("extended", awsStats.get("id_2"));
+            Assert.assertEquals("us-west-42", awsStats.get("region"));
+            Assert.assertEquals(0, awsStats.get("retries"));
+            Assert.assertEquals(2L, httpResponseStats.get("content_length"));
+            Assert.assertEquals(400, httpResponseStats.get("status"));
+            Assert.assertEquals(false, subsegment.isInProgress());
+            Assert.assertEquals(true, subsegment.isError());
+            Assert.assertEquals(false, subsegment.isThrottle());
+            Assert.assertEquals(false, subsegment.isFault());
+            Assert.assertEquals(1, cause.getExceptions().size());
+            Assert.assertEquals(true, cause.getExceptions().get(0).isRemote());
+        }
     }
 
     @Test
@@ -490,7 +529,7 @@ public class TracingInterceptorTest {
 
         interceptor.modifyHttpRequest(context, attributes);
 
-        verify(mockRequest.toBuilder(), never()).appendHeader(anyString(), anyString());
+        verify(mockRequest.toBuilder(), never()).putHeader(anyString(), anyString());
     }
 
     @Test
@@ -655,6 +694,22 @@ public class TracingInterceptorTest {
                         AwsSessionCredentials.create("key", "secret", "session")
                 ))
                 .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .addExecutionInterceptor(new TracingInterceptor())
+                        .build()
+                )
+                .build();
+    }
+
+    private static LambdaClient lambdaClientDupInterceptor(SdkHttpClient mockClient) {
+        return LambdaClient.builder()
+                .httpClient(mockClient)
+                .endpointOverride(URI.create("http://example.com"))
+                .region(Region.of("us-west-42"))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsSessionCredentials.create("key", "secret", "session")
+                ))
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .addExecutionInterceptor(new TracingInterceptor())
                         .addExecutionInterceptor(new TracingInterceptor())
                         .build()
                 )

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/test/java/com/amazonaws/xray/interceptors/TracingInterceptorTest.java
@@ -17,7 +17,6 @@ package com.amazonaws.xray.interceptors;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
*Issue #, if available:*
It is possible for a customer to inadvertently introduce more than one X-Ray interceptor into the AWS SDK v2 client, resulting in:
1. Generating subsegments with duplicate data, such as retry and exception. Below is the example even there is no retry, but subsegment contains `retries : 1`
```
"subsegments": [
                            {
                                "id": "529b401c23f45c01",
                                "name": "SQS",
                                "start_time": 1709320615.891,
                                "end_time": 1709320616.678,
                                "http": {
                                    "response": {
                                        "status": 200,
                                        "content_length": 106
                                    }
                                },
                                "aws": {
                                    "retries": 1,
                                    "queue_url": "https://sqs.us-east-1.amazonaws.com/133818585968/sam-dev-zgaouett-FlexMonitoringSe-ItemReactionStateChangeHandlerQue-ASj2Usx3cSJZ",
                                    "message_id": "024c4942-9515-44bf-b6c1-a08ead6f342d",
                                    "region": "us-east-1",
                                    "operation": "SendMessage",
                                    "request_id": "7d9b6cb5-fc44-50dd-be7b-32e9d7ac7162",
                                    "resource_names": [
                                        "https://sqs.us-east-1.amazonaws.com/133818585968/sam-dev-zgaouett-FlexMonitoringSe-ItemReactionStateChangeHandlerQue-ASj2Usx3cSJZ"
                                    ]
                                },
                                "namespace": "aws"
                            }
                        ]
```
2. Injecting duplicate trace headers to downstream.
![Screenshot 2024-03-02 at 12 27 26 PM](https://github.com/aws/aws-xray-sdk-java/assets/66336933/be30b9ce-feda-451c-8f87-6735cdd29e43)






*Description of changes:*
The PR includes 2 changes:
1. Storing the address of the first XRay Interceptor in AWS SDK context, to make sure only one XRay Interceptor takes effect
2. Using `putHeader()` instead of `appendHeader()` in trace header injection, this ensures the request contains only one xray trace header value.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
