### PR TITLE
Support Lambda PassThrough trace header propagation

### DIFF
--- a/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
+++ b/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
@@ -18,7 +18,7 @@ package com.amazonaws.xray.proxies.apache.http;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Namespace;
-import com.amazonaws.xray.entities.NoOpSubSegment;
+import com.amazonaws.xray.entities.NoOpSegment;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
@@ -107,7 +107,7 @@ public class TracedHttpClient extends CloseableHttpClient {
         if (subsegment.shouldPropagate()) {
             // If no-op, only propagate root trace ID to not taint sampling decision
             TraceHeader t = TraceHeader.fromEntity(subsegment);
-            if (subsegment instanceof NoOpSubSegment) {
+            if (parentSegment instanceof NoOpSegment) {
                 request.addHeader(
                         TraceHeader.HEADER_KEY,
                         "Root=" + t.getRootTraceId().toString());

--- a/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
+++ b/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
@@ -104,7 +104,16 @@ public class TracedHttpClient extends CloseableHttpClient {
         Segment parentSegment = subsegment.getParentSegment();
 
         if (subsegment.shouldPropagate()) {
-            request.addHeader(TraceHeader.HEADER_KEY, TraceHeader.fromEntity(subsegment).toString());
+            // If the trace is not sampled, passing Parent and Sampled won't matter
+            TraceHeader t = TraceHeader.fromEntity(subsegment);
+            if (t.getSampled() != TraceHeader.SampleDecision.SAMPLED) {
+                request.addHeader(
+                        TraceHeader.HEADER_KEY,
+                        "Root=" + t.getRootTraceId().toString());
+            } else {
+                // This will propagate Parent and Sampled
+                request.addHeader(TraceHeader.HEADER_KEY, TraceHeader.fromEntity(subsegment).toString());
+            }
         }
 
         Map<String, Object> requestInformation = new HashMap<>();

--- a/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
+++ b/aws-xray-recorder-sdk-apache-http/src/main/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClient.java
@@ -18,6 +18,7 @@ package com.amazonaws.xray.proxies.apache.http;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Namespace;
+import com.amazonaws.xray.entities.NoOpSubSegment;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
@@ -104,15 +105,15 @@ public class TracedHttpClient extends CloseableHttpClient {
         Segment parentSegment = subsegment.getParentSegment();
 
         if (subsegment.shouldPropagate()) {
-            // If the trace is not sampled, passing Parent and Sampled won't matter
+            // If no-op, only propagate root trace ID to not taint sampling decision
             TraceHeader t = TraceHeader.fromEntity(subsegment);
-            if (t.getSampled() != TraceHeader.SampleDecision.SAMPLED) {
+            if (subsegment instanceof NoOpSubSegment) {
                 request.addHeader(
                         TraceHeader.HEADER_KEY,
                         "Root=" + t.getRootTraceId().toString());
             } else {
                 // This will propagate Parent and Sampled
-                request.addHeader(TraceHeader.HEADER_KEY, TraceHeader.fromEntity(subsegment).toString());
+                request.addHeader(TraceHeader.HEADER_KEY, t.toString());
             }
         }
 

--- a/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
+++ b/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
@@ -114,7 +114,7 @@ public class TracedHttpClientTest {
 
         verify(getRequestedFor(urlPathEqualTo("/"))
                    .withHeader(TraceHeader.HEADER_KEY,
-                               equalTo("Root=1-67891233-abcdef012345678912345678")));
+                               equalTo("Root=1-67891233-abcdef012345678912345678;Sampled=0")));
     }
 
     @Test

--- a/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
+++ b/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -114,7 +115,7 @@ public class TracedHttpClientTest {
 
         verify(getRequestedFor(urlPathEqualTo("/"))
                    .withHeader(TraceHeader.HEADER_KEY,
-                               equalTo("Root=1-67891233-abcdef012345678912345678;Sampled=0")));
+                               matching("Root=1-67891233-abcdef012345678912345678;Parent=[a-z0-9]{16};Sampled=0")));
     }
 
     @Test

--- a/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
+++ b/aws-xray-recorder-sdk-apache-http/src/test/java/com/amazonaws/xray/proxies/apache/http/TracedHttpClientTest.java
@@ -99,7 +99,7 @@ public class TracedHttpClientTest {
 
         verify(getRequestedFor(urlPathEqualTo("/"))
                    .withHeader(TraceHeader.HEADER_KEY,
-                               equalTo("Root=1-00000000-000000000000000000000000;Sampled=0")));
+                               equalTo("Root=1-00000000-000000000000000000000000")));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class TracedHttpClientTest {
 
         verify(getRequestedFor(urlPathEqualTo("/"))
                    .withHeader(TraceHeader.HEADER_KEY,
-                               equalTo("Root=1-67891233-abcdef012345678912345678;Sampled=0")));
+                               equalTo("Root=1-67891233-abcdef012345678912345678")));
     }
 
     @Test

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
@@ -21,7 +21,7 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.EntityDataKeys;
 import com.amazonaws.xray.entities.EntityHeaderKeys;
 import com.amazonaws.xray.entities.Namespace;
