### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -1,4 +1,6 @@
 name: Master Build
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/aws/aws-xray-sdk-java/security/code-scanning/2](https://github.com/aws/aws-xray-sdk-java/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file. The preferred location is at the root level (top of the YAML), which will apply these permissions to all jobs that don't specify otherwise. The minimal, most secure starting point is `contents: read`, because all shown steps require at most read access to repository contents for checking out code, reading dependencies, caching, reporting, and publishing with secrets provided, rather than relying on `GITHUB_TOKEN` write access. No steps require write access to the repository via `GITHUB_TOKEN` (such as pushing code, creating PRs, or drafting releases). This change is made by inserting the `permissions` block immediately following the `name:` key (after line 1) in `.github/workflows/master-build.yml`.

**Needed steps:**
- Insert the block:
    ```yaml
    permissions:
      contents: read
    ```
  after the `name: Master Build` line (line 1).
- No additional dependencies or changes are required.
- No changes to per-job permissions, as no job in the shown code needs more than `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
