### PR TITLE
Support extracting Trace Header via MDC in Lambda Segment Context

### DIFF
--- a/aws-xray-recorder-sdk-core/build.gradle.kts
+++ b/aws-xray-recorder-sdk-core/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("com.google.auto.value:auto-value-annotations:1.10.4")
     implementation("com.google.auto.service:auto-service-annotations:1.1.1")
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    implementation("org.slf4j:slf4j-api:1.7.30")
 
     annotationProcessor("com.google.auto.value:auto-value:1.10.4")
 
@@ -26,6 +27,8 @@ dependencies {
     testImplementation("org.powermock:powermock-api-mockito2:2.0.7")
     testImplementation("org.skyscreamer:jsonassert:1.3.0")
     testImplementation("jakarta.servlet:jakarta.servlet-api:5.0.0")
+    testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.2")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.17.2")
 }
 
 tasks.jar {


### PR DESCRIPTION
*Issue #, if available:*
Follow pattern used by AWS SDK for Java:
- https://github.com/aws/aws-sdk-java-v2/pull/6295

*Description of changes:*
- Lambda segment context will prioritize extracting `lambdaTraceHeader` from MDC first, then Env Var, then System Property. Before it would just prioritize Env Var then System Property.
- Add unit tests.

*Other Thoughts:*
- X-Ray SDK will only use the API for `slf4j` to extract from MDC, similarly to AWS SDK. If there is no implementation for logging (e.g. `log4j-slf4j-impl`, `log4j-core`), this extraction logic will not work (`MDC.get(...)` returns `null`) and fallback to Env Var or System Property. I'm not exactly what guarantees (if it is guaranteed) the logging implementation to exist in Lambda Environments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
