### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,6 +5,9 @@ on:
         description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-xray-sdk-java/security/code-scanning/1](https://github.com/aws/aws-xray-sdk-java/security/code-scanning/1)

To fix this issue, we should add the `permissions` key at the job or workflow level to explicitly set the minimum required permissions for the workflow. In this case, the workflow creates a GitHub release (for which the `contents: write` permission is needed) and potentially commits/tags, but there is no evidence it needs further permissions like `issues` or `pull-requests`. The best fix is to add:

```yaml
permissions:
  contents: write
```

at the root of the workflow (just before or after `on:`), so that all jobs inherit these minimal permissions unless further permissions are required later. This will ensure the `GITHUB_TOKEN` used in actions has only the required `contents: write` scope, in line with GitHub security best practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
