### PR TITLE
Bump aws-java-sdk-core version to 1.12.788 in `aws-xray-recorder-sdk-aws-sdk`

### DIFF
--- a/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
+++ b/aws-xray-recorder-sdk-aws-sdk/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     //  for resolution not only in the SDK projects but also in projects
     //  like benchmark.
     //  See PR for more details: https://github.com/aws/aws-xray-sdk-java/pull/336
-    api("com.amazonaws:aws-java-sdk-core:1.12.708")
+    api("com.amazonaws:aws-java-sdk-core:1.12.788")
 
     testImplementation("com.amazonaws:aws-java-sdk-lambda:1.12.228")
     testImplementation("com.amazonaws:aws-java-sdk-s3:1.12.228")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump `aws-java-sdk-core` version to `1.12.788` ([latest as of 08/04/2025](https://central.sonatype.com/artifact/com.amazonaws/aws-java-sdk-core/1.12.708/versions)) to remove vulnerability in `maven:com.fasterxml.jackson.core:jackson-databind:2.12.7.2`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
