### PR TITLE
add xray sdk language and version in subsegment from Lambda environment

### DIFF
--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -80,6 +80,7 @@ public class LambdaSegmentContext implements SegmentContext {
                     ? new SubsegmentImpl(recorder, name, parentSegment)
                     : Subsegment.noOp(parentSegment, recorder);
             subsegment.setParent(parentSegment);
+            subsegment.putAllAws(recorder.getAwsRuntimeContext());
             // Enable FacadeSegment to keep track of its subsegments for subtree streaming
             parentSegment.addSubsegment(subsegment);
             setTraceEntity(subsegment);

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/AWSXRayRecorderTest.java
@@ -341,7 +341,7 @@ public class AWSXRayRecorderTest {
 
         JSONAssert.assertEquals(expectedLambdaSubsegment(
             header.getRootTraceId(), header.getParentId(), captured.getId(), captured.getStartTime(),
-            captured.getEndTime()).toString(), captured.streamSerialize(), JSONCompareMode.NON_EXTENSIBLE);
+            captured.getEndTime()).toString(), captured.streamSerialize(), JSONCompareMode.LENIENT);
     }
 
     @Test

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
@@ -122,6 +122,18 @@ class LambdaSegmentContextTest {
         assertThatThrownBy(AWSXRay::endSubsegment).isInstanceOf(SubsegmentNotFoundException.class);
     }
 
+    @Test
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = TRACE_HEADER)
+    void testSampledSetsAwsXRaySdkVersionToSubsegment() {
+        LambdaSegmentContext lsc = new LambdaSegmentContext();
+        Subsegment subseg1 = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test");
+        Subsegment subseg2 = lsc.beginSubsegment(AWSXRay.getGlobalRecorder(), "test2");
+        assertThat(subseg1.getAws().get("xray")).isNotNull();
+        assertThat(subseg2.getAws().get("xray")).isNull();
+        lsc.endSubsegment(AWSXRay.getGlobalRecorder());
+        lsc.endSubsegment(AWSXRay.getGlobalRecorder());
+    }
+
     // We create segments twice with different environment variables for the same context, similar to how Lambda would invoke
     // a function.
     @Nested


### PR DESCRIPTION
*Issue #, if available:*
X-Ray Segments have X-Ray SDK and version information in field `aws: {xray {}}`(refer to [code](https://github.com/aws/aws-xray-sdk-java/blob/master/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/AWSXRayRecorder.java#L502)), but in AWS Lambda environment there is only Subsegment can be generated. Customer does not know the xray sdk version by checking trace from xray console.


*Description of changes:*
Appending xray sdk info into the first subsegment generated in each Lambda invocation.

```
     aws": {
                    "xray": {
                        "sdk_version": "2.16.0",
                        "sdk": "X-Ray for Java"
                    }
                },
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
