### PR TITLE
Suppress jackson-core GHSA-r7wm-3cxj-wff9 metadata-only finding in daily scan

### DIFF
--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -43,6 +43,7 @@ vulnerabilities:
     statement: "AWS SDK v1 EOL (1.12.788 is final release) — jackson-databind 2.17.2 in POM metadata only. Actual runtime JAR is 2.18.8 via X-Ray SDK BOM, which fixes this CVE."
     expired_at: 2027-07-17
   - id: CVE-2026-54513
+  - id: GHSA-r7wm-3cxj-wff9
     paths:
       - "META-INF/maven/com.amazonaws/aws-java-sdk-core/pom.xml"
       - "META-INF/maven/com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/pom.xml"


### PR DESCRIPTION
Follow-up to #458 to suppress GitHub advisory