### PR TITLE
[Lambda] Send NoOp segment when trace header is incomplete

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -23,7 +23,6 @@ import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.SubsegmentImpl;
 import com.amazonaws.xray.entities.TraceHeader;
-import com.amazonaws.xray.entities.TraceHeader.SampleDecision;
 import com.amazonaws.xray.entities.TraceID;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
 import com.amazonaws.xray.listeners.SegmentListener;
@@ -36,14 +35,14 @@ public class LambdaSegmentContext implements SegmentContext {
     private static final Log logger = LogFactory.getLog(LambdaSegmentContext.class);
 
     private static final String LAMBDA_TRACE_HEADER_KEY = "_X_AMZN_TRACE_ID";
-    
+
     // See: https://github.com/aws/aws-xray-sdk-java/issues/251
     private static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
 
     private static TraceHeader getTraceHeaderFromEnvironment() {
         String lambdaTraceHeaderKey = System.getenv(LAMBDA_TRACE_HEADER_KEY);
-        return TraceHeader.fromString(lambdaTraceHeaderKey != null && lambdaTraceHeaderKey.length() > 0 
-            ? lambdaTraceHeaderKey 
+        return TraceHeader.fromString(lambdaTraceHeaderKey != null && lambdaTraceHeaderKey.length() > 0
+            ? lambdaTraceHeaderKey
             : System.getProperty(LAMBDA_TRACE_HEADER_PROP));
     }
 
@@ -67,7 +66,12 @@ public class LambdaSegmentContext implements SegmentContext {
                 }
                 parentSegment = Segment.noOp(TraceID.create(recorder), recorder);
             } else {
-                parentSegment = new FacadeSegment(recorder, traceHeader.getRootTraceId(), traceHeader.getParentId(), traceHeader.getSampled());
+                parentSegment = new FacadeSegment(
+                    recorder,
+                    traceHeader.getRootTraceId(),
+                    traceHeader.getParentId(),
+                    traceHeader.getSampled()
+                );
             }
 
             boolean isRecording = parentSegment.isRecording();
@@ -145,8 +149,7 @@ public class LambdaSegmentContext implements SegmentContext {
                     current.getCreator().getEmitter().sendSubsegment((Subsegment) current);
                 }
                 clearTraceEntity();
-            }
-            else if (parentEntity instanceof NoOpSegment) {
+            } else if (parentEntity instanceof NoOpSegment) {
                 clearTraceEntity();
             } else {
                 setTraceEntity(current.getParent());

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -60,9 +60,15 @@ public class LambdaSegmentContext implements SegmentContext {
         TraceHeader traceHeader = LambdaSegmentContext.getTraceHeaderFromEnvironment();
         Entity entity = getTraceEntity();
         if (entity == null) { // First subsegment of a subsegment branch
-            Segment parentSegment = isInitializing(traceHeader)
-                ? Segment.noOp(TraceID.create(recorder), recorder)
-                : new FacadeSegment(recorder, traceHeader.getRootTraceId(), traceHeader.getParentId(), traceHeader.getSampled());
+            Segment parentSegment;
+            if (isInitializing(traceHeader)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Creating No-Op parent segment");
+                }
+                parentSegment = Segment.noOp(TraceID.create(recorder), recorder);
+            } else {
+                parentSegment = new FacadeSegment(recorder, traceHeader.getRootTraceId(), traceHeader.getParentId(), traceHeader.getSampled());
+            }
 
             boolean isRecording = parentSegment.isRecording();
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-class NoOpSegment implements Segment {
+public class NoOpSegment implements Segment {
 
     private final TraceID traceId;
     private final AWSXRayRecorder creator;

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
@@ -50,8 +50,10 @@ class LambdaSegmentContextTest {
 
     private static final String MALFORMED_TRACE_HEADER =
         ";;Root=1-57ff426a-80c11c39b0c928905eb0828d;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
-    private static final String MALFORMED_TRACE_HEADER_2 =
-        ";;root-missing;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
+    private static final String MALFORMED_TRACE_HEADER_2 = ";;root-missing;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
+
+    private static final String ROOT_LAMBDA_PASSTHROUGH_TRACE_HEADER =
+        "Root=1-5759e988-bd862e3fe1be46a994272711;Lineage=10:1234abcd:3";
 
     @BeforeEach
     public void setupAWSXRay() {
@@ -91,6 +93,12 @@ class LambdaSegmentContextTest {
     @Test
     @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = MALFORMED_TRACE_HEADER_2)
     void testBeginSubsegmentWithIncompleteAndMalformedTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = ROOT_LAMBDA_PASSTHROUGH_TRACE_HEADER)
+    void testBeginSubsegmentWithRootLambdaPassthroughTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
         testContextResultsInNoOpSegmentParent();
     }
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
@@ -22,6 +22,7 @@ import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.emitters.Emitter;
 import com.amazonaws.xray.entities.FacadeSegment;
+import com.amazonaws.xray.entities.NoOpSegment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
 import com.amazonaws.xray.strategy.LogErrorContextMissingStrategy;
@@ -49,6 +50,8 @@ class LambdaSegmentContextTest {
 
     private static final String MALFORMED_TRACE_HEADER =
         ";;Root=1-57ff426a-80c11c39b0c928905eb0828d;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
+    private static final String MALFORMED_TRACE_HEADER_2 =
+        ";;root-missing;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
 
     @BeforeEach
     public void setupAWSXRay() {
@@ -63,14 +66,14 @@ class LambdaSegmentContextTest {
     }
 
     @Test
-    void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
-        testContextResultsInFacadeSegmentParent();
+    void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
     }
 
     @Test
     @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = "a")
-    void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
-        testContextResultsInFacadeSegmentParent();
+    void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
     }
 
     @Test
@@ -83,6 +86,12 @@ class LambdaSegmentContextTest {
     @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = MALFORMED_TRACE_HEADER)
     void testBeginSubsegmentWithCompleteButMalformedTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
         testContextResultsInFacadeSegmentParent();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = MALFORMED_TRACE_HEADER_2)
+    void testBeginSubsegmentWithIncompleteAndMalformedTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
     }
 
     @Test
@@ -146,6 +155,14 @@ class LambdaSegmentContextTest {
         LambdaSegmentContext mockContext = new LambdaSegmentContext();
         assertThat(mockContext.beginSubsegment(AWSXRay.getGlobalRecorder(), "test").getParent())
             .isInstanceOf(FacadeSegment.class);
+        mockContext.endSubsegment(AWSXRay.getGlobalRecorder());
+        assertThat(AWSXRay.getTraceEntity()).isNull();
+    }
+
+    private static void testContextResultsInNoOpSegmentParent() {
+        LambdaSegmentContext mockContext = new LambdaSegmentContext();
+        assertThat(mockContext.beginSubsegment(AWSXRay.getGlobalRecorder(), "test").getParent())
+            .isInstanceOf(NoOpSegment.class);
         mockContext.endSubsegment(AWSXRay.getGlobalRecorder());
         assertThat(AWSXRay.getTraceEntity()).isNull();
     }


### PR DESCRIPTION
When using Lambda, if there is no trace header or an invalid one we would like to send a NoOp segment instead of a Facade segment so that customers can call X-Ray SDK APIs and utilize X-Ray SDK without any output. This will not send data to X-Ray nor inject X-Ray trace headers downstream.

*Description of changes:*
- Modify condition to create a NoOp segment when trace header is "initializing", i.e. it is incomplete
- Ensure trace entity is cleared when ending the segment
- Make `NoOpSegment` public for the above changes
- Update unit tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
