### PR TITLE
Bump aws-java-sdk-core version to 1.12.708

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     //  for resolution not only in the SDK projects but also in projects
     //  like benchmark.
     //  See PR for more details: https://github.com/aws/aws-xray-sdk-java/pull/336
-    api("com.amazonaws:aws-java-sdk-core:1.12.704")
+    api("com.amazonaws:aws-java-sdk-core:1.12.708")
 
     testImplementation("com.amazonaws:aws-java-sdk-lambda:1.12.228")
     testImplementation("com.amazonaws:aws-java-sdk-s3:1.12.228")

--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     //  for resolution not only in the SDK projects but also in projects
     //  like benchmark.
     //  See PR for more details: https://github.com/aws/aws-xray-sdk-java/pull/336
-    api("com.amazonaws:aws-java-sdk-core:1.12.228")
+    api("com.amazonaws:aws-java-sdk-core:1.12.704")
 
     testImplementation("com.amazonaws:aws-java-sdk-lambda:1.12.228")
     testImplementation("com.amazonaws:aws-java-sdk-s3:1.12.228")


### PR DESCRIPTION
Bumping up the `aws-java-sdk-core` version to 1.12.708 ([latest as of 04/25/2024](https://central.sonatype.com/artifact/com.amazonaws/aws-java-sdk-core/1.12.708/versions)) to update/remove the following transitive dependencies as vulnerabilities have been reported for them.
- joda-time:jar:2.8.1
- on-java:jar:1.0.2


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
