### PR TITLE
Migrate to publishing URL of Sonatype Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,8 @@ release {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set("${findProperty("aws.sonatype.username") ?: System.getenv("SONATYPE_USERNAME")}")
             password.set("${findProperty("aws.sonatype.password") ?: System.getenv("SONATYPE_PASSWORD")}")
         }


### PR DESCRIPTION
*Description of changes:*

With [EOL of  Sonatype OSSRH](https://central.sonatype.org/news/20250326_ossrh_sunset/), Sonatype publishing URLs are updated as per [this sonatype doc](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration) and the internal recommendation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