-import com.amazonaws.xray.entities.NoOpSubSegment;
+import com.amazonaws.xray.entities.NoOpSegment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.handlers.config.AWSOperationHandler;
@@ -299,7 +299,7 @@ public class TracingInterceptor implements ExecutionInterceptor {
 
         // If no-op, only propagate root trace ID to not taint sampling decision
         TraceHeader t = TraceHeader.fromEntity(subsegment);
-        if (subsegment instanceof NoOpSubSegment) {
+        if (subsegment.getParentSegment() instanceof NoOpSegment) {
             return httpRequest.toBuilder().putHeader(
                     TraceHeader.HEADER_KEY,
                     "Root=" + t.getRootTraceId().toString()).build();

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
@@ -21,6 +21,7 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.EntityDataKeys;
 import com.amazonaws.xray.entities.EntityHeaderKeys;
 import com.amazonaws.xray.entities.Namespace;
+import com.amazonaws.xray.entities.NoOpSubSegment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.handlers.config.AWSOperationHandler;
@@ -296,9 +297,9 @@ public class TracingInterceptor implements ExecutionInterceptor {
             return httpRequest;
         }
 
-        // If the trace is not sampled, passing Parent and Sampled won't matter
+        // If no-op, only propagate root trace ID to not taint sampling decision
         TraceHeader t = TraceHeader.fromEntity(subsegment);
-        if (t.getSampled() != TraceHeader.SampleDecision.SAMPLED) {
+        if (subsegment instanceof NoOpSubSegment) {
             return httpRequest.toBuilder().putHeader(
                     TraceHeader.HEADER_KEY,
                     "Root=" + t.getRootTraceId().toString()).build();
@@ -307,7 +308,7 @@ public class TracingInterceptor implements ExecutionInterceptor {
         // This will propagate Parent and Sampled
         return httpRequest.toBuilder().putHeader(
                 TraceHeader.HEADER_KEY,
-                TraceHeader.fromEntity(subsegment).toString()).build();
+                t.toString()).build();
     }
 
     @Override

--- a/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
+++ b/aws-xray-recorder-sdk-aws-sdk-v2/src/main/java/com/amazonaws/xray/interceptors/TracingInterceptor.java
@@ -296,6 +296,15 @@ public class TracingInterceptor implements ExecutionInterceptor {
             return httpRequest;
         }
 
+        // If the trace is not sampled, passing Parent and Sampled won't matter
+        TraceHeader t = TraceHeader.fromEntity(subsegment);
+        if (t.getSampled() != TraceHeader.SampleDecision.SAMPLED) {
+            return httpRequest.toBuilder().putHeader(
+                    TraceHeader.HEADER_KEY,
+                    "Root=" + t.getRootTraceId().toString()).build();
+        }
+
+        // This will propagate Parent and Sampled
         return httpRequest.toBuilder().putHeader(
                 TraceHeader.HEADER_KEY,
                 TraceHeader.fromEntity(subsegment).toString()).build();

--- a/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
@@ -192,7 +192,16 @@ public class TracingHandler extends RequestHandler2 {
         currentSubsegment.setNamespace(Namespace.AWS.toString());
 
         if (recorder.getCurrentSegment() != null && recorder.getCurrentSubsegment().shouldPropagate()) {
-            request.addHeader(TraceHeader.HEADER_KEY, TraceHeader.fromEntity(currentSubsegment).toString());
+            // If the trace is not sampled, passing Parent and Sampled won't matter
+            TraceHeader t = TraceHeader.fromEntity(currentSubsegment);
+            if (t.getSampled() != TraceHeader.SampleDecision.SAMPLED) {
+                request.addHeader(
+                        TraceHeader.HEADER_KEY,
+                        "Root=" + t.getRootTraceId().toString());
+            } else {
+                // This will propagate Parent and Sampled
+                request.addHeader(TraceHeader.HEADER_KEY, TraceHeader.fromEntity(currentSubsegment).toString());
+            }
         }
     }
 

--- a/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
@@ -31,6 +31,7 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.EntityDataKeys;
 import com.amazonaws.xray.entities.EntityHeaderKeys;
 import com.amazonaws.xray.entities.Namespace;
+import com.amazonaws.xray.entities.NoOpSubSegment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.handlers.config.AWSOperationHandler;
@@ -192,15 +193,15 @@ public class TracingHandler extends RequestHandler2 {
         currentSubsegment.setNamespace(Namespace.AWS.toString());
 
         if (recorder.getCurrentSegment() != null && recorder.getCurrentSubsegment().shouldPropagate()) {
-            // If the trace is not sampled, passing Parent and Sampled won't matter
+            // If no-op, only propagate root trace ID to not taint sampling decision
             TraceHeader t = TraceHeader.fromEntity(currentSubsegment);
-            if (t.getSampled() != TraceHeader.SampleDecision.SAMPLED) {
+            if (currentSubsegment instanceof NoOpSubSegment) {
                 request.addHeader(
                         TraceHeader.HEADER_KEY,
                         "Root=" + t.getRootTraceId().toString());
             } else {
                 // This will propagate Parent and Sampled
-                request.addHeader(TraceHeader.HEADER_KEY, TraceHeader.fromEntity(currentSubsegment).toString());
+                request.addHeader(TraceHeader.HEADER_KEY, t.toString());
             }
         }
     }

--- a/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/main/java/com/amazonaws/xray/handlers/TracingHandler.java
@@ -31,7 +31,7 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.EntityDataKeys;
 import com.amazonaws.xray.entities.EntityHeaderKeys;
 import com.amazonaws.xray.entities.Namespace;
-import com.amazonaws.xray.entities.NoOpSubSegment;
+import com.amazonaws.xray.entities.NoOpSegment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
 import com.amazonaws.xray.handlers.config.AWSOperationHandler;
@@ -195,7 +195,7 @@ public class TracingHandler extends RequestHandler2 {
         if (recorder.getCurrentSegment() != null && recorder.getCurrentSubsegment().shouldPropagate()) {
             // If no-op, only propagate root trace ID to not taint sampling decision
             TraceHeader t = TraceHeader.fromEntity(currentSubsegment);
-            if (currentSubsegment instanceof NoOpSubSegment) {
+            if (currentSubsegment.getParentSegment() instanceof NoOpSegment) {
                 request.addHeader(
                         TraceHeader.HEADER_KEY,
                         "Root=" + t.getRootTraceId().toString());

--- a/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
@@ -137,10 +137,12 @@ public class TracingHandlerLambdaTest {
         TraceHeader traceHeader = TraceHeader.fromString(request.getHeaders().get(TraceHeader.HEADER_KEY));
         String serviceEntityId = recorder.getCurrentSubsegment().getId();
 
-        assertThat(traceHeader.getSampled()).isEqualTo(
-                subsegment.isSampled() ?
-                        TraceHeader.SampleDecision.SAMPLED :
-                        TraceHeader.SampleDecision.NOT_SAMPLED);
+        if (subsegment.isSampled()) {
+            assertThat(traceHeader.getSampled()).isEqualTo(TraceHeader.SampleDecision.SAMPLED);
+        } else {
+            // Can't assert non-initialized variable to null, assert absence instead
+            assertThat(traceHeader.toString()).doesNotContain("Sampled=");
+        }
         assertThat(traceHeader.getRootTraceId()).isEqualTo(subsegment.getTraceId());
         assertThat(traceHeader.getParentId()).isEqualTo(subsegment.isSampled() ? serviceEntityId : null);
 

--- a/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
+++ b/aws-xray-recorder-sdk-aws-sdk/src/test/java/com/amazonaws/xray/handlers/TracingHandlerLambdaTest.java
@@ -137,14 +137,15 @@ public class TracingHandlerLambdaTest {
         TraceHeader traceHeader = TraceHeader.fromString(request.getHeaders().get(TraceHeader.HEADER_KEY));
         String serviceEntityId = recorder.getCurrentSubsegment().getId();
 
-        if (subsegment.isSampled()) {
-            assertThat(traceHeader.getSampled()).isEqualTo(TraceHeader.SampleDecision.SAMPLED);
-        } else {
-            // Can't assert non-initialized variable to null, assert absence instead
-            assertThat(traceHeader.toString()).doesNotContain("Sampled=");
-        }
+        assertThat(traceHeader.getSampled()).isEqualTo(
+                subsegment.isSampled() ?
+                        TraceHeader.SampleDecision.SAMPLED :
+                        TraceHeader.SampleDecision.NOT_SAMPLED);
         assertThat(traceHeader.getRootTraceId()).isEqualTo(subsegment.getTraceId());
-        assertThat(traceHeader.getParentId()).isEqualTo(subsegment.isSampled() ? serviceEntityId : null);
+        assertThat(traceHeader.getParentId()).isEqualTo(
+                subsegment.isSampled() ?
+                        serviceEntityId :
+                        subsegment.getParentSegment().getId());
 
         tracingHandler.afterResponse(request, new Response(new InvokeResult(), new HttpResponse(request, null)));
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -55,12 +55,14 @@ public class LambdaSegmentContext implements SegmentContext {
         }
 
         TraceHeader traceHeader = LambdaSegmentContext.getTraceHeaderFromEnvironment();
+        logger.warn("TRACE HEADER IN CODE: " + traceHeader.toString());
         Entity entity = getTraceEntity();
         if (entity == null) { // First subsegment of a subsegment branch
             Segment parentSegment;
             // Trace header either takes the structure `Root=...;<extra-data>` or
             // `Root=...;Parent=...;Sampled=...;<extra-data>`
             if (traceHeader.getRootTraceId() != null && traceHeader.getParentId() != null && traceHeader.getSampled() != null) {
+                logger.warn("CREATING FACADE SEGMENT");
                 parentSegment = new FacadeSegment(
                     recorder,
                     traceHeader.getRootTraceId(),

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/contexts/LambdaSegmentContext.java
@@ -18,11 +18,11 @@ package com.amazonaws.xray.contexts;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.FacadeSegment;
+import com.amazonaws.xray.entities.NoOpSegment;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.SubsegmentImpl;
 import com.amazonaws.xray.entities.TraceHeader;
-import com.amazonaws.xray.entities.TraceHeader.SampleDecision;
 import com.amazonaws.xray.entities.TraceID;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
 import com.amazonaws.xray.listeners.SegmentListener;
@@ -39,36 +39,44 @@ public class LambdaSegmentContext implements SegmentContext {
     // See: https://github.com/aws/aws-xray-sdk-java/issues/251
     private static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
 
-    private static TraceHeader getTraceHeaderFromEnvironment() {
+    public static TraceHeader getTraceHeaderFromEnvironment() {
         String lambdaTraceHeaderKey = System.getenv(LAMBDA_TRACE_HEADER_KEY);
         return TraceHeader.fromString(lambdaTraceHeaderKey != null && lambdaTraceHeaderKey.length() > 0 
             ? lambdaTraceHeaderKey 
             : System.getProperty(LAMBDA_TRACE_HEADER_PROP));
     }
 
-    private static boolean isInitializing(TraceHeader traceHeader) {
-        return traceHeader.getRootTraceId() == null || traceHeader.getSampled() == null || traceHeader.getParentId() == null;
-    }
-
-    private static FacadeSegment newFacadeSegment(AWSXRayRecorder recorder, String name) {
-        TraceHeader traceHeader = getTraceHeaderFromEnvironment();
-        if (isInitializing(traceHeader)) {
-            logger.warn(LAMBDA_TRACE_HEADER_KEY + " is missing a trace ID, parent ID, or sampling decision. Subsegment "
-                        + name + " discarded.");
-            return new FacadeSegment(recorder, TraceID.create(recorder), "", SampleDecision.NOT_SAMPLED);
-        }
-        return new FacadeSegment(recorder, traceHeader.getRootTraceId(), traceHeader.getParentId(), traceHeader.getSampled());
-    }
-
+    // SuppressWarnings is needed for passing Root TraceId to noOp segment
+    @SuppressWarnings("nullness")
     @Override
     public Subsegment beginSubsegment(AWSXRayRecorder recorder, String name) {
         if (logger.isDebugEnabled()) {
             logger.debug("Beginning subsegment named: " + name);
         }
 
+        TraceHeader traceHeader = LambdaSegmentContext.getTraceHeaderFromEnvironment();
         Entity entity = getTraceEntity();
-        if (entity == null) { // First subsgment of a subsegment branch.
-            Segment parentSegment = newFacadeSegment(recorder, name);
+        if (entity == null) { // First subsegment of a subsegment branch
+            Segment parentSegment;
+            // We rely on the AWS SDK to propagate one or both of these
+            // It is therefore possible to get just Root, or Root and Parent
+            if (traceHeader.getRootTraceId() != null) {
+                if (traceHeader.getParentId() != null) {
+                    parentSegment = new FacadeSegment(
+                        recorder,
+                        traceHeader.getRootTraceId(),
+                        traceHeader.getParentId(),
+                        traceHeader.getSampled());
+                } else {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Creating No-Op parent segment");
+                    }
+                    TraceID t = traceHeader.getRootTraceId();
+                    parentSegment = Segment.noOp(t, recorder);
+                }
+            } else {
+                parentSegment = Segment.noOp(TraceID.create(recorder), recorder);
+            }
 
             boolean isRecording = parentSegment.isRecording();
 
@@ -144,6 +152,8 @@ public class LambdaSegmentContext implements SegmentContext {
                 if (((Subsegment) current).isSampled()) {
                     current.getCreator().getEmitter().sendSubsegment((Subsegment) current);
                 }
+                clearTraceEntity();
+            } else if (parentEntity instanceof NoOpSegment) {
                 clearTraceEntity();
             } else {
                 setTraceEntity(current.getParent());

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSegment.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-class NoOpSegment implements Segment {
+public class NoOpSegment implements Segment {
 
     private final TraceID traceId;
     private final AWSXRayRecorder creator;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-class NoOpSubSegment implements Subsegment {
+public class NoOpSubSegment implements Subsegment {
     private final Segment parentSegment;
     private final AWSXRayRecorder creator;
     private final boolean shouldPropagate;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/NoOpSubSegment.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class NoOpSubSegment implements Subsegment {
+class NoOpSubSegment implements Subsegment {
     private final Segment parentSegment;
     private final AWSXRayRecorder creator;
     private final boolean shouldPropagate;

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
@@ -92,9 +92,16 @@ public class TraceHeader {
     }
 
     public static TraceHeader fromEntity(Entity entity) {
+        String parentId = null;
+        if (entity instanceof Subsegment) {
+            Segment segment = entity.getParentSegment();
+            if (segment != null) {
+                parentId = segment.getId();
+            }
+        }
         return new TraceHeader(
                 entity.getTraceId(),
-                entity.isSampled() ? entity.getId() : null,
+                entity.isSampled() ? entity.getId() : parentId,
                 entity.isSampled() ? SampleDecision.SAMPLED : SampleDecision.NOT_SAMPLED);
     }
 

--- a/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
+++ b/aws-xray-recorder-sdk-core/src/main/java/com/amazonaws/xray/entities/TraceHeader.java
@@ -101,7 +101,7 @@ public class TraceHeader {
         }
         return new TraceHeader(
                 entity.getTraceId(),
-                entity.isSampled() ? entity.getId() : parentId,
+                (entity.getId() == null || entity.getId() == "") ? parentId : entity.getId(),
                 entity.isSampled() ? SampleDecision.SAMPLED : SampleDecision.NOT_SAMPLED);
     }
 

--- a/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
+++ b/aws-xray-recorder-sdk-core/src/test/java/com/amazonaws/xray/contexts/LambdaSegmentContextTest.java
@@ -22,6 +22,7 @@ import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.emitters.Emitter;
 import com.amazonaws.xray.entities.FacadeSegment;
+import com.amazonaws.xray.entities.NoOpSegment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.exceptions.SubsegmentNotFoundException;
 import com.amazonaws.xray.strategy.LogErrorContextMissingStrategy;
@@ -49,6 +50,10 @@ class LambdaSegmentContextTest {
 
     private static final String MALFORMED_TRACE_HEADER =
         ";;Root=1-57ff426a-80c11c39b0c928905eb0828d;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
+    private static final String MALFORMED_TRACE_HEADER_2 = ";;root-missing;;Parent=1234abcd1234abcd;;;Sampled=1;;;";
+
+    private static final String ROOT_LAMBDA_PASSTHROUGH_TRACE_HEADER =
+        "Root=1-5759e988-bd862e3fe1be46a994272711;Lineage=10:1234abcd:3";
 
     @BeforeEach
     public void setupAWSXRay() {
@@ -63,14 +68,14 @@ class LambdaSegmentContextTest {
     }
 
     @Test
-    void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
-        testContextResultsInFacadeSegmentParent();
+    void testBeginSubsegmentWithNullTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
     }
 
     @Test
     @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = "a")
-    void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
-        testContextResultsInFacadeSegmentParent();
+    void testBeginSubsegmentWithIncompleteTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
     }
 
     @Test
@@ -83,6 +88,18 @@ class LambdaSegmentContextTest {
     @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = MALFORMED_TRACE_HEADER)
     void testBeginSubsegmentWithCompleteButMalformedTraceHeaderEnvironmentVariableResultsInAFacadeSegmentParent() {
         testContextResultsInFacadeSegmentParent();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = MALFORMED_TRACE_HEADER_2)
+    void testBeginSubsegmentWithIncompleteAndMalformedTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "_X_AMZN_TRACE_ID", value = ROOT_LAMBDA_PASSTHROUGH_TRACE_HEADER)
+    void testBeginSubsegmentWithRootLambdaPassthroughTraceHeaderEnvironmentVariableResultsInANoOpSegmentParent() {
+        testContextResultsInNoOpSegmentParent();
     }
 
     @Test
@@ -146,6 +163,14 @@ class LambdaSegmentContextTest {
         LambdaSegmentContext mockContext = new LambdaSegmentContext();
         assertThat(mockContext.beginSubsegment(AWSXRay.getGlobalRecorder(), "test").getParent())
             .isInstanceOf(FacadeSegment.class);
+        mockContext.endSubsegment(AWSXRay.getGlobalRecorder());
+        assertThat(AWSXRay.getTraceEntity()).isNull();
+    }
+
+    private static void testContextResultsInNoOpSegmentParent() {
+        LambdaSegmentContext mockContext = new LambdaSegmentContext();
+        assertThat(mockContext.beginSubsegment(AWSXRay.getGlobalRecorder(), "test").getParent())
+            .isInstanceOf(NoOpSegment.class);
         mockContext.endSubsegment(AWSXRay.getGlobalRecorder());
         assertThat(AWSXRay.getTraceEntity()).isNull();
     }


### PR DESCRIPTION
## Issue

Lambda is implementing PassThrough mode which allows customers to send traces through instrumented lambda functions without those functions being traced. The way this is done is by changing the trace header structure from `Root=...;Parent=...;Sampled=1` in the active tracing case to `Root=...` in the PassThrough case. As such, our SDK needs to be updated to handle this.

## Changes

- Update logic to use no-op segment if parent and sampled are missing (ie. PassThrough mode)
  - Had to use `SuppressWarnings("nullness")` because `TraceHeader.getRootTraceId()` returns an `@Nullable TraceId` but `Segment.noOp()` expects a `@NonNull TraceId`
- Update all trace header propagations to only propagate `Root` if we're not actively sampling
  - Not propagating Parent and Sampled is fine because Parent will be re-generated in the next traced context and missing Sampled will be treated as not actively sampling anyways
  - We can't propagate only one of these, it needs to be either both or neither
- Updated unit tests

## Testing

Ran many extensive tests using v2.16.0, v2.17.0, and these changes to compare the outcomes. In these tests I configured 3 lambda functions to interact with each other ALL instrumented with the new changes:
- Lambda A: Calls Lambda B
- Lambda B: Calls Lambda C
- Lambda C: Calls `GetAccountSettings`

***The trace headers in the below cases are from logging `System.getenv("_X_AMZN_TRACE_ID")` in the lambda functions themselves***

The following are some important cases that prove the functionality of the code change

### Case 1.a: Lambda A Active &rarr; Lambda B PassThrough &rarr; Lambda C Active
- Lineage is NOT propagated or received by any of these functions
- Lambda B has an inferred node due to the invocation in Lambda A which is actively traced, this is expected behaviour and not controlled by the SDK
- Lambda B function is being appropriately suppressed aside from the previous note
- Lambda C invocation is appropriately connected to the Lambda A function

```
A: Root=1-66abd797-167a78c02dcfeb4551890716;Parent=ad075ec25766d3f9;Sampled=1;Lineage=456f6a97:0
B: Root=1-66abd797-167a78c02dcfeb4551890716;Parent=57696313aea6f4a2;Sampled=1;Lineage=8408dcb0:0
C: Root=1-66abd797-167a78c02dcfeb4551890716;Parent=710d6393cf68bccc;Sampled=1;Lineage=7d2b6fd0:0
```
![Image](https://github.com/user-attachments/assets/61bddce9-5577-41c5-b122-0b9e20acf9e8)

### Case 1.b: Same thing but Lambda A Active sets `Sampled=0`
- Lineage is NOT propagated or received by any of the functions
- No trace is generated
- Lambda A, B, and C all have Sampled=0
- Lambda C appropriately changes Parent as expected, as it is actively traced, but still maintains the Sampled=0

```
A: Root=1-66b32340-6a4114ff44ca3e5240b1ac5b;Parent=63033870537134cd;Sampled=0;Lineage=456f6a97:0
B: Root=1-66b32340-6a4114ff44ca3e5240b1ac5b;Parent=63033870537134cd;Sampled=0;Lineage=8408dcb0:0
C: Root=1-66b32340-6a4114ff44ca3e5240b1ac5b;Parent=71d11ee442af5530;Sampled=0;Lineage=7d2b6fd0:0
```

### Case 2: Lambda A PassThrough &rarr; Lambda B Active &rarr; Lambda C PassThrough
- Lineage is NOT propagated or received by any of these functions
- Lambda B is the start of the trace as expected
- Lambda C invocation is still attached to Lambda B as an inferred node (similar to case 1)
- Lambda C's `GetAccountSettings` call IS TRACED; this is expected behaviour because we entered Active tracing mode in Lambda B and this is meant to propagate to downstream services. If the downstream service has its own version of passive tracing/X-Ray integration, it should be configured as such, but PassThrough functionality should only apply to Lambda functions and not the downstream calls they trigger unless the entire pathway has been in PassThrough
```
A: Root=1-66b3b030-7155e4f41eac6ff601dfaf63;Lineage=456f6a97:0
B: Root=1-66b3b030-7155e4f41eac6ff601dfaf63;Parent=ad139ed6effb18d2;Sampled=1;Lineage=8408dcb0:0
C: Root=1-66b3b030-7155e4f41eac6ff601dfaf63;Parent=50262dfb251d8754;Sampled=1;Lineage=7d2b6fd0:0
```
![Image (1)](https://github.com/user-attachments/assets/c46bd680-8a18-4c39-b6f2-c7330e6b1e6b)

### Case 3.a: Calling Lambda B PassThrough &rarr; Lambda C PassThrough
- Lineage not propagated
- No trace, proves statement above that a complete trace entirely in PassThrough mode will not trace the final `GetAccountSettings` call since we never entered Active tracing mode.
```
B: Root=1-66abfc06-3cbd74727bb2f86a6a772af2;Lineage=8408dcb0:0
C: Root=1-66abfc06-3cbd74727bb2f86a6a772af2;Lineage=7d2b6fd0:0
```

### Case 3.b: Calling Lambda B Active &rarr; Lambda C Active
- Lineage not propagated
- Complete and correct trace
```
B: Root=1-66abfd06-5e95193a3dcfa6a25cec5b30;Parent=11c07dc8ed123be7;Sampled=1;Lineage=8408dcb0:0
C: Root=1-66abfd06-5e95193a3dcfa6a25cec5b30;Parent=613a4ff907527f30;Sampled=1;Lineage=7d2b6fd0:0
```
<img width="1421" alt="Screenshot 2024-08-01 at 2 25 21 PM" src="https://github.com/user-attachments/assets/cc8d4db1-8d21-4d53-9bb7-cb54ed313dd2">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
