### PR TITLE
update daily scan link to published artifacts

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Download published artifact for scanning
         run: |
           mkdir -p scan-target
-          XRAY_VERSION=$(curl -s "https://search.maven.org/solrsearch/select?q=g:com.amazonaws+AND+a:aws-xray-recorder-sdk-core&rows=1&wt=json" | jq -r '.response.docs[0].latestVersion')
+          XRAY_VERSION=$(curl -s "https://repo1.maven.org/maven2/com/amazonaws/aws-xray-recorder-sdk-core/maven-metadata.xml" | grep '<release>' | sed 's/.*<release>\(.*\)<\/release>.*/\1/')
           echo "Latest version: $XRAY_VERSION"
           ARTIFACTS=(
             aws-xray-recorder-sdk-core


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The daily scan fetches the latest published artifact from Maven repository for scanning; however, the current link resolves to an older 2.18.1 instead of the latest 2.21.0 (see [recent workflow run](https://github.com/aws/aws-xray-sdk-java/actions/runs/24135575580).

This PR updates the link to a newer API that doesn't suffer from stale version indexing. Tested in CLI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
