### PR TITLE
Update aws-java-sdk-xray dependency version.

### DIFF
--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api("com.amazonaws:aws-java-sdk-xray:1.12.228")
+    api("com.amazonaws:aws-java-sdk-xray:1.12.767")
 
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     compileOnly("javax.servlet:javax.servlet-api:3.1.0")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update dependency to com.amazonaws:aws-java-sdk-xray:1.12.767, which has a vulnerabilities fix with Jackson-databind 2.12.17.1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
